### PR TITLE
feat: dockerize vrs-python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10
+COPY . .
+RUN pip install -e .[dev,extras]
+RUN mkdir /data
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ to install the biocommons tools that provide these data.
     docker volume create --name=seqrepo_vol
     docker-compose up
 
-This should start three containers:
+This should start four containers:
 
 - [seqrepo](https://github.com/biocommons/seqrepo): downloads seqrepo into a
   docker volume and exits
@@ -66,6 +66,7 @@ This should start three containers:
   REST service on seqrepo (localhost:5000)
 - [uta](https://github.com/biocommons/uta): a database of transcripts and
   alignments (localhost:5432)
+- vrs-python: docker image for vrs-python application
 
 Check that the containers are running:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     depends_on:
       - seqrepo
     command: seqrepo-rest-service -w /usr/local/share/seqrepo/2021-01-29
-    network_mode: bridge
     ports:
       - 5000:5000
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
     network_mode: bridge
     ports:
       - 5000:5000
-  
+    networks:
+      - local
+
   uta:
     # Test:
     # psql -XAt postgres://anonymous@localhost/uta -c 'select count(*) from transcript'
@@ -28,8 +30,28 @@ services:
     ports:
       - 5432:5432
 
+  vrs-python:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    depends_on:
+      - seqrepo-rest-service
+    volumes:
+      - seqrepo_vol:/usr/local/share/seqrepo
+      - data:/data
+    tty:
+      true
+    networks:
+      - local
+
 volumes:
   seqrepo_vol:
     external: true
   uta_vol:
     external: true
+  data:
+    external: false
+
+networks:
+  local:
+    driver: bridge

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -1,0 +1,19 @@
+# Docker
+
+This README includes information on how to use the docker containers.
+
+## Running the VCF Annotator
+
+Commands to run inside the Docker CLI. Ensure that the `vcf_out` and `vrs_file` are output to the `/data` directory so that data persists.
+
+To use local SeqRepo (uses test data for example):
+
+```commandline
+python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in tests/extras/data/test_vcf_input.vcf --vcf_out /data/output.vcf.gz --vrs_file /data/vrs_objects.pkl --seqrepo_root_dir /usr/local/share/seqrepo/2021-01-29
+```
+
+To use SeqRepo REST (uses test data for example):
+
+```commandline
+python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in tests/extras/data/test_vcf_input.vcf --vcf_out /data/output.vcf.gz --vrs_file /data/vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://seqrepo-rest-service:5000/seqrepo
+```


### PR DESCRIPTION
Close #119 

Creates a docker image for vrs-python. I'm still pretty new to working with Docker, so any feedback is very appreciated. This work was mainly so that collaborators could run the VCF VRS Annotation tool. I've made it so that you can use the Docker CLI to run the commands. Data will need to be exported to `/data` for it to persist. 