### PR TITLE
feat: VCFAnnotator accepts both seqrepo dps + clean up

### DIFF
--- a/docs/extras/README.md
+++ b/docs/extras/README.md
@@ -1,0 +1,3 @@
+# Extras READMEs
+
+This directory contains READMEs for tools in the `extras` directory

--- a/docs/extras/vcf_annotator.md
+++ b/docs/extras/vcf_annotator.md
@@ -1,0 +1,54 @@
+# VCF Annotator
+
+The [VCF Annotator tool](../../src/ga4gh/vrs/extras/vcf_annotation.py) provides utility for annotating VCF's with VRS Allele IDs.
+
+## How to use
+
+*Note:\
+The examples run from the root of the vrs-python directory and assumes that `input.vcf.gz` lives in the current directory*
+
+To see the help page:
+
+```commandline
+python3 -m src.ga4gh.vrs.extras.vcf_annotation --help
+```
+
+### Use local SeqRepo Data Proxy with default root directory
+
+The tool uses a SeqRepo data proxy. By default, the local instance at `/usr/local/share/seqrepo/latest` is used.
+
+Example of how to run:
+
+```commandline
+python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_file vrs_objects.pkl
+```
+
+`--vcf_in` specifies the path of the input VCF file to annotate. `--vcf_out` specifies the path of the output annotated VCF file. The `--vrs_file` specifies the path of the output pickle file containing VRS data.
+
+### Use local SeqRepo Data Proxy with different
+
+You can change the root directory of SeqRepo by using `seqrepo_root_dir`.
+
+To use the local SeqRepo data proxy with SeqRepo root directory at `vrs-python/seqrepo/latest`:
+
+```commandline
+python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_file vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
+```
+
+### Use the REST SeqRepo Data Proxy with default base url
+
+You can change the data proxy type by using: `--seqrepo_dp_type` (options are `local` or `rest`).
+
+To use the REST SeqRepo data proxy at default url: `http://localhost:5000/seqrepo`:
+
+```commandline
+python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_file vrs_objects.pkl --seqrepo_dp_type rest
+```
+
+### Use the REST SeqRepo Data Proxy with different base url
+You can change the SeqRepo REST base url by using: `--seqrepo_base_url`.
+
+To use the REST SeqRepo data proxy, at custom url: `http://custom.url:5000/seqrepo`:
+```commandline
+python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_file vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
+```

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,6 +101,7 @@ extras =
     bioutils>=0.5.2
     hgvs>=1.4
     requests
+    click
 notebooks =
     ipython
     jupyter

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -1,4 +1,9 @@
-"""Module containing tools for annotating VCFs with VRS"""
+"""Module containing tools for annotating VCFs with VRS
+
+Example of how to run from root of vrs-python directory:
+python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz \
+    --vcf_out output.vcf.gz --vrs_file vrs_objects.pkl
+"""
 import pickle
 from enum import Enum
 from typing import Dict, List, Optional
@@ -44,24 +49,33 @@ class SeqRepoProxyType(str, Enum):
     default=SeqRepoProxyType.LOCAL,
     type=click.Choice([v.value for v in SeqRepoProxyType.__members__.values()],
                       case_sensitive=True),
-    help="The type of the SeqRepo Data Proxy to use"
+    help="The type of the SeqRepo Data Proxy to use",
+    show_default=True,
+    show_choices=True
 )
 @click.option(
     "--seqrepo_root_dir",
     required=False,
     default="/usr/local/share/seqrepo/latest",
-    help="The root directory for local SeqRepo instance"
+    help="The root directory for local SeqRepo instance",
+    show_default=True
 )
 @click.option(
     "--seqrepo_base_url",
     required=False,
     default="http://localhost:5000/seqrepo",
-    help="The base url for SeqRepo REST API"
+    help="The base url for SeqRepo REST API",
+    show_default=True
 )
 def annotate_click(vcf_in: str, vcf_out: str, vrs_file: str,
                    seqrepo_dp_type: SeqRepoProxyType, seqrepo_root_dir: str,
                    seqrepo_base_url: str) -> None:
-    """Annotate VCF file via click"""
+    """Annotate VCF file via click
+
+    Example arguments:
+
+    --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_file vrs_objects.pkl
+    """
     annotator = VCFAnnotator(seqrepo_dp_type, seqrepo_base_url, seqrepo_root_dir)
     start = timer()
     annotator.annotate(vcf_in, vcf_out, vrs_file)
