### PR TITLE
feat: add pre-commit hook for pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pycqa/pylint
+    rev: v2.15.9
+    hooks:
+      - id: pylint
+        args:
+          - --fail-under=10  # Makes it so that new changes must resolve all warnings
+          - --rcfile=.pylintrc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,5 +6,5 @@ repos:
     hooks:
       - id: pylint
         args:
-          - --fail-under=10  # Makes it so that new changes must resolve all warnings
-          - --rcfile=.pylintrc
+          - src/ga4gh/core
+          - src/ga4gh/vrs

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ Fork the repo at https://github.com/ga4gh/vrs-python/ .
     $ cd vrs-python
     $ make devready
 
+## Pre-commit
+
+We use [pre-commit](https://pre-commit.com/) to check code style.
+
+Before first commit, run:
+
+    $ pre-commit install
+
 ## Testing
 
 This package implements typical unit tests for ga4gh.core and ga4gh.vrs. This

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ dev =
     tox
     vcrpy
     yapf
+    pre-commit
 extras =
     psycopg2-binary
     biocommons.seqrepo>=0.5.1


### PR DESCRIPTION
Close #138 

Adds pre-commit hook so that new changes must be above the pylint fail under score defined in `.pylintrc`. Many times, we've seen our GitHub Action fail due to pylint. This should fix this and help us resolve warnings before we're able to commit our changes!

You will need to make sure to run `pre-commit install`