### PR TITLE
Update SEQREPO_ROOT_DIR in Makefile to fix failing test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PKGD=$(subst .,/,${PKG})
 PYV:=3.9
 VEDIR=venv/${PYV}
 
-export SEQREPO_ROOT_DIR=tests/data/seqrepo
+export SEQREPO_ROOT_DIR=tests/data/seqrepo/latest
 
 
 ############################################################################
@@ -133,13 +133,13 @@ cleanest: cleaner
 
 ## <LICENSE>
 ## Copyright 2016 Source Code Committers
-## 
+##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
 ## You may obtain a copy of the License at
-## 
+##
 ##     http://www.apache.org/licenses/LICENSE-2.0
-## 
+##
 ## Unless required by applicable law or agreed to in writing, software
 ## distributed under the License is distributed on an "AS IS" BASIS,
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
This was commented in #74 . Unsure if we wanted to make this change there or in a new PR. Since no change has been made, I decided just to create a new PR. I know @ahwagner is going to make a new release soon for our team's needs, so it would also be nice to ensure all tests pass before doing so. 