@@ -164,5 +178,5 @@ class VCFAnnotator:
 
 if __name__ == "__main__":
     # python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz \
-    #    --vcf_out ./output.vcf.gz --vrs_file ./vrs_objects.pkl
+    #    --vcf_out output.vcf.gz --vrs_file vrs_objects.pkl
     annotate_click()  # pylint: disable=no-value-for-parameter

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -1,122 +1,168 @@
-"""
-Annotate VCF files with VRS
-
-Input Format: VCF
-Output Format: VCF
-
-The user should pass arguments for the VCF input, VCF output, &
-the vrs object file name.
-
-ex. python3 src/ga4gh/vrs/extras/vcf_annotation.py input.vcf.gz --out
-./output.vcf.gz --vrs-file ./vrs_objects.pkl
-"""
-
-import argparse
-import sys
+"""Module containing tools for annotating VCFs with VRS"""
 import pickle
-import time
+from enum import Enum
+from typing import Dict, List, Optional
+from timeit import default_timer as timer
 
+import click
 from biocommons.seqrepo import SeqRepo
 import pysam
 
-from ga4gh.vrs.dataproxy import SeqRepoDataProxy
+from ga4gh.vrs.dataproxy import SeqRepoDataProxy, SeqRepoRESTDataProxy
 from ga4gh.vrs.extras.translator import Translator
 
 
+class SeqRepoProxyType(str, Enum):
+    """Define constraints for SeqRepo Data Proxy types"""
+
+    LOCAL = "local"
+    REST = "rest"
+
+
+@click.command()
+@click.option(
+    "--vcf_in",
+    required=True,
+    type=str,
+    help="The path for the input VCF file to annotate"
+)
+@click.option(
+    "--vcf_out",
+    required=True,
+    type=str,
+    help="The path for the output VCF file"
+)
+@click.option(
+    "--vrs_file",
+    required=True,
+    type=str,
+    help="The path for the output VCF pickle file"
+)
+@click.option(
+    "--seqrepo_dp_type",
+    required=False,
+    default=SeqRepoProxyType.LOCAL,
+    type=click.Choice([v.value for v in SeqRepoProxyType.__members__.values()],
+                      case_sensitive=True),
+    help="The type of the SeqRepo Data Proxy to use"
+)
+@click.option(
+    "--seqrepo_root_dir",
+    required=False,
+    default="/usr/local/share/seqrepo/latest",
+    help="The root directory for local SeqRepo instance"
+)
+@click.option(
+    "--seqrepo_base_url",
+    required=False,
+    default="http://localhost:5000/seqrepo",
+    help="The base url for SeqRepo REST API"
+)
+def annotate_click(vcf_in: str, vcf_out: str, vrs_file: str,
+                   seqrepo_dp_type: SeqRepoProxyType, seqrepo_root_dir: str,
+                   seqrepo_base_url: str) -> None:
+    """Annotate VCF file via click"""
+    annotator = VCFAnnotator(seqrepo_dp_type, seqrepo_base_url, seqrepo_root_dir)
+    start = timer()
+    annotator.annotate(vcf_in, vcf_out, vrs_file)
+    end = timer()
+    click.echo(f"VCF Annotator finished in {(end - start):.5f} seconds")
+
 class VCFAnnotator:
-    """
-    This class provides utility for annotating VCF's with VRS allele id's.
-
+    """Provides utility for annotating VCF's with VRS Allele IDs.
     VCF's are read using pysam and stored as pysam objects.
-    Alleles are translated into vrs allele id's using VRS-Python Translator.
-
+    Alleles are translated into VRS Allele IDs using VRS-Python Translator.
     """
 
-    def __init__(self, tlr) -> None:
-        """
-        param: Translator tlr Valid translator object with a specified data proxy
-        """
-        self.tlr = tlr
+    def __init__(self, seqrepo_dp_type: SeqRepoProxyType = SeqRepoProxyType.LOCAL,
+                 seqrepo_base_url: str = "http://localhost:5000/seqrepo",
+                 seqrepo_root_dir: str = "/usr/local/share/seqrepo/latest") -> None:
+        """Initialize the VCFAnnotator class
 
