### PR TITLE
Add rudimentary VCF translation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ extras =
     biocommons.seqrepo>=0.5.1
     bioutils>=0.5.2
     hgvs>=1.4
+    scikit-allel
     requests
 notebooks =
     ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,7 +98,6 @@ extras =
     biocommons.seqrepo>=0.5.1
     bioutils>=0.5.2
     hgvs>=1.4
-    scikit-allel
     requests
 notebooks =
     ipython

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -21,7 +21,7 @@ import hgvs.dataproviders.uta
 
 from ga4gh.core import ga4gh_identify
 from ga4gh.vrs import models, normalize
-from ga4gh.vrs.extras.decorators import lazy_property  # this should be relocated
+from ga4gh.vrs.extras.decorators import lazy_property    # this should be relocated
 from ga4gh.vrs.utils.hgvs_tools import HgvsTools
 
 from pysam import VariantFile, VariantHeader, VariantRecord
@@ -46,7 +46,6 @@ class Translator:
     hgvs_re = re.compile(r"[^:]+:[cgnpr]\.")
     spdi_re = re.compile(r"(?P<ac>[^:]+):(?P<pos>\d+):(?P<del_len_or_seq>\w+):(?P<ins_seq>\w+)")
 
-
     def __init__(self,
                  data_proxy,
                  default_assembly_name="GRCh38",
@@ -59,7 +58,6 @@ class Translator:
         self.identify = identify
         self.normalize = normalize
         self.hgvs_tools = None
-
 
     def translate_from(self, var, fmt=None):
         """Translate variation `var` to VRS object
@@ -87,7 +85,6 @@ class Translator:
     def translate_to(self, vo, fmt):
         t = self.to_translators[fmt]
         return t(self, vo)
-
 
     ############################################################################
     ## INTERNAL
@@ -130,7 +127,6 @@ class Translator:
         allele = self._post_process_imported_allele(allele)
         return allele
 
-
     def _from_gnomad(self, gnomad_expr, assembly_name=None):
         """Parse gnomAD-style VCF expression into VRS Allele
 
@@ -169,7 +165,6 @@ class Translator:
         allele = self._post_process_imported_allele(allele)
         return allele
 
-
     def _from_hgvs(self, hgvs_expr):
         """parse hgvs into a VRS object (typically an Allele)
 
@@ -202,26 +197,19 @@ class Translator:
                 raise ValueError("Intronic HGVS variants are not supported ({sv.posedit})")
 
         if sv.posedit.edit.type == 'ins':
-            interval = models.SimpleInterval(start=sv.posedit.pos.start.base,
-                                        end=sv.posedit.pos.start.base)
+            interval = models.SimpleInterval(start=sv.posedit.pos.start.base, end=sv.posedit.pos.start.base)
             state = sv.posedit.edit.alt
         elif sv.posedit.edit.type in ('sub', 'del', 'delins', 'identity'):
-            interval = models.SimpleInterval(start=sv.posedit.pos.start.base - 1,
-                                       end=sv.posedit.pos.end.base)
+            interval = models.SimpleInterval(start=sv.posedit.pos.start.base - 1, end=sv.posedit.pos.end.base)
             if sv.posedit.edit.type == 'identity':
-                state = self.data_proxy.get_sequence(sv.ac,
-                                                     sv.posedit.pos.start.base - 1,
-                                                     sv.posedit.pos.end.base)
+                state = self.data_proxy.get_sequence(sv.ac, sv.posedit.pos.start.base - 1, sv.posedit.pos.end.base)
             else:
                 state = sv.posedit.edit.alt or ''
         elif sv.posedit.edit.type == 'dup':
 
-            interval = models.SimpleInterval(start=sv.posedit.pos.start.base - 1,
-                                             end=sv.posedit.pos.end.base)
+            interval = models.SimpleInterval(start=sv.posedit.pos.start.base - 1, end=sv.posedit.pos.end.base)
 
-            ref = self.data_proxy.get_sequence(sv.ac,
-                                               sv.posedit.pos.start.base - 1,
-                                               sv.posedit.pos.end.base)
+            ref = self.data_proxy.get_sequence(sv.ac, sv.posedit.pos.start.base - 1, sv.posedit.pos.end.base)
             state = ref + ref
         else:
             raise ValueError(f"HGVS variant type {sv.posedit.edit.type} is unsupported")
@@ -232,9 +220,7 @@ class Translator:
         allele = self._post_process_imported_allele(allele)
         return allele
 
-
     def _from_spdi(self, spdi_expr):
-
         """Parse SPDI expression in to a GA4GH Allele
 
         #>>> a = tlr.from_spdi("NM_012345.6:21:1:T")
@@ -272,7 +258,6 @@ class Translator:
         allele = models.Allele(location=location, state=sstate)
         allele = self._post_process_imported_allele(allele)
         return allele
-
 
     def _from_vrs(self, var):
         """convert from dict representation of VRS JSON to VRS object"""
@@ -353,12 +338,11 @@ class Translator:
          * worth trying to parse info fields to get an assembly ID?
          * enforce filter requirements?
         """
+        print('here')
         vcf_in = VariantFile(vcf_path)
         vrs_alleles = []
         for record in vcf_in:
-            vrs_alleles += self._from_vcf_record(record.chrom, record.pos,
-                                                 record.ref, record.alts,
-                                                 assembly_name)
+            vrs_alleles += self._from_vcf_record(record.chrom, record.pos, record.ref, record.alts, assembly_name)
 
         return vrs_alleles
 
@@ -385,7 +369,6 @@ class Translator:
         If the VRS object cannot be expressed as HGVS, raises ValueError.
 
         """
-
         def ir_stype(a):
             if a.startswith("refseq:NM_"):
                 return "n"
@@ -399,9 +382,8 @@ class Translator:
                 return "g"
             return None
 
-        if (type(vo).__name__ != "Allele"
-            or type(vo.location).__name__ != "SequenceLocation"
-            or type(vo.state).__name__ != "SequenceState"):
+        if (type(vo).__name__ != "Allele" or type(vo.location).__name__ != "SequenceLocation"
+                or type(vo.state).__name__ != "SequenceState"):
             raise ValueError(f"_to_hgvs requires a VRS Allele with SequenceLocation and SequenceState")
 
         sequence_id = str(vo.location.sequence_id)
@@ -427,20 +409,16 @@ class Translator:
             if start == end:    # insert: hgvs uses *exclusive coords*
                 ref = None
                 end += 1
-            else:               # else: hgvs uses *inclusive coords*
+            else:    # else: hgvs uses *inclusive coords*
                 ref = self.data_proxy.get_sequence(sequence_id, start, end)
                 start += 1
-            ival = hgvs.location.Interval(
-                start=hgvs.location.SimplePosition(base=start),
-                end=hgvs.location.SimplePosition(base=end))
-            alt = str(vo.state.sequence) or None  # "" => None
+            ival = hgvs.location.Interval(start=hgvs.location.SimplePosition(base=start),
+                                          end=hgvs.location.SimplePosition(base=end))
+            alt = str(vo.state.sequence) or None    # "" => None
             edit = hgvs.edit.NARefAlt(ref=ref, alt=alt)
 
         posedit = hgvs.posedit.PosEdit(pos=ival, edit=edit)
-        var = hgvs.sequencevariant.SequenceVariant(
-            ac=None,
-            type=stype,
-            posedit=posedit)
+        var = hgvs.sequencevariant.SequenceVariant(ac=None, type=stype, posedit=posedit)
 
         hgvs_exprs = []
         for alias in aliases:
@@ -482,9 +460,8 @@ class Translator:
 
         """
 
-        if (type(vo).__name__ != "Allele"
-            or type(vo.location).__name__ != "SequenceLocation"
-            or type(vo.state).__name__ != "SequenceState"):
+        if (type(vo).__name__ != "Allele" or type(vo.location).__name__ != "SequenceLocation"
+                or type(vo.state).__name__ != "SequenceState"):
             raise ValueError(f"_to_hgvs requires a VRS Allele with SequenceLocation and SequenceState")
 
         sequence_id = str(vo.location.sequence_id)
@@ -497,16 +474,46 @@ class Translator:
         spdis = [a + spdi_tail for a in aliases]
         return spdis
 
-    def _allele_to_vcf(self, vcfh, vo, namespace="refseq"):
+    vcf_info_params = {
+        'AA': (1, 'String', 'Ancestral allele'),
+        'AC': ('A', 'Integer', 'Allele count in genotypes, for each ALT allele, in the same order as listed'),
+        'AD': ('R', 'Integer', 'Total read depth for each allele'),
+        'ADF': ('R', 'Integer', 'Read depth for each allele on the forward strand'),
+        'ADR': ('R', 'Integer', 'Read depth for each allele on the reverse strand'),
+        'AF':
+        ('A', 'Float',
+         'Allele frequency for each ALT allele in the same order as listed (estimated from primary data not called genotypes)'
+         ),
+        'AN': (1, 'Integer', 'Total number of alleles in called genotypes'),
+        'BQ': (1, 'Float', 'RMS base quality'),
+        'CIGAR': ('A', 'String', 'Cigar string describing how to align an alternate allele to the reference allele'),
+        'DB': (0, 'Flag', 'dbSNP membership'),
+        'DP': (1, 'Integer', 'Combined depth across samples'),
+        'END': (1, 'Integer', 'End position on CHROM'),
+        'H2': (0, 'Flag', 'HapMap2 membership'),
+        'H3': (0, 'Flag', 'HapMap3 membership'),
+        'MQ': (1, 'Float', 'RMS mapping quality'),
+        'MQ0': (1, 'Integer', 'Number of MAPQ == 0 reads'),
+        'NS': (1, 'Integer', 'Number of samples with data'),
+        'SB': (4, 'Integer', 'Strand bias'),
+        'SOMATIC': (0, 'Flag', 'Somatic mutation'),
+        'VALIDATED': (0, 'Flag', 'Validated by follow-up experiment'),
+        '1000G': (0, 'Flag', '1000 Genomes membership')
+    }
+
+    def _allele_to_vcf(self, vcfh, vo, namespace="refseq", info={}):
         """Given a Pysam VariantHeader object `vcfh`, and a VRS Allele object
-        `vo`, return a Pysam VariantRecord
+        `vo`, return a Pysam VariantRecord. Optionally provide a `namespace`
+        string for sequence ID translation purposes, and/or an `info` dict
+        keying valid reserved INFO keys to values for the record.
+
+        Raises ValueError if given unrecognized INFO key.
 
         TODO
          * more elegant way of extracting chrom
         """
-        if (type(vo).__name__ != "Allele"
-            or type(vo.location).__name__ != "SequenceLocation"
-            or type(vo.state).__name__ != "SequenceState"):
+        if (type(vo).__name__ != "Allele" or type(vo.location).__name__ != "SequenceLocation"
+                or type(vo.state).__name__ != "SequenceState"):
             raise ValueError(f"_to_vcf requires a VRS Allele with SequenceLocation and SequenceState")
 
         start = int(vo.location.interval.start)
@@ -516,8 +523,7 @@ class Translator:
         interval_length = end - start
         sequence_id = str(vo.location.sequence_id)
         ref_sequence = self.data_proxy.get_sequence(sequence_id, start, end)
-        aliases = self.data_proxy.translate_sequence_identifier(sequence_id,
-                                                                namespace)
+        aliases = self.data_proxy.translate_sequence_identifier(sequence_id, namespace)
 
         if interval_length == alt_sequence_length:
             # SNVs/MNVs
@@ -531,47 +537,67 @@ class Translator:
             pos = start - 1
         else:
             # ins
-            diff_bases = [i[2] for i in ndiff(ref_sequence[::-1], alt[::-1])
-                          if i.startswith('+ ')][::-1]
+            diff_bases = [i[2] for i in ndiff(ref_sequence[::-1], alt[::-1]) if i.startswith('+ ')][::-1]
             diff = ''.join(diff_bases)
             pos = start - 1
             ref = self.data_proxy.get_sequence(sequence_id, start - 1, start)
             alt = ref + diff
 
         if namespace == 'refseq':
-            chrom = str(int(aliases[0][14:16]))  # drop leading 0
+            chrom = str(int(aliases[0][14:16]))    # drop leading 0
         else:
-            raise NotImplementedError  # TODO
+            raise NotImplementedError    # TODO
         if chrom not in vcfh.contigs.keys():
             vcfh.add_meta('contig', items=[('ID', chrom)])
 
-        record = vcfh.new_record(contig=chrom, start=pos,
-                                 alleles=(ref, alt))
+        for key in info.keys():
+            if key not in vcfh.info.keys():
+                key_meta = self.vcf_info_params.get(key)
+                if not key_meta:
+                    raise ValueError(f'Unrecognized INFO key: {key}')
+                vcfh.info.add(key, *key_meta)
+
+        record = vcfh.new_record(contig=chrom, start=pos, alleles=(ref, alt), info=info)
         return record
 
-    def _to_vcf(self, vrs_objects, file_path, namespace="refseq"):
+    def _to_vcf(self, vrs_objects, file_path, namespace="refseq", info=[]):
         """Given an iterable collection of VRS Alleles, write to `file_path`
-        a basic VCF file.
+        a basic VCF file. Optionally provide a List of Dicts, which must be
+        of length equal to `vrs_objects`, where `info[i]` contains keys and
+        values for valid INFO fields for `vrs_objects[i]`. Keys and values
+        must adhere to the reserved INFO keys as defined in the VCF 4.3 spec.
 
-        Raises ValueError if provided list contains non-Allele objects, or
-        if they don't have SequenceLocation and SequenceState attributes.
+        Raises ValueError if
+         * Provided list contains non-Allele objects or if they don't have
+           SequenceLocation and SequenceState attributes.
+         * if len(info) != 0 and len(info) != len(vrs_objects)
 
         WORKING
          * basic SNVs, insertions, deletions
+         * collapsing alleles at same position into single records
 
         TODO
          * be more intelligent about getting namespace IDs
          * other variation types
         """
+        if len(info) != 0 and len(info) != len(vrs_objects):
+            raise ValueError(f'length of info param must be either 0 or '
+                             f'== len(vrs_objects) == {len(vrs_objects)}, '
+                             f'got {len(info)} instead.')
+
         vcfh = VariantHeader()
         records = []
 
-        for vo in vrs_objects:
-            records.append(self._allele_to_vcf(vcfh, vo, namespace))
+        if info:
+            for vo, vo_info in zip(vrs_objects, info):
+                records.append(self._allele_to_vcf(vcfh, vo, namespace, vo_info))
+        else:
+            for vo in vrs_objects:
+                records.append(self._allele_to_vcf(vcfh, vo, namespace))
 
         records_grouped = {}
         for record in records:
-            key = (record.chrom, record.pos)
+            key = (record.chrom, record.pos, record.ref)
             if key in records_grouped.keys():
                 records_grouped[key] += [record]
             else:
@@ -583,9 +609,7 @@ class Translator:
                 records_out.append(group[0])
             else:
                 alts = ','.join([r.alts[0] for r in group])
-                record = vcfh.new_record(contig=group[0].chrom,
-                                         start=group[0].pos - 1,
-                                         alleles=(group[0].ref, alts))
+                record = vcfh.new_record(contig=group[0].chrom, start=group[0].pos - 1, alleles=(group[0].ref, alts))
                 records_out.append(record)
 
         records_out.sort(key=lambda r: ((r.chrom).zfill(2), r.pos))
@@ -595,13 +619,11 @@ class Translator:
             vcf.write(record)
         vcf.close()
 
-
     @lazy_property
     def _hgvs_parser(self):
         """instantiates and returns an hgvs parser instance"""
         _logger.info("Creating  parser")
         return hgvs.parser.Parser()
-
 
     def _post_process_imported_allele(self, allele):
         """Provide common post-processing for imported Alleles IN-PLACE.
@@ -620,12 +642,10 @@ class Translator:
 
         return allele
 
-
     def _seq_id_mapper(self, ir):
         if self.translate_sequence_identifiers:
             return self.data_proxy.translate_sequence_identifier(ir, "ga4gh")[0]
         return ir
-
 
     from_translators = {
         "beacon": _from_beacon,
@@ -639,7 +659,7 @@ class Translator:
     to_translators = {
         "hgvs": _to_hgvs,
         "spdi": _to_spdi,
-        #"gnomad": to_gnomad,
+    #"gnomad": to_gnomad,
         "vcf": _to_vcf,
     }
 
@@ -653,11 +673,7 @@ if __name__ == "__main__":
     tlr = Translator(data_proxy=dp)
 
     expressions = [
-        "bogus",
-        "1-55516888-G-GA",
-        "13 : 32936732 G > C",
-        "NC_000013.11:g.32936732G>C",
-        "NM_000551.3:21:1:T", {
+        "bogus", "1-55516888-G-GA", "13 : 32936732 G > C", "NC_000013.11:g.32936732G>C", "NM_000551.3:21:1:T", {
             'location': {
                 'interval': {
                     'end': 22,

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -298,8 +298,10 @@ class Translator:
         Currently working:
          * Basic SNPs
          * Basic insertions
+         * Basic deletions
 
         TODO:
+         * Plan some logic branches for SVs (raise not implemented etc)
          * Handle 0th coordinate refs
          * sequence_id: ensembl
          * other types of variations
@@ -308,6 +310,7 @@ class Translator:
          * handle indels, deletions
          * handle multiple alleles -- waiting on future versions of VRS?
         """
+        print(chrom, pos, ref, alt, assembly_name)
 
         # construct interval
         start = int(pos) - 1

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -496,7 +496,6 @@ class Translator:
         `vo`, return a Pysam VariantRecord
 
         TODO
-         * restore left-justification
          * more elegant way of getting chrom
         """
         if (type(vo).__name__ != "Allele"
@@ -552,18 +551,18 @@ class Translator:
         if they don't have SequenceLocation and SequenceState attributes.
 
         WORKING
-         * basic SNPs
+         * basic SNVs, insertions, deletions
 
         TODO
          * be more intelligent about getting namespace IDs
          * other variation types
-         * does write order matter? sort() by contig + start position
         """
         vcfh = VariantHeader()
         records = []
 
         for vo in vrs_objects:
             records.append(self._allele_to_vcf(vcfh, vo, namespace))
+        records.sort(key=lambda r: ((r.chrom).zfill(2), r.pos))
 
         vcf = VariantFile(file_path, 'w', header=vcfh)
         for record in records:

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -584,10 +584,8 @@ class Translator:
             else:
                 alts = ','.join([r.alts[0] for r in group])
                 record = vcfh.new_record(contig=group[0].chrom,
-                                         start=group[0].pos,
+                                         start=group[0].pos - 1,
                                          alleles=(group[0].ref, alts))
-                # record = group[0]  # arbitrarily selecting first item in group
-                # record.alts = (r.alts[0] for r in group)
                 records_out.append(record)
 
         records_out.sort(key=lambda r: ((r.chrom).zfill(2), r.pos))

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -576,10 +576,6 @@ class Translator:
         WORKING
          * basic SNVs, insertions, deletions
          * collapsing alleles at same position into single records
-
-        TODO
-         * be more intelligent about getting namespace IDs
-         * other variation types
         """
         if len(info) != 0 and len(info) != len(vrs_objects):
             raise ValueError(f'length of info param must be either 0 or '

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -271,9 +271,6 @@ class Translator:
             return None
         return model(**var)
 
-    # for from_VCF
-    chrom_re = re.compile(r'(chr)?(?P<chrom>([0-2]?[0-9]|X|Y))', re.IGNORECASE)
-
     def _from_vcf_record(self, chrom, pos, ref, alts, assembly_name):
         """Given provided record attributes, return an instance of a VRS
         Variation (either an Allele or a VariationSet) or None if no

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,16 @@ def tlr(dataproxy):
     )
 
 
+@pytest.fixture(scope="session")
+def tlr_norm(dataproxy):
+    return Translator(
+        data_proxy=dataproxy,
+        default_assembly_name="GRCh38",
+        identify=True,
+        normalize=True,
+        translate_sequence_identifiers=True,
+    )
+
 # See https://github.com/ga4gh/vrs-python/issues/24
 # @pytest.fixture(autouse=True)
 # def setup_doctest(doctest_namespace, tlr):

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -227,8 +227,37 @@ vcf_tests = (
     )
 )
 
+
 @pytest.mark.parametrize("record,expected", vcf_tests)
 def test_vcf(tlr, record, expected):
     tlr.normalize = True
     allele = tlr._from_vcf_record(*record, 'GRCh37')
     assert allele.as_dict() == expected
+
+
+vcf_file = """
+    ##fileformat=VCFv4.3
+    ##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta
+    ##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>
+    ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+    ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
+    ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+    ##FILTER=<ID=q10,Description="Quality below 10">
+    ##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+    ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+    ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+    #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+    20	14370	rs6054257	G	A	29	PASS	DP=14;AF=0.5;DB	GT:DP	0/0:1	0/1:8	1/1:5
+    """
+
+vcf_file_expected = {
+    'type': 'Allele',
+    'location'
+}
+
+
+def test_vcf_file(tlr, vcf_file, vcf_file_expected):
+
+
+    allele = tlr._from_vcf(test, 'GRCh37')
+    assert allele

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -132,13 +132,15 @@ vcf_tests = (
     (
         ('1', '92633', 'C', ['T']),
         {
+            '_id': 'ga4gh:VA.qAK6JCN3-AVa9_6Qq3AqAuppUU0bWgfH',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:GS.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU',
+                'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
                 'interval': {
                     'type': 'SimpleInterval',
-                    'start': 92632, 'end': 92633
+                    'start': 92632,
+                    'end': 92633
                 }
             },
             'state': {'type': 'SequenceState', 'sequence': 'T'}
@@ -147,10 +149,11 @@ vcf_tests = (
     (
         ('1', '63002', 'A', ['G']),
         {
+           '_id': 'ga4gh:VA.VewFnlxS7DmjEdKMkj0xZK-9GaHGMJcx',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:GS.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU',
+                'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
                 'interval': {
                     'type': 'SimpleInterval',
                     'start': 63001,
@@ -164,26 +167,28 @@ vcf_tests = (
     (
         ('Y', '22304601', 'G', ['GA']),
         {
+            '_id': 'ga4gh:VA.TDba99qQKLMUiooxOgIX_EEFDgyNPBAq',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:GS.BT7QyW5iXaX_1PSX-msSGYsqRdMKqkj-',
+                'sequence_id': 'ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5',
                 'interval': {
                     'type': 'SimpleInterval',
                     'start': 22304601,
-                    'end': 22304601
+                    'end': 22304607
                 }
             },
-            'state': {'type': 'SequenceState', 'sequence': 'A'}
+            'state': {'type': 'SequenceState', 'sequence': 'AAAAAAA'}
         }
     ),
     (
         ('1', '72297', 'G', ['GTAT']),
         {
+            '_id': 'ga4gh:VA.wbhpDCQ0MRtG0pZZWH-yarqSdOjGNJEL',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:GS.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU',
+                'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
                 'interval': {
                     'type': 'SimpleInterval',
                     'start': 72297,
@@ -197,83 +202,103 @@ vcf_tests = (
     (
         ('17', '29204173', 'TACA', ['T']),
         {
+            '_id': 'ga4gh:VA.mId9FgDqwHkP3mBt1lgfSr2-bhCJaxGg',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:GS.AjWXsI7AkTK35XW9pgd3UbjpC3MAevlz',
+                'sequence_id': 'ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7',
                 'interval': {
                     'type': 'SimpleInterval',
-                    'start': 29204173,
-                    'end': 29204176
+                    'start': 29204173, 'end': 29204179
                 }
             },
-            'state': {'type': 'SequenceState', 'sequence': ''}
+            'state': {'type': 'SequenceState', 'sequence': 'ACA'}
         }
     ),
     (
         ('4', '116619313', 'GT', ['G']),
         {
+            '_id': 'ga4gh:VA.GVcxxtyjvhuuCtcdpcNAvVhRHWbzAhra',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:GS.iy7Zfceb5_VGtTQzJ-v5JpPbpeifHD_V',
+                'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
                 'interval': {
                     'type': 'SimpleInterval',
-                    'start': 116619312,
+                    'start': 116619313,
                     'end': 116619314
                 }
             },
-            'state': {'type': 'SequenceState', 'sequence': 'G'}
+            'state': {'type': 'SequenceState', 'sequence': ''}
         }
     )
 )
 
 
 @pytest.mark.parametrize("record,expected", vcf_tests)
-def test_vcf(tlr, record, expected):
-    tlr.normalize = True
-    allele = tlr._from_vcf_record(*record, 'GRCh37')
+def test_vcf(tlr_norm, record, expected):
+    tlr_norm.normalize = True
+    allele = tlr_norm._from_vcf_record(*record)
     assert allele.as_dict() == expected
 
 
-vcf_files = (
-    [
-        '##fileformat=VCFv4.3\n' + \
-        '##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta\n' + \
-        '##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>\n' + \
-        '##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">\n' + \
-        '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n' + \
-        '##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">\n' + \
-        '##FILTER=<ID=q10,Description="Quality below 10">\n' + \
-        '##FILTER=<ID=s50,Description="Less than 50% of samples have data">\n' + \
-        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n' + \
-        '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">\n' + \
-        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003\n' + \
-        '20\t14370\trs6054257\tG\tA\t29\tPASS\tDP=14;AF=0.5;DB\tGT:DP\t0/0:1\t0/1:8\t1/1:5\n',
+@pytest.fixture(scope="session")
+def vcf_file():
+    file_string = '##fileformat=VCFv4.3\n' + \
+                  '##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta\n' + \
+                  '##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>\n' + \
+                  '##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">\n' + \
+                  '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n' + \
+                  '##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">\n' + \
+                  '##FILTER=<ID=q10,Description="Quality below 10">\n' + \
+                  '##FILTER=<ID=s50,Description="Less than 50% of samples have data">\n' + \
+                  '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n' + \
+                  '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">\n' + \
+                  '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003\n' + \
+                  '20\t14370\trs6054257\tG\tA\t29\tPASS\tDP=14;AF=0.5;DB\tGT:DP\t0/0:1\t0/1:8\t1/1:5\n' + \
+                  '4\t116612759\trs566366173\tATTGTT\tA\t.\tPASS\tRS=566366173;RSPOS=116612760;dbSNPBuildID=142;SSR=0;SAO=0;VP=0x050000000005040026000200;WGT=1;VC=DIV;ASP;VLD;KGPhase3;CAF=0.9968,0.003195;COMMON=1;TOPMED=0.99684633027522935,0.00315366972477064'
+    file_bytes = file_string.encode('utf-8')
+    fp = TemporaryFile()
+    fp.write(file_bytes)
+    fp.seek(0)
+    return fp
+
+
+@pytest.fixture(scope="session")
+def vcf_file_expected():
+    return [
         {
+            '_id': 'ga4gh:VA.m8e1aRLy--eKkjzCJWz5w7fZEBmOhbXZ',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:GS.-A1QmD_MatoqxvgVxBLZTONHz9-c7nQo',
+                'sequence_id': 'ga4gh:SQ.-A1QmD_MatoqxvgVxBLZTONHz9-c7nQo',
                 'interval': {
-                    'type': 'SimpleInterval', 'start': 14369, 'end': 14370
+                    'type': 'SimpleInterval',
+                    'start': 14369,
+                    'end': 14370
                 }
             },
-            'state': {
-                'type': 'SequenceState', 'sequence': 'A'
-            }
+            'state': {'type': 'SequenceState', 'sequence': 'A'}
+        },
+        {
+            '_id': 'ga4gh:VA.EG07sjR0AIU2XOTHvlXvM__egaimtuPT',
+            'type': 'Allele',
+            'location': {
+                'type': 'SequenceLocation',
+                'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+                'interval': {
+                    'type': 'SimpleInterval',
+                    'start': 116612759,
+                    'end': 116612766
+                }
+            },
+            'state': {'type': 'SequenceState', 'sequence': 'TT'}
         }
-    ],
-)
+    ]
 
 
-
-
-@pytest.mark.parametrize("vcf_file,vcf_file_expected", vcf_files)
-def test_vcf_file(tlr, vcf_file, vcf_file_expected):
-    v = vcf_file.encode('utf-8')
-    fp = TemporaryFile()
-    fp.write(v)
-    fp.seek(0)
-    alleles = tlr._from_vcf(fp)
-    assert alleles[0].as_dict() == vcf_file_expected
+def test_vcf_file(tlr_norm, vcf_file, vcf_file_expected):
+    alleles = tlr_norm._from_vcf(vcf_file)
+    for i in range(len(alleles)):
+        assert alleles[i].as_dict() == vcf_file_expected[i]

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -1,6 +1,9 @@
 import pytest
 from tempfile import TemporaryFile
 from ga4gh.vrs import models
+from os import remove
+import time
+from pysam import VariantHeader
 
 inputs = {
     "hgvs": "NC_000013.11:g.32936732G>C",
@@ -42,7 +45,8 @@ def test_from_spdi(tlr):
 
 @pytest.mark.vcr
 def test_from_vcf(tlr):
-    assert tlr._from_vcf(inputs["vcf"]).as_dict() == output
+    assert tlr._from_vcf_record(*inputs["vcf"]).as_dict() == output
+
 
 hgvs_tests = (
     ("NC_000013.11:g.32936732=",
@@ -87,14 +91,14 @@ hgvs_tests = (
                    'type': 'SequenceLocation'},
       'state': {'sequence': 'TTTTTTTTTTTTTT', 'type': 'SequenceState'},
       'type': 'Allele'}),
-     ("NC_000013.11:g.32316467dup",
-      {'location': {'interval': {'end': 32316467,
+    ("NC_000013.11:g.32316467dup",
+     {'location': {'interval': {'end': 32316467,
                                 'start': 32316466,
                                 'type': 'SimpleInterval'},
                    'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
                    'type': 'SequenceLocation'},
       'state': {'sequence': 'AA', 'type': 'SequenceState'},
-       'type': 'Allele'}),
+      'type': 'Allele'}),
 )
 
 
@@ -108,6 +112,7 @@ def test_hgvs(tlr, hgvsexpr, expected):
     to_hgvs = tlr.translate_to(allele, "hgvs")
     assert 1 == len(to_hgvs)
     assert hgvsexpr == to_hgvs[0]
+
 
 # TODO: Readd these tests
 # @pytest.mark.vcr
@@ -151,7 +156,7 @@ to_vcf_tests = (
     (
         ('1', '63002', 'A', ['G']),
         {
-           '_id': 'ga4gh:VA.VewFnlxS7DmjEdKMkj0xZK-9GaHGMJcx',
+            '_id': 'ga4gh:VA.VewFnlxS7DmjEdKMkj0xZK-9GaHGMJcx',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
@@ -165,24 +170,58 @@ to_vcf_tests = (
             'state': {'type': 'SequenceState', 'sequence': 'G'}
         }
     ),
-    # ins
     (
-        ('Y', '22304601', 'G', ['GA']),
-        {
-            '_id': 'ga4gh:VA.TDba99qQKLMUiooxOgIX_EEFDgyNPBAq',
-            'type': 'Allele',
-            'location': {
-                'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5',
-                'interval': {
-                    'type': 'SimpleInterval',
-                    'start': 22304601,
-                    'end': 22304607
-                }
-            },
-            'state': {'type': 'SequenceState', 'sequence': 'AAAAAAA'}
-        }
+        ('3', '166125806', 'G', ['A']),
+        {'_id': 'ga4gh:VA.UAcSqA7iJtI36BysCOYXR8wPGVwUm4En',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 166125805,
+                                   'end': 166125806}},
+         'state': {'type': 'SequenceState', 'sequence': 'A'}}
     ),
+    (
+        ('5', '1100700', 'G', ['A']),
+        {'_id': 'ga4gh:VA.UrXpOOJGuCHAQgQ2sY85FsZ3CztIwI6C',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+                      'interval': {'type': 'SimpleInterval', 'start': 1100699, 'end': 1100700}},
+         'state': {'type': 'SequenceState', 'sequence': 'A'}}
+    ),
+    (
+        ('7', '108934752', 'T', ['C']),
+        {'_id': 'ga4gh:VA.pwoWgFDuLdigDfQRTEU7gCdSB4DoHED1',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 108934751,
+                                   'end': 108934752}},
+         'state': {'type': 'SequenceState', 'sequence': 'C'}}
+    ),
+    (
+        ('13', '59140800', 'G', ['A']),
+        {'_id': 'ga4gh:VA.Ii5EzfJNVealFy9Wc7UMjd4WrzqSpbmg',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
+                      'interval': {'type': 'SimpleInterval', 'start': 59140799, 'end': 59140800}},
+         'state': {'type': 'SequenceState', 'sequence': 'A'}}
+    ),
+    (
+        ('23', '127226377', 'A', ['G']),
+        {'_id': 'ga4gh:VA.nyaA37BGIVLcP6LPfpT1GKg-nfLhxPOD',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 127226376,
+                                   'end': 127226377}},
+         'state': {'type': 'SequenceState', 'sequence': 'G'}}
+    ),
+    # ins
     (
         ('1', '72297', 'G', ['GTAT']),
         {
@@ -200,40 +239,147 @@ to_vcf_tests = (
             'state': {'type': 'SequenceState', 'sequence': 'TATTATT'}
         }
     ),
-    # del
     (
-        ('17', '29204173', 'TACA', ['T']),
+        ('3', '166114496', 'T', ['TA']),
+        {'_id': 'ga4gh:VA.LVqeAmYsZxO3kYb-lvmYOrqnoY1NbKWd',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 166114496,
+                                   'end': 166114496}},
+         'state': {'type': 'SequenceState', 'sequence': 'A'}}
+    ),
+    (
+        ('5', '127031196', 'C', ['CG']),
+        {'_id': 'ga4gh:VA.4lIsTJ1zxjQ7UjXTSnCLb-HF2jw733NK',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 127031196,
+                                   'end': 127031201}},
+         'state': {'type': 'SequenceState', 'sequence': 'GGGGGG'}}
+    ),
+    (
+        ('7', '156408692', 'C', ['CAT']),
+        {'_id': 'ga4gh:VA.uvVtM0pr6hFMLfKTurDcdFj_3rRHbBqp',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 156408692,
+                                   'end': 156408703}},
+         'state': {'type': 'SequenceState', 'sequence': 'ATATATATATATA'}}
+    ),
+    (
+        ('10', '106329140', 'C', ['CATTT']),
+        {'_id': 'ga4gh:VA.7tZ-MNUx-ZXdOElypDtzWJ1jL5JbMYgE',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 106329140,
+                                   'end': 106329143}},
+         'state': {'type': 'SequenceState', 'sequence': 'ATTTATT'}}
+    ),
+    (
+        ('24', '22304601', 'G', ['GA']),
         {
-            '_id': 'ga4gh:VA.mId9FgDqwHkP3mBt1lgfSr2-bhCJaxGg',
+            '_id': 'ga4gh:VA.TDba99qQKLMUiooxOgIX_EEFDgyNPBAq',
             'type': 'Allele',
             'location': {
                 'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7',
+                'sequence_id': 'ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5',
                 'interval': {
                     'type': 'SimpleInterval',
-                    'start': 29204173, 'end': 29204179
+                    'start': 22304601,
+                    'end': 22304607
                 }
             },
-            'state': {'type': 'SequenceState', 'sequence': 'ACA'}
+            'state': {'type': 'SequenceState', 'sequence': 'AAAAAAA'}
         }
     ),
+    # del
     (
         ('4', '116619313', 'GT', ['G']),
         {
             '_id': 'ga4gh:VA.GVcxxtyjvhuuCtcdpcNAvVhRHWbzAhra',
             'type': 'Allele',
-            'location': {
-                'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
-                'interval': {
-                    'type': 'SimpleInterval',
-                    'start': 116619313,
-                    'end': 116619314
-                }
-            },
+            'location': {'type': 'SequenceLocation',
+                         'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+                         'interval': {'type': 'SimpleInterval', 'start': 116619313, 'end': 116619314}},
             'state': {'type': 'SequenceState', 'sequence': ''}
         }
-    )
+    ),
+    (
+        ('5', '81229982', 'TG', ['T']),
+        {'_id': 'ga4gh:VA.UU86eospaxRFVjtkX0VHKBbcNenwDfU3',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+                      'interval': {'type': 'SimpleInterval', 'start': 81229982, 'end': 81229983}},
+         'state': {'type': 'SequenceState', 'sequence': ''}}
+    ),
+    (
+        ('5', '81230677', 'AG', ['A']),
+        {'_id': 'ga4gh:VA.xJctu09E74WfvRu-TvtjesE8S_spoKoB',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+                      'interval': {'type': 'SimpleInterval', 'start': 81230677, 'end': 81230684}},
+         'state': {'type': 'SequenceState', 'sequence': 'GGGGGG'}}
+    ),
+    (
+        ('5', '81233450', 'TGGA', ['T']),
+        {'_id': 'ga4gh:VA.JxnxekfJP329pXfBum6U8a5u0NSNFmnp',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+                      'interval': {'type': 'SimpleInterval', 'start': 81233450, 'end': 81233457}},
+         'state': {'type': 'SequenceState', 'sequence': 'GGAG'}}
+    ),
+    (
+        ('5', '81233494', 'GCTGA', ['G']),
+        {'_id': 'ga4gh:VA.-lNWDXnYR4hs2u6fFncH1ZOqILu4xZT8',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+                      'interval': {'type': 'SimpleInterval', 'start': 81233494, 'end': 81233501}},
+         'state': {'type': 'SequenceState', 'sequence': 'CTG'}}
+    ),
+    (
+        ('8', '62540756', 'TCTC', ['T']),
+        {'_id': 'ga4gh:VA.oq5H3D7ea1BLpVONa-UmLhDiKug7kOaU',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.209Z7zJ-mFypBEWLk4rNC6S_OxY5p7bs',
+                      'interval': {'type': 'SimpleInterval', 'start': 62540756, 'end': 62540761}},
+         'state': {'type': 'SequenceState', 'sequence': 'CT'}}
+    ),
+    (
+        ('10', '106332351', 'CAT', ['C']),
+        {'_id': 'ga4gh:VA.xti_mlNXAekytcegCcaqk9csAQ5f5pYw',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 106332351,
+                                   'end': 106332355}},
+         'state': {'type': 'SequenceState', 'sequence': 'AT'}}
+    ),
+    (
+        ('17', '29204173', 'TACA', ['T']),
+        {'_id': 'ga4gh:VA.mId9FgDqwHkP3mBt1lgfSr2-bhCJaxGg',
+         'type': 'Allele',
+         'location': {'type': 'SequenceLocation',
+                      'sequence_id': 'ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7',
+                      'interval': {'type': 'SimpleInterval',
+                                   'start': 29204173,
+                                   'end': 29204179}},
+            'state': {'type': 'SequenceState', 'sequence': 'ACA'}
+         }
+    ),
 )
 
 
@@ -259,8 +405,7 @@ def vcf_file_in():
                   '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n' + \
                   '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">\n' + \
                   '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA00001\tNA00002\tNA00003\n' + \
-                  '20\t14370\trs6054257\tG\tA\t29\tPASS\tDP=14;AF=0.5;DB\tGT:DP\t0/0:1\t0/1:8\t1/1:5\n' + \
-                  '4\t116612759\trs566366173\tATTGTT\tA\t.\tPASS\tRS=566366173;RSPOS=116612760;dbSNPBuildID=142;SSR=0;SAO=0;VP=0x050000000005040026000200;WGT=1;VC=DIV;ASP;VLD;KGPhase3;CAF=0.9968,0.003195;COMMON=1;TOPMED=0.99684633027522935,0.00315366972477064'
+                  '20\t14370\trs6054257\tG\tA\t29\tPASS\tDP=14;AF=0.5;DB\tGT:DP\t0/0:1\t0/1:8\t1/1:5\n'
     file_bytes = file_string.encode('utf-8')
     fp = TemporaryFile()
     fp.write(file_bytes)
@@ -286,20 +431,6 @@ def vcf_from_file_expected():
             },
             'state': {'type': 'SequenceState', 'sequence': 'A'}
         },
-        {
-            '_id': 'ga4gh:VA.EG07sjR0AIU2XOTHvlXvM__egaimtuPT',
-            'type': 'Allele',
-            'location': {
-                'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
-                'interval': {
-                    'type': 'SimpleInterval',
-                    'start': 116612759,
-                    'end': 116612766
-                }
-            },
-            'state': {'type': 'SequenceState', 'sequence': 'TT'}
-        }
     ]
 
 
@@ -311,40 +442,38 @@ def test_from_vcf_file(tlr_norm, vcf_file_in, vcf_from_file_expected):
 
 
 @pytest.fixture(scope="session")
-def vcf_file_vrs_input():
-    """Provide VRS Allele objects as input to test Translator._to_vcf"""
-    return [
-        models.Allele(
-            _id='ga4gh:VA.VewFnlxS7DmjEdKMkj0xZK-9GaHGMJcx',
-            location=models.Location(
-                sequence_id='ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-                interval=models.SimpleInterval(start=63001, end=63002)
-            ),
-            state=models.SequenceState(sequence='G')
-        ),
-        models.Allele(
-            _id='ga4gh:VA.qAK6JCN3-AVa9_6Qq3AqAuppUU0bWgfH',
-            location=models.Location(
-                sequence_id='ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-                interval=models.SimpleInterval(start=92632, end=92633)
-            ),
-            state=models.SequenceState(sequence='T')
-        )
-    ]
+def vcf_to_file():
+    return to_vcf_tests
 
-@pytest.fixture(scope="session")
-def vcf_from_file_expected():
-    """Provide expected output for Translator._to_vcf"""
-    return [
-        '1\t63002\t.\tA\tG\t.\t.\t.\n',
-        '1\t92633\t.\tC\tT\t.\t.\t.\n'
-    ]
 
-def test_to_vcf(tlr_norm, vcf_file_vrs_input, vcf_from_file_expected):
-    """Test Translator._to_vcf"""
+def test_to_vcf(tlr_norm, vcf_to_file):
+    alleles = [tlr_norm._from_vrs(i[1]) for i in vcf_to_file]
     outfile_path = "test_out.vcf"
-    tlr_norm._to_vcf(vcf_file_vrs_input, outfile_path)
+    tlr_norm._to_vcf(alleles, outfile_path)
     with open(outfile_path) as f:
         outfile_lines = list(f.readlines())
-    assert outfile_lines[4] == vcf_from_file_expected[0]
-    assert outfile_lines[5] == vcf_from_file_expected[1]
+
+    def format_as_vcf_row(tup):
+        return f'{tup[0]}\t{tup[1]}\t.\t{tup[2]}\t{tup[3][0]}\t.\t.\tEND=0\n'
+
+    for i in range(len(vcf_to_file)):
+        assert outfile_lines[i + 15] == format_as_vcf_row(vcf_to_file[i][0])
+
+    remove(outfile_path)
+
+
+# def test_to_vcf(tlr_norm, )
+#     vcfh = VariantHeader()
+#     assert tlr_norm._allele_to_vcf(vcfh, record) == tlr_norm._from_vrs(expected)
+
+
+# def test_to_vcf(tlr_norm, vcf_file_vrs_input, vcf_to_file_expected):
+#     """Test Translator._to_vcf"""
+#     outfile_path = "test_out.vcf"
+#     tlr_norm._to_vcf(vcf_file_vrs_input, outfile_path)
+#     with open(outfile_path) as f:
+#         outfile_lines = list(f.readlines())
+#     assert outfile_lines[5] == vcf_to_file_expected[0]
+#     assert outfile_lines[6] == vcf_to_file_expected[1]
+#     assert outfile_lines[7] == vcf_to_file_expected[2]
+#     remove(outfile_path)

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -782,7 +782,6 @@ def vcf_to_file():
 
 def test_to_vcf_file(tlr_norm, vcf_to_file):
     """Test Translator._to_vcf"""
-    # alleles = [tlr_norm._from_vrs(i) for j in vcf_to_file for i in j[1]]
     alleles = [tlr_norm._from_vrs(i[1]) for i in vcf_to_file]
     outfile_path = "test_out.vcf"
     tlr_norm._to_vcf(alleles, outfile_path)

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -460,20 +460,3 @@ def test_to_vcf(tlr_norm, vcf_to_file):
         assert outfile_lines[i + 15] == format_as_vcf_row(vcf_to_file[i][0])
 
     remove(outfile_path)
-
-
-# def test_to_vcf(tlr_norm, )
-#     vcfh = VariantHeader()
-#     assert tlr_norm._allele_to_vcf(vcfh, record) == tlr_norm._from_vrs(expected)
-
-
-# def test_to_vcf(tlr_norm, vcf_file_vrs_input, vcf_to_file_expected):
-#     """Test Translator._to_vcf"""
-#     outfile_path = "test_out.vcf"
-#     tlr_norm._to_vcf(vcf_file_vrs_input, outfile_path)
-#     with open(outfile_path) as f:
-#         outfile_lines = list(f.readlines())
-#     assert outfile_lines[5] == vcf_to_file_expected[0]
-#     assert outfile_lines[6] == vcf_to_file_expected[1]
-#     assert outfile_lines[7] == vcf_to_file_expected[2]
-#     remove(outfile_path)

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -4,7 +4,8 @@ inputs = {
     "hgvs": "NC_000013.11:g.32936732G>C",
     "beacon": "13 : 32936732 G > C",
     "spdi": "NC_000013.11:32936731:1:C",
-    "gnomad": "13-32936732-G-C"
+    "gnomad": "13-32936732-G-C",
+    "vcf": ['13', '32936732', 'G', 'C']
 }
 
 output = {
@@ -36,6 +37,10 @@ def test_from_hgvs(tlr):
 def test_from_spdi(tlr):
     assert tlr._from_spdi(inputs["spdi"]).as_dict() == output
 
+
+@pytest.mark.vcr
+def test_from_vcf(tlr):
+    assert tlr._from_vcf(inputs["vcf"]).as_dict() == output
 
 hgvs_tests = (
     ("NC_000013.11:g.32936732=",
@@ -119,3 +124,111 @@ def test_hgvs(tlr, hgvsexpr, expected):
 #
 #     with pytest.raises(ValueError):
 #         tlr._from_spdi("NM_182763.2:c.688+403C>T")
+
+
+vcf_tests = (
+    # SNPs
+    (
+        ('1', '92633', 'C', ['T']),
+        {
+            'type': 'Allele',
+            'location': {
+                'type': 'SequenceLocation',
+                'sequence_id': 'ga4gh:GS.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU',
+                'interval': {
+                    'type': 'SimpleInterval',
+                    'start': 92632, 'end': 92633
+                }
+            },
+            'state': {'type': 'SequenceState', 'sequence': 'T'}
+        }
+    ),
+    (
+        ('1', '63002', 'A', ['G']),
+        {
+            'type': 'Allele',
+            'location': {
+                'type': 'SequenceLocation',
+                'sequence_id': 'ga4gh:GS.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU',
+                'interval': {
+                    'type': 'SimpleInterval',
+                    'start': 63001,
+                    'end': 63002
+                }
+            },
+            'state': {'type': 'SequenceState', 'sequence': 'G'}
+        }
+    ),
+    # ins
+    (
+        ('Y', '22304601', 'G', ['GA']),
+        {
+            'type': 'Allele',
+            'location': {
+                'type': 'SequenceLocation',
+                'sequence_id': 'ga4gh:GS.BT7QyW5iXaX_1PSX-msSGYsqRdMKqkj-',
+                'interval': {
+                    'type': 'SimpleInterval',
+                    'start': 22304601,
+                    'end': 22304601
+                }
+            },
+            'state': {'type': 'SequenceState', 'sequence': 'A'}
+        }
+    ),
+    (
+        ('1', '72297', 'G', ['GTAT']),
+        {
+            'type': 'Allele',
+            'location': {
+                'type': 'SequenceLocation',
+                'sequence_id': 'ga4gh:GS.S_KjnFVz-FE7M0W6yoaUDgYxLPc1jyWU',
+                'interval': {
+                    'type': 'SimpleInterval',
+                    'start': 72297,
+                    'end': 72301
+                }
+            },
+            'state': {'type': 'SequenceState', 'sequence': 'TATTATT'}
+        }
+    ),
+    # del
+    (
+        ('17', '29204173', 'TACA', ['T']),
+        {
+            'type': 'Allele',
+            'location': {
+                'type': 'SequenceLocation',
+                'sequence_id': 'ga4gh:GS.AjWXsI7AkTK35XW9pgd3UbjpC3MAevlz',
+                'interval': {
+                    'type': 'SimpleInterval',
+                    'start': 29204173,
+                    'end': 29204176
+                }
+            },
+            'state': {'type': 'SequenceState', 'sequence': ''}
+        }
+    ),
+    (
+        ('4', '116619313', 'GT', ['G']),
+        {
+            'type': 'Allele',
+            'location': {
+                'type': 'SequenceLocation',
+                'sequence_id': 'ga4gh:GS.iy7Zfceb5_VGtTQzJ-v5JpPbpeifHD_V',
+                'interval': {
+                    'type': 'SimpleInterval',
+                    'start': 116619312,
+                    'end': 116619314
+                }
+            },
+            'state': {'type': 'SequenceState', 'sequence': 'G'}
+        }
+    )
+)
+
+@pytest.mark.parametrize("record,expected", vcf_tests)
+def test_vcf(tlr, record, expected):
+    tlr.normalize = True
+    allele = tlr._from_vcf_record(*record, 'GRCh37')
+    assert allele.as_dict() == expected

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -464,7 +464,7 @@ to_vcf_tests = (
                                    'end': 29204179}},
          'state': {'type': 'SequenceState', 'sequence': 'ACA'}
          }]
-    ),
+    )
 )
 
 
@@ -534,16 +534,19 @@ def vcf_to_file():
 
 
 def test_to_vcf(tlr_norm, vcf_to_file):
-    alleles = [tlr_norm._from_vrs(i[1]) for i in vcf_to_file]
+    alleles = [tlr_norm._from_vrs(i) for j in vcf_to_file for i in j[1]]
     outfile_path = "test_out.vcf"
     tlr_norm._to_vcf(alleles, outfile_path)
     with open(outfile_path) as f:
         outfile_lines = list(f.readlines())
 
     def format_as_vcf_row(tup):
-        return f'{tup[0]}\t{tup[1]}\t.\t{tup[2]}\t{tup[3][0]}\t.\t.\tEND=0\n'
+        return f'{tup[0]}\t{tup[1]}\t.\t{tup[2]}\t{",".join(tup[3])}\t.\t.\tEND=0\n'
+
+    expected = [i[0] for i in vcf_to_file]
+    expected.sort(key=lambda r: (r[0].zfill(2), int(r[1])))
 
     for i in range(len(vcf_to_file)):
-        assert outfile_lines[i + 15] == format_as_vcf_row(vcf_to_file[i][0])
+        assert outfile_lines[i + 16] == format_as_vcf_row(expected[i])
 
-    remove(outfile_path)
+    # remove(outfile_path)

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -10,7 +10,7 @@ inputs = {
     "beacon": "13 : 32936732 G > C",
     "spdi": "NC_000013.11:32936731:1:C",
     "gnomad": "13-32936732-G-C",
-    "vcf": ['13', '32936732', 'G', 'C']
+    "vcf": ['13', '32936732', 'G', ['C']]
 }
 
 output = {
@@ -135,10 +135,95 @@ def test_hgvs(tlr, hgvsexpr, expected):
 
 # provide test inputs and expected outputs testing Translator._from_vcf_record
 to_vcf_tests = (
+    # multiple alleles
+    (
+        ('1', '29881425', 'C', ['A', 'T']),
+        [{'_id': 'ga4gh:VA.32Q-JABVQ7pecrW2RPlYYLxBeP6j6ZN_',
+          'location': {'interval': {'end': 29881425,
+                                    'start': 29881424,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'A', 'type': 'SequenceState'},
+          'type': 'Allele'},
+         {'_id': 'ga4gh:VA.wUquYEB9ztjtsc9Xc4BnlpdQHOP4SvwN',
+          'location': {'interval': {'end': 29881425,
+                                    'start': 29881424,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'T', 'type': 'SequenceState'},
+          'type': 'Allele'}]
+    ),
+    (
+        ('4', '147973044', 'C', ['A', 'T']),
+        [{'_id': 'ga4gh:VA.I-Ol7SHx4gVYmvSDZ4tSrbKjQFQFnmAF',
+          'location': {'interval': {'end': 147973044,
+                                    'start': 147973043,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'A', 'type': 'SequenceState'},
+          'type': 'Allele'},
+         {'_id': 'ga4gh:VA.SPrLYmcDQqlPOGYZWvE3AZ5skV9_EnXe',
+          'location': {'interval': {'end': 147973044,
+                                    'start': 147973043,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'T', 'type': 'SequenceState'},
+          'type': 'Allele'}]
+    ),
+    (
+        ('7', '142149548', 'G', ['GT', 'GTT']),
+        [{'_id': 'ga4gh:VA.y8-6HmQkyOLtgYCWozwfuSy8I8HbQocl',
+          'location': {'interval': {'end': 142149558,
+                                    'start': 142149548,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'TTTTTTTTTTT', 'type': 'SequenceState'},
+          'type': 'Allele'},
+         {'_id': 'ga4gh:VA.z8z9fvWr1RHnOa_LjIr22rDnmXU7WkjZ',
+          'location': {'interval': {'end': 142149558,
+                                    'start': 142149548,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'TTTTTTTTTTTT', 'type': 'SequenceState'},
+          'type': 'Allele'}]
+    ),
+    (
+        ('12', '49520727', 'A', ['AT', 'ATT', 'ATTT']),
+        [{'_id': 'ga4gh:VA.y7R6DdlWtMVpe9H_1cKtuMS2egyf4inX',
+          'location': {'interval': {'end': 49520742,
+                                    'start': 49520727,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'TTTTTTTTTTTTTTTT', 'type': 'SequenceState'},
+          'type': 'Allele'},
+         {'_id': 'ga4gh:VA.uZ_O9g5pteehH2E_gmjv4WkKK3lk4QOd',
+          'location': {'interval': {'end': 49520742,
+                                    'start': 49520727,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'TTTTTTTTTTTTTTTTT', 'type': 'SequenceState'},
+          'type': 'Allele'},
+         {'_id': 'ga4gh:VA.kNYqY6TpWQ2EM400mW6fZrwRL1HZmz9S',
+          'location': {'interval': {'end': 49520742,
+                                    'start': 49520727,
+                                    'type': 'SimpleInterval'},
+                       'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+                       'type': 'SequenceLocation'},
+          'state': {'sequence': 'TTTTTTTTTTTTTTTTTT', 'type': 'SequenceState'},
+          'type': 'Allele'}]
+    ),
     # SNPs
     (
         ('1', '92633', 'C', ['T']),
-        {
+        [{
             '_id': 'ga4gh:VA.qAK6JCN3-AVa9_6Qq3AqAuppUU0bWgfH',
             'type': 'Allele',
             'location': {
@@ -151,11 +236,11 @@ to_vcf_tests = (
                 }
             },
             'state': {'type': 'SequenceState', 'sequence': 'T'}
-        }
+        }]
     ),
     (
         ('1', '63002', 'A', ['G']),
-        {
+        [{
             '_id': 'ga4gh:VA.VewFnlxS7DmjEdKMkj0xZK-9GaHGMJcx',
             'type': 'Allele',
             'location': {
@@ -168,63 +253,63 @@ to_vcf_tests = (
                 }
             },
             'state': {'type': 'SequenceState', 'sequence': 'G'}
-        }
+        }]
     ),
     (
         ('3', '166125806', 'G', ['A']),
-        {'_id': 'ga4gh:VA.UAcSqA7iJtI36BysCOYXR8wPGVwUm4En',
+        [{'_id': 'ga4gh:VA.UAcSqA7iJtI36BysCOYXR8wPGVwUm4En',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 166125805,
                                    'end': 166125806}},
-         'state': {'type': 'SequenceState', 'sequence': 'A'}}
+         'state': {'type': 'SequenceState', 'sequence': 'A'}}]
     ),
     (
         ('5', '1100700', 'G', ['A']),
-        {'_id': 'ga4gh:VA.UrXpOOJGuCHAQgQ2sY85FsZ3CztIwI6C',
+        [{'_id': 'ga4gh:VA.UrXpOOJGuCHAQgQ2sY85FsZ3CztIwI6C',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
                       'interval': {'type': 'SimpleInterval', 'start': 1100699, 'end': 1100700}},
-         'state': {'type': 'SequenceState', 'sequence': 'A'}}
+         'state': {'type': 'SequenceState', 'sequence': 'A'}}]
     ),
     (
         ('7', '108934752', 'T', ['C']),
-        {'_id': 'ga4gh:VA.pwoWgFDuLdigDfQRTEU7gCdSB4DoHED1',
+        [{'_id': 'ga4gh:VA.pwoWgFDuLdigDfQRTEU7gCdSB4DoHED1',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 108934751,
                                    'end': 108934752}},
-         'state': {'type': 'SequenceState', 'sequence': 'C'}}
+         'state': {'type': 'SequenceState', 'sequence': 'C'}}]
     ),
     (
         ('13', '59140800', 'G', ['A']),
-        {'_id': 'ga4gh:VA.Ii5EzfJNVealFy9Wc7UMjd4WrzqSpbmg',
+        [{'_id': 'ga4gh:VA.Ii5EzfJNVealFy9Wc7UMjd4WrzqSpbmg',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
                       'interval': {'type': 'SimpleInterval', 'start': 59140799, 'end': 59140800}},
-         'state': {'type': 'SequenceState', 'sequence': 'A'}}
+         'state': {'type': 'SequenceState', 'sequence': 'A'}}]
     ),
     (
         ('23', '127226377', 'A', ['G']),
-        {'_id': 'ga4gh:VA.nyaA37BGIVLcP6LPfpT1GKg-nfLhxPOD',
+        [{'_id': 'ga4gh:VA.nyaA37BGIVLcP6LPfpT1GKg-nfLhxPOD',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 127226376,
                                    'end': 127226377}},
-         'state': {'type': 'SequenceState', 'sequence': 'G'}}
+         'state': {'type': 'SequenceState', 'sequence': 'G'}}]
     ),
     # ins
     (
         ('1', '72297', 'G', ['GTAT']),
-        {
+        [{
             '_id': 'ga4gh:VA.wbhpDCQ0MRtG0pZZWH-yarqSdOjGNJEL',
             'type': 'Allele',
             'location': {
@@ -237,55 +322,55 @@ to_vcf_tests = (
                 }
             },
             'state': {'type': 'SequenceState', 'sequence': 'TATTATT'}
-        }
+        }]
     ),
     (
         ('3', '166114496', 'T', ['TA']),
-        {'_id': 'ga4gh:VA.LVqeAmYsZxO3kYb-lvmYOrqnoY1NbKWd',
+        [{'_id': 'ga4gh:VA.LVqeAmYsZxO3kYb-lvmYOrqnoY1NbKWd',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 166114496,
                                    'end': 166114496}},
-         'state': {'type': 'SequenceState', 'sequence': 'A'}}
+         'state': {'type': 'SequenceState', 'sequence': 'A'}}]
     ),
     (
         ('5', '127031196', 'C', ['CG']),
-        {'_id': 'ga4gh:VA.4lIsTJ1zxjQ7UjXTSnCLb-HF2jw733NK',
+        [{'_id': 'ga4gh:VA.4lIsTJ1zxjQ7UjXTSnCLb-HF2jw733NK',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 127031196,
                                    'end': 127031201}},
-         'state': {'type': 'SequenceState', 'sequence': 'GGGGGG'}}
+         'state': {'type': 'SequenceState', 'sequence': 'GGGGGG'}}]
     ),
     (
         ('7', '156408692', 'C', ['CAT']),
-        {'_id': 'ga4gh:VA.uvVtM0pr6hFMLfKTurDcdFj_3rRHbBqp',
+        [{'_id': 'ga4gh:VA.uvVtM0pr6hFMLfKTurDcdFj_3rRHbBqp',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 156408692,
                                    'end': 156408703}},
-         'state': {'type': 'SequenceState', 'sequence': 'ATATATATATATA'}}
+         'state': {'type': 'SequenceState', 'sequence': 'ATATATATATATA'}}]
     ),
     (
         ('10', '106329140', 'C', ['CATTT']),
-        {'_id': 'ga4gh:VA.7tZ-MNUx-ZXdOElypDtzWJ1jL5JbMYgE',
+        [{'_id': 'ga4gh:VA.7tZ-MNUx-ZXdOElypDtzWJ1jL5JbMYgE',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 106329140,
                                    'end': 106329143}},
-         'state': {'type': 'SequenceState', 'sequence': 'ATTTATT'}}
+         'state': {'type': 'SequenceState', 'sequence': 'ATTTATT'}}]
     ),
     (
         ('24', '22304601', 'G', ['GA']),
-        {
+        [{
             '_id': 'ga4gh:VA.TDba99qQKLMUiooxOgIX_EEFDgyNPBAq',
             'type': 'Allele',
             'location': {
@@ -298,87 +383,87 @@ to_vcf_tests = (
                 }
             },
             'state': {'type': 'SequenceState', 'sequence': 'AAAAAAA'}
-        }
+        }]
     ),
     # del
     (
         ('4', '116619313', 'GT', ['G']),
-        {
+        [{
             '_id': 'ga4gh:VA.GVcxxtyjvhuuCtcdpcNAvVhRHWbzAhra',
             'type': 'Allele',
             'location': {'type': 'SequenceLocation',
                          'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
                          'interval': {'type': 'SimpleInterval', 'start': 116619313, 'end': 116619314}},
             'state': {'type': 'SequenceState', 'sequence': ''}
-        }
+        }]
     ),
     (
         ('5', '81229982', 'TG', ['T']),
-        {'_id': 'ga4gh:VA.UU86eospaxRFVjtkX0VHKBbcNenwDfU3',
+        [{'_id': 'ga4gh:VA.UU86eospaxRFVjtkX0VHKBbcNenwDfU3',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
                       'interval': {'type': 'SimpleInterval', 'start': 81229982, 'end': 81229983}},
-         'state': {'type': 'SequenceState', 'sequence': ''}}
+         'state': {'type': 'SequenceState', 'sequence': ''}}]
     ),
     (
         ('5', '81230677', 'AG', ['A']),
-        {'_id': 'ga4gh:VA.xJctu09E74WfvRu-TvtjesE8S_spoKoB',
+        [{'_id': 'ga4gh:VA.xJctu09E74WfvRu-TvtjesE8S_spoKoB',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
                       'interval': {'type': 'SimpleInterval', 'start': 81230677, 'end': 81230684}},
-         'state': {'type': 'SequenceState', 'sequence': 'GGGGGG'}}
+         'state': {'type': 'SequenceState', 'sequence': 'GGGGGG'}}]
     ),
     (
         ('5', '81233450', 'TGGA', ['T']),
-        {'_id': 'ga4gh:VA.JxnxekfJP329pXfBum6U8a5u0NSNFmnp',
+        [{'_id': 'ga4gh:VA.JxnxekfJP329pXfBum6U8a5u0NSNFmnp',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
                       'interval': {'type': 'SimpleInterval', 'start': 81233450, 'end': 81233457}},
-         'state': {'type': 'SequenceState', 'sequence': 'GGAG'}}
+         'state': {'type': 'SequenceState', 'sequence': 'GGAG'}}]
     ),
     (
         ('5', '81233494', 'GCTGA', ['G']),
-        {'_id': 'ga4gh:VA.-lNWDXnYR4hs2u6fFncH1ZOqILu4xZT8',
+        [{'_id': 'ga4gh:VA.-lNWDXnYR4hs2u6fFncH1ZOqILu4xZT8',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
                       'interval': {'type': 'SimpleInterval', 'start': 81233494, 'end': 81233501}},
-         'state': {'type': 'SequenceState', 'sequence': 'CTG'}}
+         'state': {'type': 'SequenceState', 'sequence': 'CTG'}}]
     ),
     (
         ('8', '62540756', 'TCTC', ['T']),
-        {'_id': 'ga4gh:VA.oq5H3D7ea1BLpVONa-UmLhDiKug7kOaU',
+        [{'_id': 'ga4gh:VA.oq5H3D7ea1BLpVONa-UmLhDiKug7kOaU',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.209Z7zJ-mFypBEWLk4rNC6S_OxY5p7bs',
                       'interval': {'type': 'SimpleInterval', 'start': 62540756, 'end': 62540761}},
-         'state': {'type': 'SequenceState', 'sequence': 'CT'}}
+         'state': {'type': 'SequenceState', 'sequence': 'CT'}}]
     ),
     (
         ('10', '106332351', 'CAT', ['C']),
-        {'_id': 'ga4gh:VA.xti_mlNXAekytcegCcaqk9csAQ5f5pYw',
+        [{'_id': 'ga4gh:VA.xti_mlNXAekytcegCcaqk9csAQ5f5pYw',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 106332351,
                                    'end': 106332355}},
-         'state': {'type': 'SequenceState', 'sequence': 'AT'}}
+         'state': {'type': 'SequenceState', 'sequence': 'AT'}}]
     ),
     (
         ('17', '29204173', 'TACA', ['T']),
-        {'_id': 'ga4gh:VA.mId9FgDqwHkP3mBt1lgfSr2-bhCJaxGg',
+        [{'_id': 'ga4gh:VA.mId9FgDqwHkP3mBt1lgfSr2-bhCJaxGg',
          'type': 'Allele',
          'location': {'type': 'SequenceLocation',
                       'sequence_id': 'ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7',
                       'interval': {'type': 'SimpleInterval',
                                    'start': 29204173,
                                    'end': 29204179}},
-            'state': {'type': 'SequenceState', 'sequence': 'ACA'}
-         }
+         'state': {'type': 'SequenceState', 'sequence': 'ACA'}
+         }]
     ),
 )
 
@@ -387,8 +472,9 @@ to_vcf_tests = (
 def test_from_vcf_record(tlr_norm, record, expected):
     """Test Translator._from_vcf_record"""
     tlr_norm.normalize = True
-    allele = tlr_norm._from_vcf_record(*record)
-    assert allele.as_dict() == expected
+    alleles = tlr_norm._from_vcf_record(*record)
+    for allele, allele_expected in zip(alleles, expected):
+        assert allele.as_dict() == allele_expected
 
 
 @pytest.fixture(scope="session")
@@ -396,7 +482,8 @@ def vcf_file_in():
     """Provide input file fixture to test Translator._from_vcf"""
     file_string = '##fileformat=VCFv4.3\n' + \
                   '##reference=file:///seq/references/1000GenomesPilot-NCBI36.fasta\n' + \
-                  '##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,species="Homo sapiens",taxonomy=x>\n' + \
+                  '##contig=<ID=20,length=62435964,assembly=B36,md5=f126cdf8a6e0c7f379d618ff66beb2da,' + \
+                  'species="Homo sapiens",taxonomy=x>\n' + \
                   '##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">\n' + \
                   '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n' + \
                   '##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">\n' + \

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -15,10 +15,18 @@ inputs = {
 
 output = {
     'location': {
-        'interval': {'end': 32936732, 'start': 32936731, 'type': 'SimpleInterval'},
+        'interval': {
+            'end': 32936732,
+            'start': 32936731,
+            'type': 'SimpleInterval'
+        },
         'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-        'type': 'SequenceLocation'},
-    'state': {'sequence': 'C', 'type': 'SequenceState'},
+        'type': 'SequenceLocation'
+    },
+    'state': {
+        'sequence': 'C',
+        'type': 'SequenceState'
+    },
     'type': 'Allele'
 }
 
@@ -49,56 +57,102 @@ def test_from_vcf(tlr):
 
 
 hgvs_tests = (
-    ("NC_000013.11:g.32936732=",
-     {'location': {'interval': {'end': 32936732,
-                                'start': 32936731,
-                                'type': 'SimpleInterval'},
-                   'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'C', 'type': 'SequenceState'},
-      'type': 'Allele'}),
-
-    ("NC_000007.14:g.55181320A>T",
-     {'location': {'interval': {'end': 55181320,
-                                'start': 55181319,
-                                'type': 'SimpleInterval'},
-                   'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'T', 'type': 'SequenceState'},
-      'type': 'Allele'}),
-
-    ("NC_000007.14:g.55181220del",
-     {'location': {'interval': {'end': 55181220,
-                                'start': 55181219,
-                                'type': 'SimpleInterval'},
-                   'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': '', 'type': 'SequenceState'},
-      'type': 'Allele'}),
-
-    ("NC_000007.14:g.55181230_55181231insGGCT",
-     {'location': {'interval': {'end': 55181230,
-                                'start': 55181230,
-                                'type': 'SimpleInterval'},
-                   'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'GGCT', 'type': 'SequenceState'},
-      'type': 'Allele'}),
-    ("NC_000013.11:g.32331093_32331094dup",
-     {'location': {'interval': {'end': 32331094,
-                                'start': 32331082, 'type': 'SimpleInterval'},
-                   'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'TTTTTTTTTTTTTT', 'type': 'SequenceState'},
-      'type': 'Allele'}),
-    ("NC_000013.11:g.32316467dup",
-     {'location': {'interval': {'end': 32316467,
-                                'start': 32316466,
-                                'type': 'SimpleInterval'},
-                   'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'AA', 'type': 'SequenceState'},
-      'type': 'Allele'}),
+    ("NC_000013.11:g.32936732=", {
+        'location': {
+            'interval': {
+                'end': 32936732,
+                'start': 32936731,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'C',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }),
+    ("NC_000007.14:g.55181320A>T", {
+        'location': {
+            'interval': {
+                'end': 55181320,
+                'start': 55181319,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'T',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }),
+    ("NC_000007.14:g.55181220del", {
+        'location': {
+            'interval': {
+                'end': 55181220,
+                'start': 55181219,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': '',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }),
+    ("NC_000007.14:g.55181230_55181231insGGCT", {
+        'location': {
+            'interval': {
+                'end': 55181230,
+                'start': 55181230,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'GGCT',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }),
+    ("NC_000013.11:g.32331093_32331094dup", {
+        'location': {
+            'interval': {
+                'end': 32331094,
+                'start': 32331082,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'TTTTTTTTTTTTTT',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }),
+    ("NC_000013.11:g.32316467dup", {
+        'location': {
+            'interval': {
+                'end': 32316467,
+                'start': 32316466,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'AA',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }),
 )
 
 
@@ -132,340 +186,517 @@ def test_hgvs(tlr, hgvsexpr, expected):
 #     with pytest.raises(ValueError):
 #         tlr._from_spdi("NM_182763.2:c.688+403C>T")
 
-
 # provide test inputs and expected outputs testing Translator._from_vcf_record
 to_vcf_tests = (
     # multiple alleles
-    (
-        ('1', '29881425', 'C', ['A', 'T']),
-        [{'_id': 'ga4gh:VA.32Q-JABVQ7pecrW2RPlYYLxBeP6j6ZN_',
-          'location': {'interval': {'end': 29881425,
-                                    'start': 29881424,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'A', 'type': 'SequenceState'},
-          'type': 'Allele'},
-         {'_id': 'ga4gh:VA.wUquYEB9ztjtsc9Xc4BnlpdQHOP4SvwN',
-          'location': {'interval': {'end': 29881425,
-                                    'start': 29881424,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'T', 'type': 'SequenceState'},
-          'type': 'Allele'}]
-    ),
-    (
-        ('4', '147973044', 'C', ['A', 'T']),
-        [{'_id': 'ga4gh:VA.I-Ol7SHx4gVYmvSDZ4tSrbKjQFQFnmAF',
-          'location': {'interval': {'end': 147973044,
-                                    'start': 147973043,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'A', 'type': 'SequenceState'},
-          'type': 'Allele'},
-         {'_id': 'ga4gh:VA.SPrLYmcDQqlPOGYZWvE3AZ5skV9_EnXe',
-          'location': {'interval': {'end': 147973044,
-                                    'start': 147973043,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'T', 'type': 'SequenceState'},
-          'type': 'Allele'}]
-    ),
-    (
-        ('7', '142149548', 'G', ['GT', 'GTT']),
-        [{'_id': 'ga4gh:VA.y8-6HmQkyOLtgYCWozwfuSy8I8HbQocl',
-          'location': {'interval': {'end': 142149558,
-                                    'start': 142149548,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'TTTTTTTTTTT', 'type': 'SequenceState'},
-          'type': 'Allele'},
-         {'_id': 'ga4gh:VA.z8z9fvWr1RHnOa_LjIr22rDnmXU7WkjZ',
-          'location': {'interval': {'end': 142149558,
-                                    'start': 142149548,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'TTTTTTTTTTTT', 'type': 'SequenceState'},
-          'type': 'Allele'}]
-    ),
-    (
-        ('12', '49520727', 'A', ['AT', 'ATT', 'ATTT']),
-        [{'_id': 'ga4gh:VA.y7R6DdlWtMVpe9H_1cKtuMS2egyf4inX',
-          'location': {'interval': {'end': 49520742,
-                                    'start': 49520727,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'TTTTTTTTTTTTTTTT', 'type': 'SequenceState'},
-          'type': 'Allele'},
-         {'_id': 'ga4gh:VA.uZ_O9g5pteehH2E_gmjv4WkKK3lk4QOd',
-          'location': {'interval': {'end': 49520742,
-                                    'start': 49520727,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'TTTTTTTTTTTTTTTTT', 'type': 'SequenceState'},
-          'type': 'Allele'},
-         {'_id': 'ga4gh:VA.kNYqY6TpWQ2EM400mW6fZrwRL1HZmz9S',
-          'location': {'interval': {'end': 49520742,
-                                    'start': 49520727,
-                                    'type': 'SimpleInterval'},
-                       'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
-                       'type': 'SequenceLocation'},
-          'state': {'sequence': 'TTTTTTTTTTTTTTTTTT', 'type': 'SequenceState'},
-          'type': 'Allele'}]
-    ),
+    (('1', '29881425', 'C', ['A', 'T']), [{
+        '_id': 'ga4gh:VA.32Q-JABVQ7pecrW2RPlYYLxBeP6j6ZN_',
+        'location': {
+            'interval': {
+                'end': 29881425,
+                'start': 29881424,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'A',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }, {
+        '_id': 'ga4gh:VA.wUquYEB9ztjtsc9Xc4BnlpdQHOP4SvwN',
+        'location': {
+            'interval': {
+                'end': 29881425,
+                'start': 29881424,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'T',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }]),
+    (('4', '147973044', 'C', ['A', 'T']), [{
+        '_id': 'ga4gh:VA.I-Ol7SHx4gVYmvSDZ4tSrbKjQFQFnmAF',
+        'location': {
+            'interval': {
+                'end': 147973044,
+                'start': 147973043,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'A',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }, {
+        '_id': 'ga4gh:VA.SPrLYmcDQqlPOGYZWvE3AZ5skV9_EnXe',
+        'location': {
+            'interval': {
+                'end': 147973044,
+                'start': 147973043,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'T',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }]),
+    (('7', '142149548', 'G', ['GT', 'GTT']), [{
+        '_id': 'ga4gh:VA.y8-6HmQkyOLtgYCWozwfuSy8I8HbQocl',
+        'location': {
+            'interval': {
+                'end': 142149558,
+                'start': 142149548,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'TTTTTTTTTTT',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }, {
+        '_id': 'ga4gh:VA.z8z9fvWr1RHnOa_LjIr22rDnmXU7WkjZ',
+        'location': {
+            'interval': {
+                'end': 142149558,
+                'start': 142149548,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'TTTTTTTTTTTT',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }]),
+    (('12', '49520727', 'A', ['AT', 'ATT', 'ATTT']), [{
+        '_id': 'ga4gh:VA.y7R6DdlWtMVpe9H_1cKtuMS2egyf4inX',
+        'location': {
+            'interval': {
+                'end': 49520742,
+                'start': 49520727,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'TTTTTTTTTTTTTTTT',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }, {
+        '_id': 'ga4gh:VA.uZ_O9g5pteehH2E_gmjv4WkKK3lk4QOd',
+        'location': {
+            'interval': {
+                'end': 49520742,
+                'start': 49520727,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'TTTTTTTTTTTTTTTTT',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }, {
+        '_id': 'ga4gh:VA.kNYqY6TpWQ2EM400mW6fZrwRL1HZmz9S',
+        'location': {
+            'interval': {
+                'end': 49520742,
+                'start': 49520727,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'TTTTTTTTTTTTTTTTTT',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }]),
     # SNPs
-    (
-        ('1', '92633', 'C', ['T']),
-        [{
-            '_id': 'ga4gh:VA.qAK6JCN3-AVa9_6Qq3AqAuppUU0bWgfH',
-            'type': 'Allele',
-            'location': {
-                'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-                'interval': {
-                    'type': 'SimpleInterval',
-                    'start': 92632,
-                    'end': 92633
-                }
-            },
-            'state': {'type': 'SequenceState', 'sequence': 'T'}
-        }]
-    ),
-    (
-        ('1', '63002', 'A', ['G']),
-        [{
-            '_id': 'ga4gh:VA.VewFnlxS7DmjEdKMkj0xZK-9GaHGMJcx',
-            'type': 'Allele',
-            'location': {
-                'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-                'interval': {
-                    'type': 'SimpleInterval',
-                    'start': 63001,
-                    'end': 63002
-                }
-            },
-            'state': {'type': 'SequenceState', 'sequence': 'G'}
-        }]
-    ),
-    (
-        ('3', '166125806', 'G', ['A']),
-        [{'_id': 'ga4gh:VA.UAcSqA7iJtI36BysCOYXR8wPGVwUm4En',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 166125805,
-                                   'end': 166125806}},
-         'state': {'type': 'SequenceState', 'sequence': 'A'}}]
-    ),
-    (
-        ('5', '1100700', 'G', ['A']),
-        [{'_id': 'ga4gh:VA.UrXpOOJGuCHAQgQ2sY85FsZ3CztIwI6C',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
-                      'interval': {'type': 'SimpleInterval', 'start': 1100699, 'end': 1100700}},
-         'state': {'type': 'SequenceState', 'sequence': 'A'}}]
-    ),
-    (
-        ('7', '108934752', 'T', ['C']),
-        [{'_id': 'ga4gh:VA.pwoWgFDuLdigDfQRTEU7gCdSB4DoHED1',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 108934751,
-                                   'end': 108934752}},
-         'state': {'type': 'SequenceState', 'sequence': 'C'}}]
-    ),
-    (
-        ('13', '59140800', 'G', ['A']),
-        [{'_id': 'ga4gh:VA.Ii5EzfJNVealFy9Wc7UMjd4WrzqSpbmg',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                      'interval': {'type': 'SimpleInterval', 'start': 59140799, 'end': 59140800}},
-         'state': {'type': 'SequenceState', 'sequence': 'A'}}]
-    ),
-    (
-        ('23', '127226377', 'A', ['G']),
-        [{'_id': 'ga4gh:VA.nyaA37BGIVLcP6LPfpT1GKg-nfLhxPOD',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 127226376,
-                                   'end': 127226377}},
-         'state': {'type': 'SequenceState', 'sequence': 'G'}}]
-    ),
+    (('1', '92633', 'C', ['T']), [{
+        '_id': 'ga4gh:VA.qAK6JCN3-AVa9_6Qq3AqAuppUU0bWgfH',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 92632,
+                'end': 92633
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'T'
+        }
+    }]),
+    (('1', '63002', 'A', ['G']), [{
+        '_id': 'ga4gh:VA.VewFnlxS7DmjEdKMkj0xZK-9GaHGMJcx',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 63001,
+                'end': 63002
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'G'
+        }
+    }]),
+    (('3', '166125806', 'G', ['A']), [{
+        '_id': 'ga4gh:VA.UAcSqA7iJtI36BysCOYXR8wPGVwUm4En',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 166125805,
+                'end': 166125806
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'A'
+        }
+    }]),
+    (('5', '1100700', 'G', ['A']), [{
+        '_id': 'ga4gh:VA.UrXpOOJGuCHAQgQ2sY85FsZ3CztIwI6C',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 1100699,
+                'end': 1100700
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'A'
+        }
+    }]),
+    (('7', '108934752', 'T', ['C']), [{
+        '_id': 'ga4gh:VA.pwoWgFDuLdigDfQRTEU7gCdSB4DoHED1',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 108934751,
+                'end': 108934752
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'C'
+        }
+    }]),
+    (('13', '59140800', 'G', ['A']), [{
+        '_id': 'ga4gh:VA.Ii5EzfJNVealFy9Wc7UMjd4WrzqSpbmg',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 59140799,
+                'end': 59140800
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'A'
+        }
+    }]),
+    (('23', '127226377', 'A', ['G']), [{
+        '_id': 'ga4gh:VA.nyaA37BGIVLcP6LPfpT1GKg-nfLhxPOD',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 127226376,
+                'end': 127226377
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'G'
+        }
+    }]),
     # ins
-    (
-        ('1', '72297', 'G', ['GTAT']),
-        [{
-            '_id': 'ga4gh:VA.wbhpDCQ0MRtG0pZZWH-yarqSdOjGNJEL',
-            'type': 'Allele',
-            'location': {
-                'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-                'interval': {
-                    'type': 'SimpleInterval',
-                    'start': 72297,
-                    'end': 72301
-                }
-            },
-            'state': {'type': 'SequenceState', 'sequence': 'TATTATT'}
-        }]
-    ),
-    (
-        ('3', '166114496', 'T', ['TA']),
-        [{'_id': 'ga4gh:VA.LVqeAmYsZxO3kYb-lvmYOrqnoY1NbKWd',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 166114496,
-                                   'end': 166114496}},
-         'state': {'type': 'SequenceState', 'sequence': 'A'}}]
-    ),
-    (
-        ('5', '127031196', 'C', ['CG']),
-        [{'_id': 'ga4gh:VA.4lIsTJ1zxjQ7UjXTSnCLb-HF2jw733NK',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 127031196,
-                                   'end': 127031201}},
-         'state': {'type': 'SequenceState', 'sequence': 'GGGGGG'}}]
-    ),
-    (
-        ('7', '156408692', 'C', ['CAT']),
-        [{'_id': 'ga4gh:VA.uvVtM0pr6hFMLfKTurDcdFj_3rRHbBqp',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 156408692,
-                                   'end': 156408703}},
-         'state': {'type': 'SequenceState', 'sequence': 'ATATATATATATA'}}]
-    ),
-    (
-        ('10', '106329140', 'C', ['CATTT']),
-        [{'_id': 'ga4gh:VA.7tZ-MNUx-ZXdOElypDtzWJ1jL5JbMYgE',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 106329140,
-                                   'end': 106329143}},
-         'state': {'type': 'SequenceState', 'sequence': 'ATTTATT'}}]
-    ),
-    (
-        ('24', '22304601', 'G', ['GA']),
-        [{
-            '_id': 'ga4gh:VA.TDba99qQKLMUiooxOgIX_EEFDgyNPBAq',
-            'type': 'Allele',
-            'location': {
-                'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5',
-                'interval': {
-                    'type': 'SimpleInterval',
-                    'start': 22304601,
-                    'end': 22304607
-                }
-            },
-            'state': {'type': 'SequenceState', 'sequence': 'AAAAAAA'}
-        }]
-    ),
+    (('1', '72297', 'G', ['GTAT']), [{
+        '_id': 'ga4gh:VA.wbhpDCQ0MRtG0pZZWH-yarqSdOjGNJEL',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 72297,
+                'end': 72301
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'TATTATT'
+        }
+    }]),
+    (('3', '166114496', 'T', ['TA']), [{
+        '_id': 'ga4gh:VA.LVqeAmYsZxO3kYb-lvmYOrqnoY1NbKWd',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.Zu7h9AggXxhTaGVsy7h_EZSChSZGcmgX',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 166114496,
+                'end': 166114496
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'A'
+        }
+    }]),
+    (('5', '127031196', 'C', ['CG']), [{
+        '_id': 'ga4gh:VA.4lIsTJ1zxjQ7UjXTSnCLb-HF2jw733NK',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 127031196,
+                'end': 127031201
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'GGGGGG'
+        }
+    }]),
+    (('7', '156408692', 'C', ['CAT']), [{
+        '_id': 'ga4gh:VA.uvVtM0pr6hFMLfKTurDcdFj_3rRHbBqp',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 156408692,
+                'end': 156408703
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'ATATATATATATA'
+        }
+    }]),
+    (('10', '106329140', 'C', ['CATTT']), [{
+        '_id': 'ga4gh:VA.7tZ-MNUx-ZXdOElypDtzWJ1jL5JbMYgE',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 106329140,
+                'end': 106329143
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'ATTTATT'
+        }
+    }]),
+    (('24', '22304601', 'G', ['GA']), [{
+        '_id': 'ga4gh:VA.TDba99qQKLMUiooxOgIX_EEFDgyNPBAq',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.8_liLu1aycC0tPQPFmUaGXJLDs5SbPZ5',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 22304601,
+                'end': 22304607
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'AAAAAAA'
+        }
+    }]),
     # del
-    (
-        ('4', '116619313', 'GT', ['G']),
-        [{
-            '_id': 'ga4gh:VA.GVcxxtyjvhuuCtcdpcNAvVhRHWbzAhra',
-            'type': 'Allele',
-            'location': {'type': 'SequenceLocation',
-                         'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
-                         'interval': {'type': 'SimpleInterval', 'start': 116619313, 'end': 116619314}},
-            'state': {'type': 'SequenceState', 'sequence': ''}
-        }]
-    ),
-    (
-        ('5', '81229982', 'TG', ['T']),
-        [{'_id': 'ga4gh:VA.UU86eospaxRFVjtkX0VHKBbcNenwDfU3',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
-                      'interval': {'type': 'SimpleInterval', 'start': 81229982, 'end': 81229983}},
-         'state': {'type': 'SequenceState', 'sequence': ''}}]
-    ),
-    (
-        ('5', '81230677', 'AG', ['A']),
-        [{'_id': 'ga4gh:VA.xJctu09E74WfvRu-TvtjesE8S_spoKoB',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
-                      'interval': {'type': 'SimpleInterval', 'start': 81230677, 'end': 81230684}},
-         'state': {'type': 'SequenceState', 'sequence': 'GGGGGG'}}]
-    ),
-    (
-        ('5', '81233450', 'TGGA', ['T']),
-        [{'_id': 'ga4gh:VA.JxnxekfJP329pXfBum6U8a5u0NSNFmnp',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
-                      'interval': {'type': 'SimpleInterval', 'start': 81233450, 'end': 81233457}},
-         'state': {'type': 'SequenceState', 'sequence': 'GGAG'}}]
-    ),
-    (
-        ('5', '81233494', 'GCTGA', ['G']),
-        [{'_id': 'ga4gh:VA.-lNWDXnYR4hs2u6fFncH1ZOqILu4xZT8',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
-                      'interval': {'type': 'SimpleInterval', 'start': 81233494, 'end': 81233501}},
-         'state': {'type': 'SequenceState', 'sequence': 'CTG'}}]
-    ),
-    (
-        ('8', '62540756', 'TCTC', ['T']),
-        [{'_id': 'ga4gh:VA.oq5H3D7ea1BLpVONa-UmLhDiKug7kOaU',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.209Z7zJ-mFypBEWLk4rNC6S_OxY5p7bs',
-                      'interval': {'type': 'SimpleInterval', 'start': 62540756, 'end': 62540761}},
-         'state': {'type': 'SequenceState', 'sequence': 'CT'}}]
-    ),
-    (
-        ('10', '106332351', 'CAT', ['C']),
-        [{'_id': 'ga4gh:VA.xti_mlNXAekytcegCcaqk9csAQ5f5pYw',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 106332351,
-                                   'end': 106332355}},
-         'state': {'type': 'SequenceState', 'sequence': 'AT'}}]
-    ),
-    (
-        ('17', '29204173', 'TACA', ['T']),
-        [{'_id': 'ga4gh:VA.mId9FgDqwHkP3mBt1lgfSr2-bhCJaxGg',
-         'type': 'Allele',
-         'location': {'type': 'SequenceLocation',
-                      'sequence_id': 'ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7',
-                      'interval': {'type': 'SimpleInterval',
-                                   'start': 29204173,
-                                   'end': 29204179}},
-         'state': {'type': 'SequenceState', 'sequence': 'ACA'}
-         }]
-    )
-)
+    (('4', '116619313', 'GT', ['G']), [{
+        '_id': 'ga4gh:VA.GVcxxtyjvhuuCtcdpcNAvVhRHWbzAhra',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 116619313,
+                'end': 116619314
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': ''
+        }
+    }]),
+    (('5', '81229982', 'TG', ['T']), [{
+        '_id': 'ga4gh:VA.UU86eospaxRFVjtkX0VHKBbcNenwDfU3',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 81229982,
+                'end': 81229983
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': ''
+        }
+    }]),
+    (('5', '81230677', 'AG', ['A']), [{
+        '_id': 'ga4gh:VA.xJctu09E74WfvRu-TvtjesE8S_spoKoB',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 81230677,
+                'end': 81230684
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'GGGGGG'
+        }
+    }]),
+    (('5', '81233450', 'TGGA', ['T']), [{
+        '_id': 'ga4gh:VA.JxnxekfJP329pXfBum6U8a5u0NSNFmnp',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 81233450,
+                'end': 81233457
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'GGAG'
+        }
+    }]),
+    (('5', '81233494', 'GCTGA', ['G']), [{
+        '_id': 'ga4gh:VA.-lNWDXnYR4hs2u6fFncH1ZOqILu4xZT8',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.aUiQCzCPZ2d0csHbMSbh2NzInhonSXwI',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 81233494,
+                'end': 81233501
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'CTG'
+        }
+    }]),
+    (('8', '62540756', 'TCTC', ['T']), [{
+        '_id': 'ga4gh:VA.oq5H3D7ea1BLpVONa-UmLhDiKug7kOaU',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.209Z7zJ-mFypBEWLk4rNC6S_OxY5p7bs',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 62540756,
+                'end': 62540761
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'CT'
+        }
+    }]),
+    (('10', '106332351', 'CAT', ['C']), [{
+        '_id': 'ga4gh:VA.xti_mlNXAekytcegCcaqk9csAQ5f5pYw',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 106332351,
+                'end': 106332355
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'AT'
+        }
+    }]),
+    (('17', '29204173', 'TACA', ['T']), [{
+        '_id': 'ga4gh:VA.mId9FgDqwHkP3mBt1lgfSr2-bhCJaxGg',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.dLZ15tNO1Ur0IcGjwc3Sdi_0A6Yf4zm7',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 29204173,
+                'end': 29204179
+            }
+        },
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'ACA'
+        }
+    }]))
 
 
 @pytest.mark.parametrize("record,expected", to_vcf_tests)
@@ -516,7 +747,10 @@ def vcf_from_file_expected():
                     'end': 14370
                 }
             },
-            'state': {'type': 'SequenceState', 'sequence': 'A'}
+            'state': {
+                'type': 'SequenceState',
+                'sequence': 'A'
+            }
         },
     ]
 
@@ -549,4 +783,4 @@ def test_to_vcf(tlr_norm, vcf_to_file):
     for i in range(len(vcf_to_file)):
         assert outfile_lines[i + 16] == format_as_vcf_row(expected[i])
 
-    # remove(outfile_path)
+    remove(outfile_path)

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -793,11 +793,11 @@ def test_to_vcf_file(tlr_norm, vcf_to_file):
 
     # build expected rows -- sort to match output rules
     def format_as_vcf_row(tup):
-        return f'{tup[0]}\t{tup[1]}\t.\t{tup[2]}\t{",".join(tup[3])}\t.\t.\tEND=0\n'
+        return f'{tup[0]}\t{tup[1]}\t.\t{tup[2]}\t{",".join(tup[3])}\t.\t.\t.\n'
     expected = [i[0] for i in vcf_to_file]
     expected.sort(key=lambda r: (int(r[0]), int(r[1])) if r[0] not in ('X', 'Y') else (ord(r[0]), int(r[1])))
 
     for i in range(len(vcf_to_file)):
-        assert outfile_lines[i + 16] == format_as_vcf_row(expected[i])
+        assert outfile_lines[i + 15] == format_as_vcf_row(expected[i])
 
     remove(outfile_path)

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -186,159 +186,175 @@ def test_hgvs(tlr, hgvsexpr, expected):
 #     with pytest.raises(ValueError):
 #         tlr._from_spdi("NM_182763.2:c.688+403C>T")
 
-# provide test inputs and expected outputs testing Translator._from_vcf_record
-to_vcf_tests = (
+# cases for testing to/from vcf records
+vcf_variation_cases = [
     # multiple alleles
-    (('1', '29881425', 'C', ['A', 'T']), [{
-        '_id': 'ga4gh:VA.32Q-JABVQ7pecrW2RPlYYLxBeP6j6ZN_',
-        'location': {
-            'interval': {
-                'end': 29881425,
-                'start': 29881424,
-                'type': 'SimpleInterval'
+    (('1', '29881425', 'C', ['A', 'T']), {
+        "type":
+        "VariationSet",
+        "members": [{
+            '_id': 'ga4gh:VA.32Q-JABVQ7pecrW2RPlYYLxBeP6j6ZN_',
+            'location': {
+                'interval': {
+                    'end': 29881425,
+                    'start': 29881424,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+                'type': 'SequenceLocation'
             },
-            'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'A',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }, {
-        '_id': 'ga4gh:VA.wUquYEB9ztjtsc9Xc4BnlpdQHOP4SvwN',
-        'location': {
-            'interval': {
-                'end': 29881425,
-                'start': 29881424,
-                'type': 'SimpleInterval'
+            'state': {
+                'sequence': 'A',
+                'type': 'SequenceState'
             },
-            'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'T',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }]),
-    (('4', '147973044', 'C', ['A', 'T']), [{
-        '_id': 'ga4gh:VA.I-Ol7SHx4gVYmvSDZ4tSrbKjQFQFnmAF',
-        'location': {
-            'interval': {
-                'end': 147973044,
-                'start': 147973043,
-                'type': 'SimpleInterval'
+            'type': 'Allele'
+        }, {
+            '_id': 'ga4gh:VA.wUquYEB9ztjtsc9Xc4BnlpdQHOP4SvwN',
+            'location': {
+                'interval': {
+                    'end': 29881425,
+                    'start': 29881424,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO',
+                'type': 'SequenceLocation'
             },
-            'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'A',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }, {
-        '_id': 'ga4gh:VA.SPrLYmcDQqlPOGYZWvE3AZ5skV9_EnXe',
-        'location': {
-            'interval': {
-                'end': 147973044,
-                'start': 147973043,
-                'type': 'SimpleInterval'
+            'state': {
+                'sequence': 'T',
+                'type': 'SequenceState'
             },
-            'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'T',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }]),
-    (('7', '142149548', 'G', ['GT', 'GTT']), [{
-        '_id': 'ga4gh:VA.y8-6HmQkyOLtgYCWozwfuSy8I8HbQocl',
-        'location': {
-            'interval': {
-                'end': 142149558,
-                'start': 142149548,
-                'type': 'SimpleInterval'
+            'type': 'Allele'
+        }]
+    }),
+    (('4', '147973044', 'C', ['A', 'T']), {
+        "type":
+        "VariationSet",
+        "members": [{
+            '_id': 'ga4gh:VA.I-Ol7SHx4gVYmvSDZ4tSrbKjQFQFnmAF',
+            'location': {
+                'interval': {
+                    'end': 147973044,
+                    'start': 147973043,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+                'type': 'SequenceLocation'
             },
-            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'TTTTTTTTTTT',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }, {
-        '_id': 'ga4gh:VA.z8z9fvWr1RHnOa_LjIr22rDnmXU7WkjZ',
-        'location': {
-            'interval': {
-                'end': 142149558,
-                'start': 142149548,
-                'type': 'SimpleInterval'
+            'state': {
+                'sequence': 'A',
+                'type': 'SequenceState'
             },
-            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'TTTTTTTTTTTT',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }]),
-    (('12', '49520727', 'A', ['AT', 'ATT', 'ATTT']), [{
-        '_id': 'ga4gh:VA.y7R6DdlWtMVpe9H_1cKtuMS2egyf4inX',
-        'location': {
-            'interval': {
-                'end': 49520742,
-                'start': 49520727,
-                'type': 'SimpleInterval'
+            'type': 'Allele'
+        }, {
+            '_id': 'ga4gh:VA.SPrLYmcDQqlPOGYZWvE3AZ5skV9_EnXe',
+            'location': {
+                'interval': {
+                    'end': 147973044,
+                    'start': 147973043,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.HxuclGHh0XCDuF8x6yQrpHUBL7ZntAHc',
+                'type': 'SequenceLocation'
             },
-            'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'TTTTTTTTTTTTTTTT',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }, {
-        '_id': 'ga4gh:VA.uZ_O9g5pteehH2E_gmjv4WkKK3lk4QOd',
-        'location': {
-            'interval': {
-                'end': 49520742,
-                'start': 49520727,
-                'type': 'SimpleInterval'
+            'state': {
+                'sequence': 'T',
+                'type': 'SequenceState'
             },
-            'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'TTTTTTTTTTTTTTTTT',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }, {
-        '_id': 'ga4gh:VA.kNYqY6TpWQ2EM400mW6fZrwRL1HZmz9S',
-        'location': {
-            'interval': {
-                'end': 49520742,
-                'start': 49520727,
-                'type': 'SimpleInterval'
+            'type': 'Allele'
+        }]
+    }),
+    (('7', '142149548', 'G', ['GT', 'GTT']), {
+        "type":
+        "VariationSet",
+        "members": [{
+            '_id': 'ga4gh:VA.y8-6HmQkyOLtgYCWozwfuSy8I8HbQocl',
+            'location': {
+                'interval': {
+                    'end': 142149558,
+                    'start': 142149548,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+                'type': 'SequenceLocation'
             },
-            'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
-            'type': 'SequenceLocation'
-        },
-        'state': {
-            'sequence': 'TTTTTTTTTTTTTTTTTT',
-            'type': 'SequenceState'
-        },
-        'type': 'Allele'
-    }]),
+            'state': {
+                'sequence': 'TTTTTTTTTTT',
+                'type': 'SequenceState'
+            },
+            'type': 'Allele'
+        }, {
+            '_id': 'ga4gh:VA.z8z9fvWr1RHnOa_LjIr22rDnmXU7WkjZ',
+            'location': {
+                'interval': {
+                    'end': 142149558,
+                    'start': 142149548,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+                'type': 'SequenceLocation'
+            },
+            'state': {
+                'sequence': 'TTTTTTTTTTTT',
+                'type': 'SequenceState'
+            },
+            'type': 'Allele'
+        }]
+    }),
+    (('12', '49520727', 'A', ['AT', 'ATT', 'ATTT']), {
+        "type":
+        "VariationSet",
+        "members": [{
+            '_id': 'ga4gh:VA.y7R6DdlWtMVpe9H_1cKtuMS2egyf4inX',
+            'location': {
+                'interval': {
+                    'end': 49520742,
+                    'start': 49520727,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+                'type': 'SequenceLocation'
+            },
+            'state': {
+                'sequence': 'TTTTTTTTTTTTTTTT',
+                'type': 'SequenceState'
+            },
+            'type': 'Allele'
+        }, {
+            '_id': 'ga4gh:VA.uZ_O9g5pteehH2E_gmjv4WkKK3lk4QOd',
+            'location': {
+                'interval': {
+                    'end': 49520742,
+                    'start': 49520727,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+                'type': 'SequenceLocation'
+            },
+            'state': {
+                'sequence': 'TTTTTTTTTTTTTTTTT',
+                'type': 'SequenceState'
+            },
+            'type': 'Allele'
+        }, {
+            '_id': 'ga4gh:VA.kNYqY6TpWQ2EM400mW6fZrwRL1HZmz9S',
+            'location': {
+                'interval': {
+                    'end': 49520742,
+                    'start': 49520727,
+                    'type': 'SimpleInterval'
+                },
+                'sequence_id': 'ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl',
+                'type': 'SequenceLocation'
+            },
+            'state': {
+                'sequence': 'TTTTTTTTTTTTTTTTTT',
+                'type': 'SequenceState'
+            },
+            'type': 'Allele'
+        }]
+    }),
     # SNPs
-    (('1', '92633', 'C', ['T']), [{
+    (('1', '92633', 'C', ['T']), {
         '_id': 'ga4gh:VA.qAK6JCN3-AVa9_6Qq3AqAuppUU0bWgfH',
         'type': 'Allele',
         'location': {
@@ -354,8 +370,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'T'
         }
-    }]),
-    (('1', '63002', 'A', ['G']), [{
+    }),
+    (('1', '63002', 'A', ['G']), {
         '_id': 'ga4gh:VA.VewFnlxS7DmjEdKMkj0xZK-9GaHGMJcx',
         'type': 'Allele',
         'location': {
@@ -371,8 +387,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'G'
         }
-    }]),
-    (('3', '166125806', 'G', ['A']), [{
+    }),
+    (('3', '166125806', 'G', ['A']), {
         '_id': 'ga4gh:VA.UAcSqA7iJtI36BysCOYXR8wPGVwUm4En',
         'type': 'Allele',
         'location': {
@@ -388,8 +404,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'A'
         }
-    }]),
-    (('5', '1100700', 'G', ['A']), [{
+    }),
+    (('5', '1100700', 'G', ['A']), {
         '_id': 'ga4gh:VA.UrXpOOJGuCHAQgQ2sY85FsZ3CztIwI6C',
         'type': 'Allele',
         'location': {
@@ -405,8 +421,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'A'
         }
-    }]),
-    (('7', '108934752', 'T', ['C']), [{
+    }),
+    (('7', '108934752', 'T', ['C']), {
         '_id': 'ga4gh:VA.pwoWgFDuLdigDfQRTEU7gCdSB4DoHED1',
         'type': 'Allele',
         'location': {
@@ -422,8 +438,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'C'
         }
-    }]),
-    (('13', '59140800', 'G', ['A']), [{
+    }),
+    (('13', '59140800', 'G', ['A']), {
         '_id': 'ga4gh:VA.Ii5EzfJNVealFy9Wc7UMjd4WrzqSpbmg',
         'type': 'Allele',
         'location': {
@@ -439,8 +455,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'A'
         }
-    }]),
-    (('X', '127226377', 'A', ['G']), [{
+    }),
+    (('X', '127226377', 'A', ['G']), {
         '_id': 'ga4gh:VA.nyaA37BGIVLcP6LPfpT1GKg-nfLhxPOD',
         'type': 'Allele',
         'location': {
@@ -456,9 +472,9 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'G'
         }
-    }]),
+    }),
     # ins
-    (('1', '72297', 'G', ['GTAT']), [{
+    (('1', '72297', 'G', ['GTAT']), {
         '_id': 'ga4gh:VA.wbhpDCQ0MRtG0pZZWH-yarqSdOjGNJEL',
         'type': 'Allele',
         'location': {
@@ -474,8 +490,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'TATTATT'
         }
-    }]),
-    (('3', '166114496', 'T', ['TA']), [{
+    }),
+    (('3', '166114496', 'T', ['TA']), {
         '_id': 'ga4gh:VA.LVqeAmYsZxO3kYb-lvmYOrqnoY1NbKWd',
         'type': 'Allele',
         'location': {
@@ -491,8 +507,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'A'
         }
-    }]),
-    (('5', '127031196', 'C', ['CG']), [{
+    }),
+    (('5', '127031196', 'C', ['CG']), {
         '_id': 'ga4gh:VA.4lIsTJ1zxjQ7UjXTSnCLb-HF2jw733NK',
         'type': 'Allele',
         'location': {
@@ -508,8 +524,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'GGGGGG'
         }
-    }]),
-    (('7', '156408692', 'C', ['CAT']), [{
+    }),
+    (('7', '156408692', 'C', ['CAT']), {
         '_id': 'ga4gh:VA.uvVtM0pr6hFMLfKTurDcdFj_3rRHbBqp',
         'type': 'Allele',
         'location': {
@@ -525,8 +541,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'ATATATATATATA'
         }
-    }]),
-    (('10', '106329140', 'C', ['CATTT']), [{
+    }),
+    (('10', '106329140', 'C', ['CATTT']), {
         '_id': 'ga4gh:VA.7tZ-MNUx-ZXdOElypDtzWJ1jL5JbMYgE',
         'type': 'Allele',
         'location': {
@@ -542,8 +558,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'ATTTATT'
         }
-    }]),
-    (('Y', '22304601', 'G', ['GA']), [{
+    }),
+    (('Y', '22304601', 'G', ['GA']), {
         '_id': 'ga4gh:VA.TDba99qQKLMUiooxOgIX_EEFDgyNPBAq',
         'type': 'Allele',
         'location': {
@@ -559,9 +575,9 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'AAAAAAA'
         }
-    }]),
+    }),
     # del
-    (('4', '116619313', 'GT', ['G']), [{
+    (('4', '116619313', 'GT', ['G']), {
         '_id': 'ga4gh:VA.GVcxxtyjvhuuCtcdpcNAvVhRHWbzAhra',
         'type': 'Allele',
         'location': {
@@ -577,8 +593,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': ''
         }
-    }]),
-    (('5', '81229982', 'TG', ['T']), [{
+    }),
+    (('5', '81229982', 'TG', ['T']), {
         '_id': 'ga4gh:VA.UU86eospaxRFVjtkX0VHKBbcNenwDfU3',
         'type': 'Allele',
         'location': {
@@ -594,8 +610,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': ''
         }
-    }]),
-    (('5', '81230677', 'AG', ['A']), [{
+    }),
+    (('5', '81230677', 'AG', ['A']), {
         '_id': 'ga4gh:VA.xJctu09E74WfvRu-TvtjesE8S_spoKoB',
         'type': 'Allele',
         'location': {
@@ -611,8 +627,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'GGGGGG'
         }
-    }]),
-    (('5', '81233450', 'TGGA', ['T']), [{
+    }),
+    (('5', '81233450', 'TGGA', ['T']), {
         '_id': 'ga4gh:VA.JxnxekfJP329pXfBum6U8a5u0NSNFmnp',
         'type': 'Allele',
         'location': {
@@ -628,8 +644,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'GGAG'
         }
-    }]),
-    (('5', '81233494', 'GCTGA', ['G']), [{
+    }),
+    (('5', '81233494', 'GCTGA', ['G']), {
         '_id': 'ga4gh:VA.-lNWDXnYR4hs2u6fFncH1ZOqILu4xZT8',
         'type': 'Allele',
         'location': {
@@ -645,8 +661,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'CTG'
         }
-    }]),
-    (('8', '62540756', 'TCTC', ['T']), [{
+    }),
+    (('8', '62540756', 'TCTC', ['T']), {
         '_id': 'ga4gh:VA.oq5H3D7ea1BLpVONa-UmLhDiKug7kOaU',
         'type': 'Allele',
         'location': {
@@ -662,8 +678,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'CT'
         }
-    }]),
-    (('10', '106332351', 'CAT', ['C']), [{
+    }),
+    (('10', '106332351', 'CAT', ['C']), {
         '_id': 'ga4gh:VA.xti_mlNXAekytcegCcaqk9csAQ5f5pYw',
         'type': 'Allele',
         'location': {
@@ -679,8 +695,8 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'AT'
         }
-    }]),
-    (('17', '29204173', 'TACA', ['T']), [{
+    }),
+    (('17', '29204173', 'TACA', ['T']), {
         '_id': 'ga4gh:VA.mId9FgDqwHkP3mBt1lgfSr2-bhCJaxGg',
         'type': 'Allele',
         'location': {
@@ -696,16 +712,15 @@ to_vcf_tests = (
             'type': 'SequenceState',
             'sequence': 'ACA'
         }
-    }]))
+    })
+]
 
 
-@pytest.mark.parametrize("record,expected", to_vcf_tests)
+@pytest.mark.parametrize("record,expected", vcf_variation_cases)
 def test_from_vcf_record(tlr_norm, record, expected):
     """Test Translator._from_vcf_record"""
-    tlr_norm.normalize = True
-    alleles = tlr_norm._from_vcf_record(record[0], record[1], record[2], record[3], assembly_name='GRCh38')
-    for allele, allele_expected in zip(alleles, expected):
-        assert allele.as_dict() == allele_expected
+    variation_from_vcf = tlr_norm._from_vcf_record(record[0], record[1], record[2], record[3], assembly_name='GRCh38')
+    assert variation_from_vcf.as_dict() == expected
 
 
 @pytest.fixture(scope="session")
@@ -734,25 +749,23 @@ def vcf_file_in():
 @pytest.fixture(scope="session")
 def vcf_from_file_expected():
     """Provide expected output to test Translator._from_vcf"""
-    return [
-        {
-            '_id': 'ga4gh:VA.m8e1aRLy--eKkjzCJWz5w7fZEBmOhbXZ',
-            'type': 'Allele',
-            'location': {
-                'type': 'SequenceLocation',
-                'sequence_id': 'ga4gh:SQ.-A1QmD_MatoqxvgVxBLZTONHz9-c7nQo',
-                'interval': {
-                    'type': 'SimpleInterval',
-                    'start': 14369,
-                    'end': 14370
-                }
-            },
-            'state': {
-                'type': 'SequenceState',
-                'sequence': 'A'
+    return {
+        '_id': 'ga4gh:VA.m8e1aRLy--eKkjzCJWz5w7fZEBmOhbXZ',
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation',
+            'sequence_id': 'ga4gh:SQ.-A1QmD_MatoqxvgVxBLZTONHz9-c7nQo',
+            'interval': {
+                'type': 'SimpleInterval',
+                'start': 14369,
+                'end': 14370
             }
         },
-    ]
+        'state': {
+            'type': 'SequenceState',
+            'sequence': 'A'
+        }
+    },
 
 
 def test_from_vcf_file(tlr_norm, vcf_file_in, vcf_from_file_expected):
@@ -764,11 +777,13 @@ def test_from_vcf_file(tlr_norm, vcf_file_in, vcf_from_file_expected):
 
 @pytest.fixture(scope="session")
 def vcf_to_file():
-    return to_vcf_tests
+    return vcf_variation_cases
 
 
-def test_to_vcf(tlr_norm, vcf_to_file):
-    alleles = [tlr_norm._from_vrs(i) for j in vcf_to_file for i in j[1]]
+def test_to_vcf_file(tlr_norm, vcf_to_file):
+    """Test Translator._to_vcf"""
+    # alleles = [tlr_norm._from_vrs(i) for j in vcf_to_file for i in j[1]]
+    alleles = [tlr_norm._from_vrs(i[1]) for i in vcf_to_file]
     outfile_path = "test_out.vcf"
     tlr_norm._to_vcf(alleles, outfile_path)
 
@@ -776,7 +791,7 @@ def test_to_vcf(tlr_norm, vcf_to_file):
     with open(outfile_path) as f:
         outfile_lines = list(f.readlines())
 
-    # build expected rows
+    # build expected rows -- sort to match output rules
     def format_as_vcf_row(tup):
         return f'{tup[0]}\t{tup[1]}\t.\t{tup[2]}\t{",".join(tup[3])}\t.\t.\tEND=0\n'
     expected = [i[0] for i in vcf_to_file]


### PR DESCRIPTION
This PR extends the Translation class to provide basic support for importing and exporting between VRS and VCF data. Happy for feedback on anything/everything, but it'd be helpful to hear about these items in particular:
* [Test cases](https://github.com/GenomicMedLab/vrs-python/blob/566ee01e2dd4c7e4945190cb870edca5b90f5b07/tests/extras/test_translator.py#L191): I added an excessive amount to compensate for my lack of confidence about correctly reversing the normalization algorithm. Let me know if anything looks wrong or if there appear to be holes (or if this is too many cases).
* I think the normalized Translator fixture breaks TravisCI - is something I can do (eg check for an env var) to prevent those tests from running in CI?
* Frankly, I don't quite understand the particulars of how the VRS repo works as a submodule here, but there's a diff listed below, so hopefully I didn't do something wrong there

I ran everything through the YAPF config in root before committing, which is why there are a bunch of cosmetic alterations