### PR TITLE
Fix bug in _from_hgvs when using SeqRepoDataProxy

### DIFF
--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -206,7 +206,7 @@ class Translator:
             interval = models.SimpleInterval(start=sv.posedit.pos.start.base - 1,
                                        end=sv.posedit.pos.end.base)
             if sv.posedit.edit.type == 'identity':
-                state = self.data_proxy.get_sequence(sv.ac,
+                state = self.data_proxy.get_sequence(sequence_id,
                                                      sv.posedit.pos.start.base - 1,
                                                      sv.posedit.pos.end.base)
             else:
@@ -216,7 +216,7 @@ class Translator:
             interval = models.SimpleInterval(start=sv.posedit.pos.start.base - 1,
                                              end=sv.posedit.pos.end.base)
 
-            ref = self.data_proxy.get_sequence(sv.ac,
+            ref = self.data_proxy.get_sequence(sequence_id,
                                                sv.posedit.pos.start.base - 1,
                                                sv.posedit.pos.end.base)
             state = ref + ref

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,31 @@ import os
 import pytest
 
 from ga4gh.vrs.extras.translator import Translator
-from ga4gh.vrs.dataproxy import SeqRepoRESTDataProxy
+from biocommons.seqrepo import SeqRepo
+from ga4gh.vrs.dataproxy import SeqRepoRESTDataProxy, SeqRepoDataProxy
+
+
+@pytest.fixture(scope="session")
+def rest_dataproxy():
+    return SeqRepoRESTDataProxy(base_url="http://localhost:5000/seqrepo")
 
 
 @pytest.fixture(scope="session")
 def dataproxy():
-    return SeqRepoRESTDataProxy(base_url="http://localhost:5000/seqrepo")
+    sr = SeqRepo(root_dir="/usr/local/share/seqrepo/latest")
+    return SeqRepoDataProxy(sr)
+
+
+@pytest.fixture(scope="session")
+def rest_tlr(rest_dataproxy):
+    return Translator(
+        data_proxy=rest_dataproxy,
+        default_assembly_name="GRCh38",
+        # TODO: Set these to defaults and adjust relevant tests
+        identify=False,
+        normalize=False,
+        translate_sequence_identifiers=True,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/extras/test_dataproxy.py
+++ b/tests/extras/test_dataproxy.py
@@ -1,8 +1,10 @@
 import pytest
 
 
+@pytest.mark.parametrize("dp", ("rest_dataproxy","dataproxy"))
 @pytest.mark.vcr
-def test_dataproxy_rest(dataproxy):
+def tset_dataproxy(dp, request):
+    dataproxy = request.getfixturevalue(dp)
     r = dataproxy.get_metadata("NM_000551.3")
     assert 4560 == r["length"]
     assert "ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_" in r["aliases"]

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -99,11 +99,11 @@ hgvs_tests = (
 )
 
 
-@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
+@pytest.mark.parametrize("tlr_fixture_name", ("rest_tlr","tlr"))
 @pytest.mark.parametrize("hgvsexpr,expected", hgvs_tests)
 @pytest.mark.vcr
-def test_hgvs_rest_dp(translator, hgvsexpr, expected, request):
-    tlr = request.getfixturevalue(translator)
+def test_hgvs_rest_dp(tlr_fixture_name, hgvsexpr, expected, request):
+    tlr = request.getfixturevalue(tlr_fixture_name)
     tlr.normalize = True
     allele = tlr.translate_from(hgvsexpr, "hgvs")
     assert expected == allele.as_dict()

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -17,23 +17,31 @@ output = {
 }
 
 
+@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
 @pytest.mark.vcr
-def test_from_beacon(tlr):
+def test_from_beacon(translator, request):
+    tlr = request.getfixturevalue(translator)
     assert tlr._from_beacon(inputs["beacon"]).as_dict() == output
 
 
+@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
 @pytest.mark.vcr
-def test_from_gnomad(tlr):
+def test_from_gnomad(translator, request):
+    tlr = request.getfixturevalue(translator)
     assert tlr._from_gnomad(inputs["gnomad"]).as_dict() == output
 
 
+@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
 @pytest.mark.vcr
-def test_from_hgvs(tlr):
+def test_from_hgvs(translator, request):
+    tlr = request.getfixturevalue(translator)
     assert tlr._from_hgvs(inputs["hgvs"]).as_dict() == output
 
 
+@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
 @pytest.mark.vcr
-def test_from_spdi(tlr):
+def test_from_spdi(translator, request):
+    tlr = request.getfixturevalue(translator)
     assert tlr._from_spdi(inputs["spdi"]).as_dict() == output
 
 
@@ -91,9 +99,11 @@ hgvs_tests = (
 )
 
 
+@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
 @pytest.mark.parametrize("hgvsexpr,expected", hgvs_tests)
 @pytest.mark.vcr
-def test_hgvs(tlr, hgvsexpr, expected):
+def test_hgvs_rest_dp(translator, hgvsexpr, expected, request):
+    tlr = request.getfixturevalue(translator)
     tlr.normalize = True
     allele = tlr.translate_from(hgvsexpr, "hgvs")
     assert expected == allele.as_dict()

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -17,31 +17,31 @@ output = {
 }
 
 
-@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
+@pytest.mark.parametrize("tlr_fixture_name", ("rest_tlr","tlr"))
 @pytest.mark.vcr
-def test_from_beacon(translator, request):
-    tlr = request.getfixturevalue(translator)
+def test_from_beacon(tlr_fixture_name, request):
+    tlr = request.getfixturevalue(tlr_fixture_name)
     assert tlr._from_beacon(inputs["beacon"]).as_dict() == output
 
 
-@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
+@pytest.mark.parametrize("tlr_fixture_name", ("rest_tlr","tlr"))
 @pytest.mark.vcr
-def test_from_gnomad(translator, request):
-    tlr = request.getfixturevalue(translator)
+def test_from_gnomad(tlr_fixture_name, request):
+    tlr = request.getfixturevalue(tlr_fixture_name)
     assert tlr._from_gnomad(inputs["gnomad"]).as_dict() == output
 
 
-@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
+@pytest.mark.parametrize("tlr_fixture_name", ("rest_tlr","tlr"))
 @pytest.mark.vcr
-def test_from_hgvs(translator, request):
-    tlr = request.getfixturevalue(translator)
+def test_from_hgvs(tlr_fixture_name, request):
+    tlr = request.getfixturevalue(tlr_fixture_name)
     assert tlr._from_hgvs(inputs["hgvs"]).as_dict() == output
 
 
-@pytest.mark.parametrize("translator", ("rest_tlr","tlr"))
+@pytest.mark.parametrize("tlr_fixture_name", ("rest_tlr","tlr"))
 @pytest.mark.vcr
-def test_from_spdi(translator, request):
-    tlr = request.getfixturevalue(translator)
+def test_from_spdi(tlr_fixture_name, request):
+    tlr = request.getfixturevalue(tlr_fixture_name)
     assert tlr._from_spdi(inputs["spdi"]).as_dict() == output
 
 

--- a/tests/test_vcr.py
+++ b/tests/test_vcr.py
@@ -1,7 +1,15 @@
 import pytest
 
+vcr_test = (
+    ("rest_dataproxy", "NC_000013.11"),
+    ("dataproxy", "refseq:NC_000013.11")
+)
+
+
+@pytest.mark.parametrize("dp,identifier", vcr_test)
 @pytest.mark.vcr
-def test_vcrtest(dataproxy):
-    seq = dataproxy.get_sequence("NC_000013.11",50_000_000,50_000_050)
+def test_vcrtest(dp, identifier, request):
+    dp = request.getfixturevalue(dp)
+    seq = dp.get_sequence(identifier, 50_000_000, 50_000_050)
     assert len(seq) == 50
     assert seq == "TTAGGTGTTTAGATGATTTCTAAGATGCTTTTAAGCCCAGTATTTCTATT"


### PR DESCRIPTION
`_from_hgvs` works when using SeqRepoRestDataProxy, but failed when using SeqRepoDataProxy for identity and dup HGVS expressions. This failed because `fetch_uri` expects a namespace and accession (ex: refseq:NM_12345) and `sv.ac` would only provide an accession (ex: NM_12345), so switched to using `sequence_id` as the identifier. 

> def fetch_uri(self, uri, start=None, end=None):
        """fetch sequence for URI/CURIE of the form namespace:alias, such as
        NCBI:NM_000059.3.
>   
>        """
>    
>       namespace, alias = uri_re.match(uri).groups()
>       AttributeError: 'NoneType' object has no attribute 'groups'

Added tests for both SeqRepoRestDataProxy and SeqRepoDataProxy. 