-    def annotate(self, inputfile, outputfile, vrsfile):
+        :param SeqRepoProxyType seqrepo_dp_type: The type of SeqRepo Data Proxy to use
+        :param str seqrepo_base_url: The base url for SeqRepo REST API
+        :param str seqrepo_root_dir: The root directory for the local SeqRepo instance
         """
-        Annotates an input VCF file with VRS allele ids & creates a
-        pickle file containing the vrs object information.
-        param: str inputfile The path and filename for the input VCF file
-        param: str outputfile The path and filename for the output VCF file
-        param: str vrsfile The path and filename for the output VRS object file
+        if seqrepo_dp_type == SeqRepoProxyType.LOCAL:
+            self.dp = SeqRepoDataProxy(SeqRepo(seqrepo_root_dir))
+        else:
+            self.dp = SeqRepoRESTDataProxy(seqrepo_base_url)
+        self.tlr = Translator(self.dp)
+
+    def annotate(self, vcf_in: str, vcf_out: str, vrs_file: str) -> None:
+        """Annotates an input VCF file with VRS Allele IDs & creates a pickle file
+        containing the vrs object information.
+
+        :param str vcf_in: The path for the input VCF file to annotate
+        :param str vcf_out: The path for the output VCF file
+        :param str vrs_file: The path for the output VCF pickle file
         """
-        INFO_FIELD_ID = "VRS_Allele"
+        INFO_FIELD_ID = "VRS_Allele"  # pylint: disable=invalid-name
         vrs_data = {}
-        vcf_in = pysam.VariantFile(filename=inputfile)
+        vcf_in = pysam.VariantFile(filename=vcf_in)  # pylint: disable=no-member
         vcf_in.header.info.add(INFO_FIELD_ID, "1", "String", "vrs")
-        vcf_out = pysam.VariantFile(outputfile, "w", header=vcf_in.header)
-        vrs_out = open(vrsfile, "wb")    # For sending VRS data to the pickle file
+        vcf_out = pysam.VariantFile(vcf_out, "w", header=vcf_in.header)  # pylint: disable=no-member
+        vrs_pickle_out = open(vrs_file, "wb")
 
         for record in vcf_in:
-            ld = self._record_digests(record, vrs_data)
-            record.info[INFO_FIELD_ID] = ",".join(ld)
+            vrs_allele_ids = self._record_digests(record, vrs_data)
+            record.info[INFO_FIELD_ID] = ",".join(vrs_allele_ids)
             vcf_out.write(record)
+        pickle.dump(vrs_data, vrs_pickle_out)
 
-        pickle.dump(vrs_data, vrs_out)
 
-        vrs_out.close()
+        vrs_pickle_out.close()
         vcf_in.close()
         vcf_out.close()
 
-    def _record_digests(self, record, vrs_data):
+    def _get_vrs_object(self, vcf_coords: str, vrs_data: Dict,
+                        vrs_allele_ids: List[str],
+                        vrs_data_key: Optional[str] = None) -> None:
+        """Get VRS Object given `vcf_coords`. `vrs_data` and `vrs_allele_ids` will
+        be mutated.
+
+        :param str vcf_coords: Allele to get VRS object for. Format is chr-pos-ref-alt
+        :param Dict vrs_data: Dictionary containing the VRS object information for the
+            VCF
+        :param List[str] vrs_allele_ids: List containing the VRS Allele IDs
+        :param Optional[str] vrs_data_key: The key to update in `vrs_data`. If not
+            provided, will use `vcf_coords` as the key.
         """
-        Mutate vrs_data with vrs object information and returning a list of vrs allele ids
-        param: pysam.VariantRecord record A row in the vcf file
-        param: dict vrs_data Dictionary containing the VRS object information for the VCF
-        return: list vrs_allele_ids List containing the vrs allele id information
+        vrs_obj = self.tlr.translate_from(vcf_coords, "gnomad")
+        key = vrs_data_key if vrs_data_key else vcf_coords
+        vrs_data[key] = str(vrs_obj.as_dict())
+        vrs_allele_ids.append(vrs_obj._id._value)
+
+    def _record_digests(self, record: pysam.VariantRecord, vrs_data: Dict) -> List[str]:
+        """Mutate `vrs_data` with VRS object information and returning a list of VRS
+        Allele IDs
+
+        :param pysam.VariantRecord record: A row in the VCF file
+        :param Dict vrs_data: Dictionary containing the VRS object information for the
+            VCF
+        :return List[str] vrs_allele_ids: List containing the VRS Allele IDs
         """
+        vrs_allele_ids = []
+
+        # Get VRS data for reference allele
         gnomad_loc = f"{record.chrom}-{record.pos}"
-        alts = record.alts if record.alts else []
-        data = f"{record.chrom}\t{record.pos}\t{record.id}\t{record.ref}\t{record.alts}"
-        # payloads like ['20:14369:1', '20:14369:1:G', '20:14369:1:A']
         reference_allele = f"{gnomad_loc}-{record.ref}-{record.ref}"
-        vrs_ref_object = self.tlr.translate_from(reference_allele, "gnomad")
-        vrs_data[reference_allele] = str(vrs_ref_object.as_dict())
-        alleles = [f"{gnomad_loc}-{record.ref}-{a}" for a in [*alts]]    # using gnomad format
-        vrs_allele_ids = [vrs_ref_object._id._value]
+        self._get_vrs_object(reference_allele, vrs_data, vrs_allele_ids)
+
+        # Get VRS data for alts
+        alts = record.alts or []
+        alleles = [f"{gnomad_loc}-{record.ref}-{a}" for a in [*alts]]
+        data = f"{record.chrom}\t{record.pos}\t{record.id}\t{record.ref}\t{record.alts}"
         for allele in alleles:
             if "*" in allele:
                 vrs_allele_ids.append("")
             else:
-                vrs_object = self.tlr.translate_from(allele, "gnomad")
-                vrs_allele_ids.append(vrs_object._id._value)
-                vrs_data[data] = str(vrs_object.as_dict())
-
+                self._get_vrs_object(allele, vrs_data, vrs_allele_ids,
+                                     vrs_data_key=data)
         return vrs_allele_ids
 
 
-def parse_args(argv):
-    """
-    Parses arguments passed in by the user
-    param: list[str] argv Arguments passed by the user to specify file locations and names
-    return: argparse.Namespace Returns the options passed by the user to be assigned to proper variables
-    """
-    ap = argparse.ArgumentParser()
-    ap.add_argument("VCF_IN")
-    ap.add_argument("--out", "-o", default="-")
-    ap.add_argument("--vrs-file", default="-")
-    opts = ap.parse_args(argv)
-    return opts
-
-
 if __name__ == "__main__":
-    start_time = time.time()
-
-    options = parse_args(sys.argv[1:])
-    print(f"These are the options that you have selected: {options}\n")
-    data_proxy = SeqRepoDataProxy(SeqRepo("/usr/local/share/seqrepo/latest"))
-    tlr = Translator(data_proxy)
-    vcf_annotator = VCFAnnotator(tlr)
-    vcf_annotator.annotate(options.VCF_IN, options.out, options.vrs_file)
-
-    end_time = time.time()
-    total_time = (float(end_time) - float(start_time))
-    total_time_minutes = (total_time / 60)
-    print(f"This program took {total_time} seconds to run.")
-    print(f"This program took {total_time_minutes} minutes to run.")
+    # python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz \
+    #    --vcf_out ./output.vcf.gz --vrs_file ./vrs_objects.pkl
+    annotate_click()  # pylint: disable=no-value-for-parameter

--- a/tests/extras/test_vcf_annotation.py
+++ b/tests/extras/test_vcf_annotation.py
@@ -10,14 +10,9 @@ from ga4gh.vrs.extras.translator import Translator
 
 
 @pytest.fixture(scope="module")
-def tlr_local(dataproxy):
-    return Translator(data_proxy=dataproxy)
-
-
-@pytest.fixture(scope="module")
-def vcf_annotator(tlr_local):
-    return VCFAnnotator(tlr_local)
-
+def vcf_annotator():
+    root_dir = os.environ.get("SEQREPO_ROOT_DIR", "/usr/local/share/seqrepo/latest")
+    return VCFAnnotator("local", seqrepo_root_dir=root_dir)
 
 @pytest.mark.vcr
 def test_annotate_vcf(vcf_annotator):
@@ -36,3 +31,5 @@ def test_annotate_vcf(vcf_annotator):
 
     assert out_vcf_lines == expected_output_lines
     assert os.path.exists(output_vrs_pkl)
+    os.remove(output_vcf)
+    os.remove(output_vrs_pkl)


### PR DESCRIPTION
Close #122

Notes:
- Replaces argparse with click
- Allows users to select from either local or REST SeqRepo Data Proxy
- Cleans up the VCFAnnotator code 