### PR TITLE
fix: support SequenceState, SimpleInterval p.2 - for 0.7

### DIFF
--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -2,9 +2,9 @@ name: Python CQA
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 0.7 ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 0.7 ]
 
 
 # TODO: separate lint and test jobs; lint first, test "needs" lint

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -371,8 +371,7 @@ class Translator:
             # ival = hgvs.location.Interval(start=start, end=end)
             # edit = hgvs.edit.AARefAlt(ref=None, alt=vo.state.sequence)
         else:                   # pylint: disable=no-else-raise
-            start = vo.location.interval.start.value
-            end = vo.location.interval.end.value
+            start, end = vo.location.interval.start.value, vo.location.interval.end.value
             # ib: 0 1 2 3 4 5
             #  h:  1 2 3 4 5
             if start == end:    # insert: hgvs uses *exclusive coords*
@@ -447,8 +446,7 @@ class Translator:
         aliases = self.data_proxy.translate_sequence_identifier(sequence_id, namespace)
         aliases = [a.split(":")[1] for a in aliases]
 
-        start = vo.location.interval.start.value
-        end = vo.location.interval.end.value
+        start, end = vo.location.interval.start.value, vo.location.interval.end.value
         spdi_tail = f":{start}:{end-start}:{vo.state.sequence}"
         spdis = [a + spdi_tail for a in aliases]
         return spdis

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -83,8 +83,26 @@ class Translator:
     def translate_to(self, vo, fmt):
         """translate vrs object `vo` to named format `fmt`"""
         t = self.to_translators[fmt]
-        return t(self, vo)
+        return t(self, self.ensure_allele_is_latest_model(vo))
 
+    def ensure_allele_is_latest_model(self, allele):
+        """
+        Change deprecated models:
+        SequenceState -> LiteralSequenceExpression
+        SimpleInterval -> SequenceInterval
+        """
+        if allele.state.type == "SequenceState":
+            allele.state = models.LiteralSequenceExpression(
+                type="LiteralSequenceExpression",
+                sequence=allele.state.sequence,
+            )
+        if allele.location.interval.type == "SimpleInterval":
+            allele.location.interval = models.SequenceInterval(
+                type="SequenceInterval",
+                start=models.Number(value=allele.location.interval.start, type="Number"),
+                end=models.Number(value=allele.location.interval.end, type="Number"),
+            )
+        return allele
 
     ############################################################################
     ## INTERNAL

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -142,8 +142,8 @@ class Translator:
         interval = models.SequenceInterval(start=models.Number(value=start),
                                            end=models.Number(value=end))
         location = models.Location(sequence_id=sequence_id, interval=interval)
-        sstate = models.LiteralSequenceExpression(sequence=ins_seq)
-        allele = models.Allele(location=location, state=sstate)
+        state = models.LiteralSequenceExpression(sequence=ins_seq)
+        allele = models.Allele(location=location, state=state)
         allele = self._post_process_imported_allele(allele)
         return allele
 
@@ -352,9 +352,7 @@ class Translator:
                 return "g"
             return None
 
-        if (type(vo).__name__ != "Allele"
-            or type(vo.location).__name__ != "SequenceLocation"
-            or type(vo.state).__name__ != "LiteralSequenceExpression"):
+        if self.is_valid_allele(vo):
             raise ValueError(f"_to_hgvs requires a VRS Allele with SequenceLocation and LiteralSequenceExpression")
 
         sequence_id = str(vo.location.sequence_id)
@@ -442,10 +440,8 @@ class Translator:
 
         """
 
-        if (type(vo).__name__ != "Allele"
-            or type(vo.location).__name__ != "SequenceLocation"
-            or type(vo.state).__name__ != "LiteralSequenceExpression"):
-            raise ValueError(f"_to_hgvs requires a VRS Allele with SequenceLocation and LiteralSequenceExpression")
+        if self.is_valid_allele(vo):
+            raise ValueError(f"_to_spdi requires a VRS Allele with SequenceLocation and LiteralSequenceExpression")
 
         sequence_id = str(vo.location.sequence_id)
         aliases = self.data_proxy.translate_sequence_identifier(sequence_id, namespace)
@@ -457,6 +453,10 @@ class Translator:
         spdis = [a + spdi_tail for a in aliases]
         return spdis
 
+    def is_valid_allele(self, vo):
+        return (type(vo).__name__ != "Allele"
+                or type(vo.location).__name__ != "SequenceLocation"
+                or type(vo.state).__name__ != "LiteralSequenceExpression")
 
     @lazy_property
     def _hgvs_parser(self):

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -1,5 +1,7 @@
 import pytest
 
+from ga4gh.vrs import models
+
 inputs = {
     "hgvs": "NC_000013.11:g.32936732G>C",
     "beacon": "13 : 32936732 G > C",
@@ -197,6 +199,37 @@ def test_hgvs(tlr, hgvsexpr, expected):
     assert 1 == len(to_hgvs)
     assert hgvsexpr == to_hgvs[0]
 
+
+def test_ensure_allele_is_latest_model(tlr):
+    allele_deprecated_dict = {
+        'location': {
+            'interval': {
+                'end': 55181320,
+                'start': 55181319,
+                'type': 'SimpleInterval'
+            },
+            'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'type': 'SequenceLocation'
+        },
+        'state': {
+            'sequence': 'T',
+            'type': 'SequenceState'
+        },
+        'type': 'Allele'
+    }
+    allele_deprecated = models.Allele(**allele_deprecated_dict)
+    assert tlr.ensure_allele_is_latest_model(allele_deprecated).as_dict() == {
+        'type': 'Allele',
+        'location': {
+            'type': 'SequenceLocation', 'sequence_id': 'ga4gh:SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
+            'interval': {
+                'type': 'SequenceInterval',
+                'start': {'type': 'Number', 'value': 55181319},
+                'end': {'type': 'Number', 'value': 55181320}
+            }
+        },
+        'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}
+    }
 
 # TODO: Readd these tests
 # @pytest.mark.vcr


### PR DESCRIPTION
fix: support SequenceState with LiteralSequenceExpression and SimpleInterval with SequenceInterval

This PR is 0.7->0.7

There was the same PR for main : https://github.com/ga4gh/vrs-python/pull/86
