### PR TITLE
Add release workflow action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Upload tagged commit to PyPI
+on:
+  push:
+    tags:
+    - '**'
+jobs:
+  get_branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.get_branch_name.outputs.name }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Get branch name
+      id: get_branch_name
+      run: |
+        raw=$(git branch -r --contains ${{ github.ref }})
+        branch=${raw##*/}
+        echo "::set-output name=name::$branch"
+  release:
+    runs-on: ubuntu-18.04
+    needs: get_branch
+    if: needs.get_branch.outputs.branch_name == 'main'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build
+      run: python3 setup.py sdist bdist_wheel
+    - name: PyPI test
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: PyPI publish
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Upload tagged commit to PyPI
 on:
   push:
     tags:
-    - '**'
+    - '*.*.**'
 jobs:
   get_branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Creates PyPI releases from tags added to commits on the main branch.

* GitHub syntax filters are a little more constrained than normal regex so it's difficult to enforce the [entire PEP440 versioning syntax](https://stackoverflow.com/a/38020327) -- the provided filter just does a pretty lax check for tags that look like semantic versioning
* Someone (@ahwagner) will need to supply PyPI API tokens as GitHub secrets named PYPI_API_TOKEN and TEST_PYPI_API_TOKEN