### PR TITLE
feat: Add validation to _from_gnomad in translator

### DIFF
--- a/notebooks/Extras.ipynb
+++ b/notebooks/Extras.ipynb
@@ -1,545 +1,543 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# ga4gh.vrs.extras\n",
-    "\n",
-    "This notebook demonstrates functionality in the vr-python package that builds on VRS but is not formally part of the specification. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Data Proxy\n",
-    "VRS implementations will need access to sequences and sequence identifiers. Sequences are used during normalization and during conversions with other formats. Sequence identifiers are necessary in order to translate identfiers from common forms to a digest-based identifier.\n",
-    "\n",
-    "VRS leaves the choice of those data sources to the implementations.  In vr-python, `ga4gh.vrs.dataproxy` provides an abstract base class as a basis for data source adapters.  One source is [SeqRepo](https://github.com/biocommons/biocommons.seqrepo/), which is used below.  (An adapter based on the GA4GH refget specification exists, but is pending necessary changes to the refget interface to provide accession-based lookups.)\n",
-    "\n",
-    "SeqRepo: [github](https://github.com/biocommons/biocommons.seqrepo/) | [data snapshots](http://dl.biocommons.org/seqrepo/) | [seqrepo-rest-service @ github](https://github.com/biocommons/seqrepo-rest-service) | [seqrepo-rest-service docker images](https://cloud.docker.com/u/biocommons/repository/docker/biocommons/seqrepo-rest-service)\n",
-    "\n",
-    "RefGet: [spec](https://samtools.github.io/hts-specs/refget.html) | [perl server](https://github.com/andrewyatz/refget-server-perl)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Removing allOf attribute from AbsoluteCopyNumber to avoid python-jsonschema-objects error.\n",
-      "Removing allOf attribute from SequenceInterval to avoid python-jsonschema-objects error.\n",
-      "Removing allOf attribute from RepeatedSequenceExpression to avoid python-jsonschema-objects error.\n",
-      "/Users/kxk102/Documents/ga4gh/vrs-python/venv/3.9/lib/python3.9/site-packages/python_jsonschema_objects/__init__.py:49: UserWarning: Schema version http://json-schema.org/draft-07/schema not recognized. Some keywords and features may not be supported.\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
-   "source": [
-    "from ga4gh.core import sha512t24u, ga4gh_digest, ga4gh_identify, ga4gh_serialize\n",
-    "from ga4gh.vrs import __version__, models, normalize\n",
-    "from ga4gh.vrs.dataproxy import SeqRepoRESTDataProxy\n",
-    "from biocommons.seqrepo import SeqRepo\n",
-    "\n",
-    "seqrepo_rest_service_url = \"https://services.genomicmedlab.org/seqrepo\"\n",
-    "dp = SeqRepoRESTDataProxy(base_url=seqrepo_rest_service_url)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'added': '2016-08-24T05:03:11Z',\n",
-       " 'aliases': ['MD5:215137b1973c1a5afcf86be7d999574a',\n",
-       "  'NCBI:NM_000551.3',\n",
-       "  'refseq:NM_000551.3',\n",
-       "  'SEGUID:T12L0p2X5E8DbnL0+SwI4Wc1S6g',\n",
-       "  'SHA1:4f5d8bd29d97e44f036e72f4f92c08e167354ba8',\n",
-       "  'VMC:GS_v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_',\n",
-       "  'sha512t24u:v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_',\n",
-       "  'ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_'],\n",
-       " 'alphabet': 'ACGT',\n",
-       " 'length': 4560}"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# ga4gh.vrs.extras\n",
+        "\n",
+        "This notebook demonstrates functionality in the vr-python package that builds on VRS but is not formally part of the specification. "
       ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dp.get_metadata(\"refseq:NM_000551.3\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "'CCTCGCCTCCGTTACAACGGCCTACGGTGCTGGAGGATCCTTCTGCGCACG...'"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Data Proxy\n",
+        "VRS implementations will need access to sequences and sequence identifiers. Sequences are used during normalization and during conversions with other formats. Sequence identifiers are necessary in order to translate identfiers from common forms to a digest-based identifier.\n",
+        "\n",
+        "VRS leaves the choice of those data sources to the implementations.  In vr-python, `ga4gh.vrs.dataproxy` provides an abstract base class as a basis for data source adapters.  One source is [SeqRepo](https://github.com/biocommons/biocommons.seqrepo/), which is used below.  (An adapter based on the GA4GH refget specification exists, but is pending necessary changes to the refget interface to provide accession-based lookups.)\n",
+        "\n",
+        "SeqRepo: [github](https://github.com/biocommons/biocommons.seqrepo/) | [data snapshots](http://dl.biocommons.org/seqrepo/) | [seqrepo-rest-service @ github](https://github.com/biocommons/seqrepo-rest-service) | [seqrepo-rest-service docker images](https://cloud.docker.com/u/biocommons/repository/docker/biocommons/seqrepo-rest-service)\n",
+        "\n",
+        "RefGet: [spec](https://samtools.github.io/hts-specs/refget.html) | [perl server](https://github.com/andrewyatz/refget-server-perl)"
       ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dp.get_sequence(\"ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_\", start=0, end=51) + \"...\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Format translator\n",
-    "ga4gh.vrs.extras.translator.Translator translates various formats into VRS representations. \n",
-    "\n",
-    "<div class=\"alert alert-success\">\n",
-    "    <span style=\"font-size: larger\">🚀</span> The examples below use the same variant in 4 formats: HGVS, beacon, spdi, and VCF/gnomAD. Notice that the resulting Allele objects and computed identifiers are identical.</b>\n",
-    "    \n",
-    "By default, `Translator` 1) translates sequence identifiers to ga4gh digest-based identifiers, 2) normalizes alleles, 3) adds a ga4gh identifier. These may be disabled as desired. (However, `ga4gh_identify` requires that all objects use identifiers, including sequence identifiers, in the `ga4gh` namespace.)\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ga4gh.vrs.extras.translator import Translator\n",
-    "tlr = Translator(data_proxy=dp,\n",
-    "                 translate_sequence_identifiers=True,  # default\n",
-    "                 normalize=True,                       # default\n",
-    "                 identify=True)                        # default"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### From/To HGVS\n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "    <span style=\"font-size: larger\">☛</span> The HGVS variant below shows G>C. The reference is actually C, meaning that this variant is actually a ref agree assertion. This example intentionally shows VRS's ability to deal with invalid variants.\n",
-    "    </div>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "{'_id': 'ga4gh:VA.DkZLLMnwoH6zIncSRh2c05nzCNLdTqHl',\n",
-       " 'type': 'Allele',\n",
-       " 'location': {'type': 'SequenceLocation',\n",
-       "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
-       "  'interval': {'type': 'SequenceInterval',\n",
-       "   'start': {'type': 'Number', 'value': 32936731},\n",
-       "   'end': {'type': 'Number', 'value': 32936732}}},\n",
-       " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "a = tlr.translate_from(\"NC_000013.11:g.32936732G>C\",\"hgvs\")\n",
-    "a.as_dict()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'The postgres default port of 5432 is blocked outbound by binder and potentially other institutions. To circumvent users having to install UTA themselves we created a rest data proxy for variation normalizer for the to_hgvs endpoint.'"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "#tlr.translate_to(a, \"hgvs\")\n",
-    "\n",
-    "\"The postgres default port of 5432 is blocked outbound by binder and potentially other institutions. \"\\\n",
-    "\"To circumvent users having to install UTA themselves we created a rest data proxy for variation normalizer for the to_hgvs endpoint.\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['NC_000013.11:g.32936732=']"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from ga4gh.vrs.extras.variation_normalizer_rest_dp import VariationNormalizerRESTDataProxy\n",
-    "vnorm = VariationNormalizerRESTDataProxy()\n",
-    "vnorm.to_hgvs(a)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### From/To SPDI"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'_id': 'ga4gh:VA.DkZLLMnwoH6zIncSRh2c05nzCNLdTqHl',\n",
-       " 'type': 'Allele',\n",
-       " 'location': {'type': 'SequenceLocation',\n",
-       "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
-       "  'interval': {'type': 'SequenceInterval',\n",
-       "   'start': {'type': 'Number', 'value': 32936731},\n",
-       "   'end': {'type': 'Number', 'value': 32936732}}},\n",
-       " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# SPDI uses 0-based coordinates\n",
-    "a = tlr.translate_from(\"NC_000013.11:32936731:1:C\",\"spdi\")\n",
-    "a.as_dict()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['NC_000013.11:32936731:1:C']"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "tlr.translate_to(a, \"spdi\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['NC_000013.11:32936731:2:C']"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "a.location.interval.end.value += 1\n",
-    "tlr.translate_to(a, \"spdi\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['NC_000013.11:32936731:2:']"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "a.state.sequence = \"\"\n",
-    "tlr.translate_to(a, \"spdi\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### from Beacon (VCF-like)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'_id': 'ga4gh:VA.DkZLLMnwoH6zIncSRh2c05nzCNLdTqHl',\n",
-       " 'type': 'Allele',\n",
-       " 'location': {'type': 'SequenceLocation',\n",
-       "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
-       "  'interval': {'type': 'SequenceInterval',\n",
-       "   'start': {'type': 'Number', 'value': 32936731},\n",
-       "   'end': {'type': 'Number', 'value': 32936732}}},\n",
-       " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# from_beacon: Translate from beacon's form\n",
-    "a = tlr.translate_from(\"13 : 32936732 G > C\", \"beacon\")\n",
-    "a.as_dict()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### from gnomAD style VCF"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'_id': 'ga4gh:VA.DkZLLMnwoH6zIncSRh2c05nzCNLdTqHl',\n",
-       " 'type': 'Allele',\n",
-       " 'location': {'type': 'SequenceLocation',\n",
-       "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
-       "  'interval': {'type': 'SequenceInterval',\n",
-       "   'start': {'type': 'Number', 'value': 32936731},\n",
-       "   'end': {'type': 'Number', 'value': 32936732}}},\n",
-       " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "a = tlr.translate_from(\"13-32936732-G-C\", \"gnomad\")   # gnomAD-style expression\n",
-    "a.as_dict()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Advanced Examples\n",
-    "\n",
-    "NM_000551.3 starts with `CCTCGCCTCC`. So, `NM_000551.3:n.5_6insC` inserts a C at the start of an existing run of two C residues."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from IPython.display import HTML, display\n",
-    "import tabulate\n",
-    "\n",
-    "hgvs_expr = \"NM_000551.3:n.5_6insC\"\n",
-    "\n",
-    "# Translator with default behaviors disabled\n",
-    "tlr2 = Translator(data_proxy=dp,\n",
-    "                  translate_sequence_identifiers=False,\n",
-    "                  normalize=False,\n",
-    "                  identify=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### translate_sequence_identifiers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<tbody>\n",
-       "<tr><td>translate_sequence_identifiers=</td><td>sequence_id                              </td></tr>\n",
-       "<tr><td>False                          </td><td>refseq:NM_000551.3                       </td></tr>\n",
-       "<tr><td>True                           </td><td>ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_</td></tr>\n",
-       "</tbody>\n",
-       "</table>"
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/Users/kxk102/Documents/ga4gh/vrs-python/venv/3.10/lib/python3.10/site-packages/python_jsonschema_objects/__init__.py:49: UserWarning: Schema version http://json-schema.org/draft-07/schema not recognized. Some keywords and features may not be supported.\n",
+            "  warnings.warn(\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "from ga4gh.core import sha512t24u, ga4gh_digest, ga4gh_identify, ga4gh_serialize\n",
+        "from ga4gh.vrs import __version__, models, normalize\n",
+        "from ga4gh.vrs.dataproxy import SeqRepoRESTDataProxy\n",
+        "from biocommons.seqrepo import SeqRepo\n",
+        "\n",
+        "seqrepo_rest_service_url = \"https://services.genomicmedlab.org/seqrepo\"\n",
+        "dp = SeqRepoRESTDataProxy(base_url=seqrepo_rest_service_url)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "header = \"translate_sequence_identifiers= sequence_id\".split()\n",
-    "table = [header]\n",
-    "for tsi in (False, True):\n",
-    "    tlr2.translate_sequence_identifiers = tsi\n",
-    "    a = tlr2.translate_from(hgvs_expr, \"hgvs\")\n",
-    "    row = [tlr2.translate_sequence_identifiers,\n",
-    "           a.location.sequence_id._value]\n",
-    "    table += [row]\n",
-    "display(HTML(tabulate.tabulate(table, tablefmt='html')))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### normalize\n",
-    "VRS normalization uses [fully-justified normalization](https://vr-spec.readthedocs.io/en/1.0/impl-guide/normalization.html). In this case, the left-aligned insertion (c.5_6insC) is renormalized as a replacement of the two C residues with three C residues at interbase coordinates [5,7]."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<tbody>\n",
-       "<tr><td>normalize=</td><td>sequence_id                              </td><td>interval</td><td>alt</td><td>hgvs              </td></tr>\n",
-       "<tr><td>False     </td><td>ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_</td><td>5,5     </td><td>C  </td><td>NM_000551.3:n.7dup</td></tr>\n",
-       "<tr><td>True      </td><td>ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_</td><td>5,7     </td><td>CCC</td><td>NM_000551.3:n.7dup</td></tr>\n",
-       "</tbody>\n",
-       "</table>"
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'added': '2016-08-24T05:03:11Z',\n",
+              " 'aliases': ['MD5:215137b1973c1a5afcf86be7d999574a',\n",
+              "  'NCBI:NM_000551.3',\n",
+              "  'refseq:NM_000551.3',\n",
+              "  'SEGUID:T12L0p2X5E8DbnL0+SwI4Wc1S6g',\n",
+              "  'SHA1:4f5d8bd29d97e44f036e72f4f92c08e167354ba8',\n",
+              "  'VMC:GS_v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_',\n",
+              "  'sha512t24u:v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_',\n",
+              "  'ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_'],\n",
+              " 'alphabet': 'ACGT',\n",
+              " 'length': 4560}"
+            ]
+          },
+          "execution_count": 2,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "dp.get_metadata(\"refseq:NM_000551.3\")"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'CCTCGCCTCCGTTACAACGGCCTACGGTGCTGGAGGATCCTTCTGCGCACG...'"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "dp.get_sequence(\"ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_\", start=0, end=51) + \"...\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Format translator\n",
+        "ga4gh.vrs.extras.translator.Translator translates various formats into VRS representations. \n",
+        "\n",
+        "<div class=\"alert alert-success\">\n",
+        "    <span style=\"font-size: larger\">🚀</span> The examples below use the same variant in 4 formats: HGVS, beacon, spdi, and VCF/gnomAD. Notice that the resulting Allele objects and computed identifiers are identical.</b>\n",
+        "    \n",
+        "By default, `Translator` 1) translates sequence identifiers to ga4gh digest-based identifiers, 2) normalizes alleles, 3) adds a ga4gh identifier. These may be disabled as desired. (However, `ga4gh_identify` requires that all objects use identifiers, including sequence identifiers, in the `ga4gh` namespace.)\n",
+        "</div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from ga4gh.vrs.extras.translator import Translator\n",
+        "tlr = Translator(data_proxy=dp,\n",
+        "                 translate_sequence_identifiers=True,  # default\n",
+        "                 normalize=True,                       # default\n",
+        "                 identify=True)                        # default"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### From/To HGVS\n",
+        "\n",
+        "<div class=\"alert alert-info\">\n",
+        "    <span style=\"font-size: larger\">☛</span> The HGVS variant below shows C>T.\n",
+        "    </div>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'_id': 'ga4gh:VA.CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD',\n",
+              " 'type': 'Allele',\n",
+              " 'location': {'type': 'SequenceLocation',\n",
+              "  'sequence_id': 'ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl',\n",
+              "  'interval': {'type': 'SequenceInterval',\n",
+              "   'start': {'type': 'Number', 'value': 44908821},\n",
+              "   'end': {'type': 'Number', 'value': 44908822}}},\n",
+              " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "a = tlr.translate_from(\"NC_000019.10:g.44908822C>T\",\"hgvs\")\n",
+        "a.as_dict()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'The postgres default port of 5432 is blocked outbound by binder and potentially other institutions. To circumvent users having to install UTA themselves we created a rest data proxy for variation normalizer for the to_hgvs endpoint.'"
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "#tlr.translate_to(a, \"hgvs\")\n",
+        "\n",
+        "\"The postgres default port of 5432 is blocked outbound by binder and potentially other institutions. \"\\\n",
+        "\"To circumvent users having to install UTA themselves we created a rest data proxy for variation normalizer for the to_hgvs endpoint.\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['NC_000019.10:g.44908822C>T']"
+            ]
+          },
+          "execution_count": 7,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "from ga4gh.vrs.extras.variation_normalizer_rest_dp import VariationNormalizerRESTDataProxy\n",
+        "vnorm = VariationNormalizerRESTDataProxy()\n",
+        "vnorm.to_hgvs(a)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### From/To SPDI"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'_id': 'ga4gh:VA.CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD',\n",
+              " 'type': 'Allele',\n",
+              " 'location': {'type': 'SequenceLocation',\n",
+              "  'sequence_id': 'ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl',\n",
+              "  'interval': {'type': 'SequenceInterval',\n",
+              "   'start': {'type': 'Number', 'value': 44908821},\n",
+              "   'end': {'type': 'Number', 'value': 44908822}}},\n",
+              " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# SPDI uses 0-based coordinates\n",
+        "a = tlr.translate_from(\"NC_000019.10:44908821:1:T\",\"spdi\")\n",
+        "a.as_dict()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['NC_000019.10:44908821:1:T']"
+            ]
+          },
+          "execution_count": 9,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "tlr.translate_to(a, \"spdi\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['NC_000019.10:44908821:2:T']"
+            ]
+          },
+          "execution_count": 10,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "a.location.interval.end.value += 1\n",
+        "tlr.translate_to(a, \"spdi\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['NC_000019.10:44908821:2:']"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "a.state.sequence = \"\"\n",
+        "tlr.translate_to(a, \"spdi\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### from Beacon (VCF-like)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'_id': 'ga4gh:VA.CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD',\n",
+              " 'type': 'Allele',\n",
+              " 'location': {'type': 'SequenceLocation',\n",
+              "  'sequence_id': 'ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl',\n",
+              "  'interval': {'type': 'SequenceInterval',\n",
+              "   'start': {'type': 'Number', 'value': 44908821},\n",
+              "   'end': {'type': 'Number', 'value': 44908822}}},\n",
+              " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
+            ]
+          },
+          "execution_count": 12,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# from_beacon: Translate from beacon's form\n",
+        "a = tlr.translate_from(\"19 : 44908822 C > T\", \"beacon\")\n",
+        "a.as_dict()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### from gnomAD style VCF"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'_id': 'ga4gh:VA.CxiA_hvYbkD8Vqwjhx5AYuyul4mtlkpD',\n",
+              " 'type': 'Allele',\n",
+              " 'location': {'type': 'SequenceLocation',\n",
+              "  'sequence_id': 'ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl',\n",
+              "  'interval': {'type': 'SequenceInterval',\n",
+              "   'start': {'type': 'Number', 'value': 44908821},\n",
+              "   'end': {'type': 'Number', 'value': 44908822}}},\n",
+              " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "a = tlr.translate_from(\"19-44908822-C-T\", \"gnomad\")   # gnomAD-style expression\n",
+        "a.as_dict()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Advanced Examples\n",
+        "\n",
+        "NM_000551.3 starts with `CCTCGCCTCC`. So, `NM_000551.3:n.5_6insC` inserts a C at the start of an existing run of two C residues."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from IPython.display import HTML, display\n",
+        "import tabulate\n",
+        "\n",
+        "hgvs_expr = \"NM_000551.3:n.5_6insC\"\n",
+        "\n",
+        "# Translator with default behaviors disabled\n",
+        "tlr2 = Translator(data_proxy=dp,\n",
+        "                  translate_sequence_identifiers=False,\n",
+        "                  normalize=False,\n",
+        "                  identify=False)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### translate_sequence_identifiers"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "<tbody>\n",
+              "<tr><td>translate_sequence_identifiers=</td><td>sequence_id                              </td></tr>\n",
+              "<tr><td>False                          </td><td>refseq:NM_000551.3                       </td></tr>\n",
+              "<tr><td>True                           </td><td>ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_</td></tr>\n",
+              "</tbody>\n",
+              "</table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "header = \"translate_sequence_identifiers= sequence_id\".split()\n",
+        "table = [header]\n",
+        "for tsi in (False, True):\n",
+        "    tlr2.translate_sequence_identifiers = tsi\n",
+        "    a = tlr2.translate_from(hgvs_expr, \"hgvs\")\n",
+        "    row = [tlr2.translate_sequence_identifiers,\n",
+        "           a.location.sequence_id._value]\n",
+        "    table += [row]\n",
+        "display(HTML(tabulate.tabulate(table, tablefmt='html')))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### normalize\n",
+        "VRS normalization uses [fully-justified normalization](https://vr-spec.readthedocs.io/en/1.0/impl-guide/normalization.html). In this case, the left-aligned insertion (c.5_6insC) is renormalized as a replacement of the two C residues with three C residues at interbase coordinates [5,7]."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "<tbody>\n",
+              "<tr><td>normalize=</td><td>sequence_id                              </td><td>interval</td><td>alt</td><td>hgvs              </td></tr>\n",
+              "<tr><td>False     </td><td>ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_</td><td>5,5     </td><td>C  </td><td>NM_000551.3:n.7dup</td></tr>\n",
+              "<tr><td>True      </td><td>ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_</td><td>5,7     </td><td>CCC</td><td>NM_000551.3:n.7dup</td></tr>\n",
+              "</tbody>\n",
+              "</table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "tlr2.translate_sequence_identifiers = True\n",
+        "\n",
+        "header = \"normalize= sequence_id interval alt hgvs\".split()\n",
+        "table = [header]\n",
+        "for normalize in (False, True):\n",
+        "    tlr2.normalize = normalize\n",
+        "    a = tlr2.translate_from(hgvs_expr, \"hgvs\")\n",
+        "    row = [tlr2.normalize,\n",
+        "           a.location.sequence_id,\n",
+        "           f\"{a.location.interval.start.value},{a.location.interval.end.value}\",\n",
+        "           a.state.sequence,\n",
+        "           #tlr2.translate_to(a, 'hgvs')[0]\n",
+        "           vnorm.to_hgvs(a)[0]\n",
+        "          ]\n",
+        "    table += [row]\n",
+        "display(HTML(tabulate.tabulate(table, tablefmt='html')))"
+      ]
     }
-   ],
-   "source": [
-    "tlr2.translate_sequence_identifiers = True\n",
-    "\n",
-    "header = \"normalize= sequence_id interval alt hgvs\".split()\n",
-    "table = [header]\n",
-    "for normalize in (False, True):\n",
-    "    tlr2.normalize = normalize\n",
-    "    a = tlr2.translate_from(hgvs_expr, \"hgvs\")\n",
-    "    row = [tlr2.normalize,\n",
-    "           a.location.sequence_id,\n",
-    "           f\"{a.location.interval.start.value},{a.location.interval.end.value}\",\n",
-    "           a.state.sequence,\n",
-    "           #tlr2.translate_to(a, 'hgvs')[0]\n",
-    "           vnorm.to_hgvs(a)[0]\n",
-    "          ]\n",
-    "    table += [row]\n",
-    "display(HTML(tabulate.tabulate(table, tablefmt='html')))"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.13"
+    },
+    "toc": {
+      "base_numbering": 1,
+      "nav_menu": {},
+      "number_sections": true,
+      "sideBar": true,
+      "skip_h1_title": false,
+      "title_cell": "Table of Contents",
+      "title_sidebar": "Contents",
+      "toc_cell": false,
+      "toc_position": {},
+      "toc_section_display": true,
+      "toc_window_display": false
+    }
   },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.13"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": false,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 4
 }

--- a/notebooks/HGVS Translation.ipynb
+++ b/notebooks/HGVS Translation.ipynb
@@ -1,485 +1,494 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This notebook demonstrates the mechanics of translating an HGVS expression to a VR representation for educational purposes. Users who wish to translate HGVS or other expressions routinely should use ga4gh.vrs.extras.translator."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ga4gh.core import ga4gh_identify\n",
-    "from ga4gh.vrs import models\n",
-    "from ga4gh.vrs.dataproxy import SeqRepoRESTDataProxy\n",
-    "from ga4gh.vrs.extras.translator import Translator\n",
-    "from biocommons.seqrepo import SeqRepo\n",
-    "from IPython.display import HTML, display"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Translate an expression manually\n",
-    "\n",
-    "First, we'll translate NC_000013.11:g.32936732G>C to VR manually to see the evolution of the process. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# We'll translate this expression to VR:\n",
-    "hgvs_expr = \"\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
+  "cells": [
     {
-     "data": {
-      "text/plain": [
-       "{'type': 'Allele',\n",
-       " 'location': {'type': 'SequenceLocation',\n",
-       "  'sequence_id': 'refseq:NC_000013.11',\n",
-       "  'interval': {'type': 'SequenceInterval',\n",
-       "   'start': {'type': 'Number', 'value': 32936731},\n",
-       "   'end': {'type': 'Number', 'value': 32936732}}},\n",
-       " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This notebook demonstrates the mechanics of translating an HGVS expression to a VR representation for educational purposes. Users who wish to translate HGVS or other expressions routinely should use ga4gh.vrs.extras.translator."
       ]
-     },
-     "execution_count": 31,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "allele = models.Allele(\n",
-    "    location = models.SequenceLocation(\n",
-    "        sequence_id = \"refseq:NC_000013.11\",\n",
-    "        interval = models.SequenceInterval(\n",
-    "            start = models.Number(value=32936731, type=\"Number\"),\n",
-    "            end = models.Number(value=32936732, type=\"Number\"),\n",
-    "            type=\"SequenceInterval\"\n",
-    "        ),\n",
-    "        type=\"SequenceLocation\"\n",
-    "    ),\n",
-    "    state = models.SequenceExpression(\n",
-    "        sequence = \"C\",\n",
-    "        type=\"LiteralSequenceExpression\"\n",
-    "    ),\n",
-    "    type=\"Allele\"\n",
-    ")\n",
-    "\n",
-    "allele.as_dict()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-success\">\n",
-    "    👍 The above message is a valid VR message. VR requires that\n",
-    "    sequence identifiers use CURIE syntax with a namespace from identifiers.org and\n",
-    "    that locations are specified with interbase coordinates. Using sequence digests\n",
-    "    is NOT required.\n",
-    "    </div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Replace the RefSeq sequence with a GA4GH sequence id\n",
-    "\n",
-    "In order to use the computed identifier mechanism in VR, the sequence_id MUST use\n",
-    "GA4GH computed sequence identifiers. \n",
-    "\n",
-    "Implementations choose how to provide sequence and sequence accession services"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
-   "metadata": {},
-   "outputs": [
+    },
     {
-     "data": {
-      "text/plain": [
-       "'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT'"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "seqrepo_rest_service_url = \"https://services.genomicmedlab.org/seqrepo\"\n",
-    "dp = SeqRepoRESTDataProxy(base_url=seqrepo_rest_service_url)\n",
-    "\n",
-    "# In general, one identifier may be related to many others in another namespace\n",
-    "# Therefore, translate_sequence_identifier() returns a list.\n",
-    "# Because there will be only 1 ga4gh sequence digest, we choose the first\n",
-    "# and then replace the sequence id in allele.location.\n",
-    "\n",
-    "refseq_ir = str(allele.location.sequence_id)\n",
-    "ga4gh_ir = dp.translate_sequence_identifier(refseq_ir, \"ga4gh\")[0]\n",
-    "ga4gh_ir"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'type': 'Allele',\n",
-       " 'location': {'type': 'SequenceLocation',\n",
-       "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
-       "  'interval': {'type': 'SequenceInterval',\n",
-       "   'start': {'type': 'Number', 'value': 32936731},\n",
-       "   'end': {'type': 'Number', 'value': 32936732}}},\n",
-       " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Now, simply replace the identifier with the GA4GH identifier\n",
-    "allele.location.sequence_id = ga4gh_ir\n",
-    "allele.as_dict()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Computed Identifiers (optional)\n",
-    "\n",
-    "ga4gh_identify() serializes the object and computes the identifier\n",
-    "(See ga4gh_serialize and ga4gh_digest for details)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'_id': 'ga4gh:VA.DkZLLMnwoH6zIncSRh2c05nzCNLdTqHl',\n",
-       " 'type': 'Allele',\n",
-       " 'location': {'type': 'SequenceLocation',\n",
-       "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
-       "  'interval': {'type': 'SequenceInterval',\n",
-       "   'start': {'type': 'Number', 'value': 32936731},\n",
-       "   'end': {'type': 'Number', 'value': 32936732}}},\n",
-       " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "allele._id = ga4gh_identify(allele)\n",
-    "allele.as_dict()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Using ga4gh.vrs.extras.translator\n",
-    "\n",
-    "The VR Translator imports HGVS, SPDI, Beacon, and VCF formats, and appropriate handles more complex cases than shown above.\n",
-    "\n",
-    "By default, the translator translates HGVS reference sequences to GA4GH sequence digest identifiers and adds identifiers to the resulting Allele objects."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 35,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tlr = Translator(data_proxy=dp)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### HGVS → VR"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'_id': 'ga4gh:VA.hMfrqZuECxo2yyGLltnim_q71QDkK-HR',\n",
-       " 'type': 'Allele',\n",
-       " 'location': {'type': 'SequenceLocation',\n",
-       "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
-       "  'interval': {'type': 'SequenceInterval',\n",
-       "   'start': {'type': 'Number', 'value': 32936731},\n",
-       "   'end': {'type': 'Number', 'value': 32936732}}},\n",
-       " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'G'}}"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "hgvs_expr1 = \"NC_000013.11:g.32936732C>G\"\n",
-    "allele1 = tlr.translate_from(hgvs_expr1,'hgvs')\n",
-    "allele1.as_dict()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### VR → HGVS\n",
-    "\n",
-    "Because a GA4GH sequence identifier may have many aliases, each VR Allele\n",
-    "may be expressed as multiple HGVS expressions. For this reason, `translate_to(allele, \"hgvs\")` returns\n",
-    "a *list* of HGVS expressions, optionally limited to aliases from a specified namespace."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The postgres default port of 5432 is blocked outbound by binder and potentially other institutions. To circumvent users having to install UTA themselves we created a rest data proxy for variation normalizer for the to_hgvs endpoint."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ga4gh.vrs.extras.variation_normalizer_rest_dp import VariationNormalizerRESTDataProxy\n",
-    "vnorm = VariationNormalizerRESTDataProxy()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 38,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['NC_000013.11:g.32936732=']"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# tlr.translate_to(allele, \"hgvs\")\n",
-    "vnorm.to_hgvs(allele)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['NC_000013.11:g.32936732=']"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Most commonly, we'll want expressions from a well-known authority like RefSeq\n",
-    "# Again, there might in general be multiple `refseq` expressions\n",
-    "# tlr._to_hgvs(allele, \"refseq\")\n",
-    "vnorm.to_hgvs(allele, \"refseq\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 40,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# GRC namespaces is handled as a special case: Because aliases are shared \n",
-    "# between GRCh releases, they're shown only on request\n",
-    "# tlr._to_hgvs(allele, \"GRCh38\")\n",
-    "vnorm.to_hgvs(allele, \"GRCh38\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 41,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import json\n",
-    "import yaml\n",
-    "def filter_dict(d):\n",
-    "    try:\n",
-    "        return {k: filter_dict(d[k])\n",
-    "                for k in d\n",
-    "                if not k.startswith(\"_\")}\n",
-    "    except:\n",
-    "        return d\n",
-    "def as_str(s):\n",
-    "    return s if isinstance(s, str) else s.decode()\n",
-    "def dj(o):\n",
-    "    \"\"\"print VR object as pretty formated json\"\"\"\n",
-    "    print(json.dumps(filter_dict(o.as_dict()), indent=2, sort_keys=True))\n",
-    "def dy(fns, o):\n",
-    "    \"\"\"execute function f in fns on o, returning a yaml block representing the test\"\"\"\n",
-    "    r = {\n",
-    "        \"in\": o.as_dict(),\n",
-    "        \"out\": {f.__name__: as_str(f(o)) for f in fns}\n",
-    "    }\n",
-    "    print(yaml.dump(filter_dict({o.type._value: {\"-\": r}})).replace(\"'-':\",\"-\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table>\n",
-       "<tbody>\n",
-       "<tr><td>check</td><td>hgvs_orig                              </td><td>sequence_id                              </td><td>sequence_id_normalized                   </td><td>hgvs_normalized                    </td></tr>\n",
-       "<tr><td>✔    </td><td>NC_000013.11:g.32936732_32936733del    </td><td>ga4gh:VA.kYyJV-7Lb4fZf-YqHu10cYtx9gIXjdcy</td><td>ga4gh:VA.7ahP-UdJqNPSEE-uNrU0ZGmds4l_-KpV</td><td>NC_000013.11:g.32936732_32936733del</td></tr>\n",
-       "<tr><td>✔    </td><td>NC_000013.11:g.32936732_32936737del    </td><td>ga4gh:VA.9W6Jz2q2qjbGApLum_VDqlkXemmvcwXi</td><td>ga4gh:VA.TaMm-xIwFH1p7O4Wp9gWOLMIR65LgUmf</td><td>NC_000013.11:g.32936732_32936737del</td></tr>\n",
-       "<tr><td>✘    </td><td>NC_000013.11:g.32936732_32936733insC   </td><td>ga4gh:VA.8wBFNOtRXN_nLXl7RuegLBFsVjIXx-F3</td><td>ga4gh:VA.qzQBN8ZdKnE1tpD_7_VTalAVwipUriZ3</td><td>NC_000013.11:g.32936733dup         </td></tr>\n",
-       "<tr><td>✘    </td><td>NC_000013.11:g.32936732_32936733delinsC</td><td>ga4gh:VA.I5brmWPyNXAs40tBrm1j3Kq8XRMwiejd</td><td>ga4gh:VA._eer8nWJENP2nbbWPBb732GnqCMHu0eG</td><td>NC_000013.11:g.32936733del         </td></tr>\n",
-       "<tr><td>✘    </td><td>NC_000013.11:g.32936732_32936735delinsC</td><td>ga4gh:VA.Uprg7LRIsxG0E115oq0dx2YVC2eN7uBO</td><td>ga4gh:VA.Ecj7hDMT7mRzGjlIYzfPTlhblgAu8b8p</td><td>NC_000013.11:g.32936733_32936735del</td></tr>\n",
-       "<tr><td>✔    </td><td>NC_000013.11:g.32936732C&gt;G             </td><td>ga4gh:VA.hMfrqZuECxo2yyGLltnim_q71QDkK-HR</td><td>ga4gh:VA.hMfrqZuECxo2yyGLltnim_q71QDkK-HR</td><td>NC_000013.11:g.32936732C&gt;G         </td></tr>\n",
-       "<tr><td>✔    </td><td>NM_015102.3:n.2802C&gt;T                  </td><td>ga4gh:VA.tqiPzREp-I9ZCQghRbhuN5M9Vl-EiwQA</td><td>ga4gh:VA.tqiPzREp-I9ZCQghRbhuN5M9Vl-EiwQA</td><td>NM_015102.3:n.2802C&gt;T              </td></tr>\n",
-       "<tr><td>✔    </td><td>NC_000013.10:g.32331094_32331095dup    </td><td>ga4gh:VA.jLiYl2hu82a2xPBGqxUS31eD_ZQ0QSHw</td><td>ga4gh:VA.OSLHYPUEUo2qI9nyX2LvI0cwc-BCkZau</td><td>NC_000013.10:g.32331094_32331095dup</td></tr>\n",
-       "<tr><td>✘    </td><td>NC_000013.10:g.32331092_32331093insTA  </td><td>ga4gh:VA.PiDvexGcIBmp99C4SP7JWzhqz1Fp_TBR</td><td>ga4gh:VA.OSLHYPUEUo2qI9nyX2LvI0cwc-BCkZau</td><td>NC_000013.10:g.32331094_32331095dup</td></tr>\n",
-       "</tbody>\n",
-       "</table>"
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "/Users/kxk102/Documents/ga4gh/vrs-python/venv/3.10/lib/python3.10/site-packages/python_jsonschema_objects/__init__.py:49: UserWarning: Schema version http://json-schema.org/draft-07/schema not recognized. Some keywords and features may not be supported.\n",
+            "  warnings.warn(\n"
+          ]
+        }
       ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
+      "source": [
+        "from ga4gh.core import ga4gh_identify\n",
+        "from ga4gh.vrs import models\n",
+        "from ga4gh.vrs.dataproxy import SeqRepoRESTDataProxy\n",
+        "from ga4gh.vrs.extras.translator import Translator\n",
+        "from biocommons.seqrepo import SeqRepo\n",
+        "from IPython.display import HTML, display"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Translate an expression manually\n",
+        "\n",
+        "First, we'll translate NC_000019.10:g.44908822C>T to VR manually to see the evolution of the process. "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# We'll translate this expression to VR:\n",
+        "hgvs_expr = \"\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'type': 'Allele',\n",
+              " 'location': {'type': 'SequenceLocation',\n",
+              "  'sequence_id': 'refseq:NC_000013.11',\n",
+              "  'interval': {'type': 'SequenceInterval',\n",
+              "   'start': {'type': 'Number', 'value': 32936731},\n",
+              "   'end': {'type': 'Number', 'value': 32936732}}},\n",
+              " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
+            ]
+          },
+          "execution_count": 3,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "allele = models.Allele(\n",
+        "    location = models.SequenceLocation(\n",
+        "        sequence_id = \"refseq:NC_000013.11\",\n",
+        "        interval = models.SequenceInterval(\n",
+        "            start = models.Number(value=32936731, type=\"Number\"),\n",
+        "            end = models.Number(value=32936732, type=\"Number\"),\n",
+        "            type=\"SequenceInterval\"\n",
+        "        ),\n",
+        "        type=\"SequenceLocation\"\n",
+        "    ),\n",
+        "    state = models.SequenceExpression(\n",
+        "        sequence = \"C\",\n",
+        "        type=\"LiteralSequenceExpression\"\n",
+        "    ),\n",
+        "    type=\"Allele\"\n",
+        ")\n",
+        "\n",
+        "allele.as_dict()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<div class=\"alert alert-success\">\n",
+        "    👍 The above message is a valid VR message. VR requires that\n",
+        "    sequence identifiers use CURIE syntax with a namespace from identifiers.org and\n",
+        "    that locations are specified with interbase coordinates. Using sequence digests\n",
+        "    is NOT required.\n",
+        "    </div>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Replace the RefSeq sequence with a GA4GH sequence id\n",
+        "\n",
+        "In order to use the computed identifier mechanism in VR, the sequence_id MUST use\n",
+        "GA4GH computed sequence identifiers. \n",
+        "\n",
+        "Implementations choose how to provide sequence and sequence accession services"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT'"
+            ]
+          },
+          "execution_count": 4,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "seqrepo_rest_service_url = \"https://services.genomicmedlab.org/seqrepo\"\n",
+        "dp = SeqRepoRESTDataProxy(base_url=seqrepo_rest_service_url)\n",
+        "\n",
+        "# In general, one identifier may be related to many others in another namespace\n",
+        "# Therefore, translate_sequence_identifier() returns a list.\n",
+        "# Because there will be only 1 ga4gh sequence digest, we choose the first\n",
+        "# and then replace the sequence id in allele.location.\n",
+        "\n",
+        "refseq_ir = str(allele.location.sequence_id)\n",
+        "ga4gh_ir = dp.translate_sequence_identifier(refseq_ir, \"ga4gh\")[0]\n",
+        "ga4gh_ir"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'type': 'Allele',\n",
+              " 'location': {'type': 'SequenceLocation',\n",
+              "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
+              "  'interval': {'type': 'SequenceInterval',\n",
+              "   'start': {'type': 'Number', 'value': 32936731},\n",
+              "   'end': {'type': 'Number', 'value': 32936732}}},\n",
+              " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
+            ]
+          },
+          "execution_count": 5,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Now, simply replace the identifier with the GA4GH identifier\n",
+        "allele.location.sequence_id = ga4gh_ir\n",
+        "allele.as_dict()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Computed Identifiers (optional)\n",
+        "\n",
+        "ga4gh_identify() serializes the object and computes the identifier\n",
+        "(See ga4gh_serialize and ga4gh_digest for details)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'_id': 'ga4gh:VA.DkZLLMnwoH6zIncSRh2c05nzCNLdTqHl',\n",
+              " 'type': 'Allele',\n",
+              " 'location': {'type': 'SequenceLocation',\n",
+              "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
+              "  'interval': {'type': 'SequenceInterval',\n",
+              "   'start': {'type': 'Number', 'value': 32936731},\n",
+              "   'end': {'type': 'Number', 'value': 32936732}}},\n",
+              " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'C'}}"
+            ]
+          },
+          "execution_count": 6,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "allele._id = ga4gh_identify(allele)\n",
+        "allele.as_dict()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Using ga4gh.vrs.extras.translator\n",
+        "\n",
+        "The VR Translator imports HGVS, SPDI, Beacon, and VCF formats, and appropriate handles more complex cases than shown above.\n",
+        "\n",
+        "By default, the translator translates HGVS reference sequences to GA4GH sequence digest identifiers and adds identifiers to the resulting Allele objects."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 7,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "tlr = Translator(data_proxy=dp)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### HGVS → VR"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "{'_id': 'ga4gh:VA.hMfrqZuECxo2yyGLltnim_q71QDkK-HR',\n",
+              " 'type': 'Allele',\n",
+              " 'location': {'type': 'SequenceLocation',\n",
+              "  'sequence_id': 'ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',\n",
+              "  'interval': {'type': 'SequenceInterval',\n",
+              "   'start': {'type': 'Number', 'value': 32936731},\n",
+              "   'end': {'type': 'Number', 'value': 32936732}}},\n",
+              " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'G'}}"
+            ]
+          },
+          "execution_count": 8,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "hgvs_expr1 = \"NC_000013.11:g.32936732C>G\"\n",
+        "allele1 = tlr.translate_from(hgvs_expr1,'hgvs')\n",
+        "allele1.as_dict()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### VR → HGVS\n",
+        "\n",
+        "Because a GA4GH sequence identifier may have many aliases, each VR Allele\n",
+        "may be expressed as multiple HGVS expressions. For this reason, `translate_to(allele, \"hgvs\")` returns\n",
+        "a *list* of HGVS expressions, optionally limited to aliases from a specified namespace."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The postgres default port of 5432 is blocked outbound by binder and potentially other institutions. To circumvent users having to install UTA themselves we created a rest data proxy for variation normalizer for the to_hgvs endpoint."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 9,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from ga4gh.vrs.extras.variation_normalizer_rest_dp import VariationNormalizerRESTDataProxy\n",
+        "vnorm = VariationNormalizerRESTDataProxy()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['NC_000013.11:g.32936732=']"
+            ]
+          },
+          "execution_count": 10,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# tlr.translate_to(allele, \"hgvs\")\n",
+        "vnorm.to_hgvs(allele)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "['NC_000013.11:g.32936732=']"
+            ]
+          },
+          "execution_count": 11,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# Most commonly, we'll want expressions from a well-known authority like RefSeq\n",
+        "# Again, there might in general be multiple `refseq` expressions\n",
+        "# tlr._to_hgvs(allele, \"refseq\")\n",
+        "vnorm.to_hgvs(allele, \"refseq\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "[]"
+            ]
+          },
+          "execution_count": 12,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "# GRC namespaces is handled as a special case: Because aliases are shared \n",
+        "# between GRCh releases, they're shown only on request\n",
+        "# tlr._to_hgvs(allele, \"GRCh38\")\n",
+        "vnorm.to_hgvs(allele, \"GRCh38\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "import yaml\n",
+        "def filter_dict(d):\n",
+        "    try:\n",
+        "        return {k: filter_dict(d[k])\n",
+        "                for k in d\n",
+        "                if not k.startswith(\"_\")}\n",
+        "    except:\n",
+        "        return d\n",
+        "def as_str(s):\n",
+        "    return s if isinstance(s, str) else s.decode()\n",
+        "def dj(o):\n",
+        "    \"\"\"print VR object as pretty formated json\"\"\"\n",
+        "    print(json.dumps(filter_dict(o.as_dict()), indent=2, sort_keys=True))\n",
+        "def dy(fns, o):\n",
+        "    \"\"\"execute function f in fns on o, returning a yaml block representing the test\"\"\"\n",
+        "    r = {\n",
+        "        \"in\": o.as_dict(),\n",
+        "        \"out\": {f.__name__: as_str(f(o)) for f in fns}\n",
+        "    }\n",
+        "    print(yaml.dump(filter_dict({o.type._value: {\"-\": r}})).replace(\"'-':\",\"-\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 14,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<table>\n",
+              "<tbody>\n",
+              "<tr><td>check</td><td>hgvs_orig                              </td><td>sequence_id                              </td><td>sequence_id_normalized                   </td><td>hgvs_normalized                    </td></tr>\n",
+              "<tr><td>✔    </td><td>NC_000013.11:g.32936732_32936733del    </td><td>ga4gh:VA.kYyJV-7Lb4fZf-YqHu10cYtx9gIXjdcy</td><td>ga4gh:VA.7ahP-UdJqNPSEE-uNrU0ZGmds4l_-KpV</td><td>NC_000013.11:g.32936732_32936733del</td></tr>\n",
+              "<tr><td>✔    </td><td>NC_000013.11:g.32936732_32936737del    </td><td>ga4gh:VA.9W6Jz2q2qjbGApLum_VDqlkXemmvcwXi</td><td>ga4gh:VA.TaMm-xIwFH1p7O4Wp9gWOLMIR65LgUmf</td><td>NC_000013.11:g.32936732_32936737del</td></tr>\n",
+              "<tr><td>✘    </td><td>NC_000013.11:g.32936732_32936733insC   </td><td>ga4gh:VA.8wBFNOtRXN_nLXl7RuegLBFsVjIXx-F3</td><td>ga4gh:VA.qzQBN8ZdKnE1tpD_7_VTalAVwipUriZ3</td><td>NC_000013.11:g.32936733dup         </td></tr>\n",
+              "<tr><td>✘    </td><td>NC_000013.11:g.32936732_32936733delinsC</td><td>ga4gh:VA.I5brmWPyNXAs40tBrm1j3Kq8XRMwiejd</td><td>ga4gh:VA._eer8nWJENP2nbbWPBb732GnqCMHu0eG</td><td>NC_000013.11:g.32936733del         </td></tr>\n",
+              "<tr><td>✘    </td><td>NC_000013.11:g.32936732_32936735delinsC</td><td>ga4gh:VA.Uprg7LRIsxG0E115oq0dx2YVC2eN7uBO</td><td>ga4gh:VA.Ecj7hDMT7mRzGjlIYzfPTlhblgAu8b8p</td><td>NC_000013.11:g.32936733_32936735del</td></tr>\n",
+              "<tr><td>✔    </td><td>NC_000013.11:g.32936732C&gt;G             </td><td>ga4gh:VA.hMfrqZuECxo2yyGLltnim_q71QDkK-HR</td><td>ga4gh:VA.hMfrqZuECxo2yyGLltnim_q71QDkK-HR</td><td>NC_000013.11:g.32936732C&gt;G         </td></tr>\n",
+              "<tr><td>✔    </td><td>NM_015102.3:n.2802C&gt;T                  </td><td>ga4gh:VA.tqiPzREp-I9ZCQghRbhuN5M9Vl-EiwQA</td><td>ga4gh:VA.tqiPzREp-I9ZCQghRbhuN5M9Vl-EiwQA</td><td>NM_015102.3:n.2802C&gt;T              </td></tr>\n",
+              "<tr><td>✔    </td><td>NC_000013.10:g.32331094_32331095dup    </td><td>ga4gh:VA.jLiYl2hu82a2xPBGqxUS31eD_ZQ0QSHw</td><td>ga4gh:VA.OSLHYPUEUo2qI9nyX2LvI0cwc-BCkZau</td><td>NC_000013.10:g.32331094_32331095dup</td></tr>\n",
+              "<tr><td>✘    </td><td>NC_000013.10:g.32331092_32331093insTA  </td><td>ga4gh:VA.PiDvexGcIBmp99C4SP7JWzhqz1Fp_TBR</td><td>ga4gh:VA.OSLHYPUEUo2qI9nyX2LvI0cwc-BCkZau</td><td>NC_000013.10:g.32331094_32331095dup</td></tr>\n",
+              "</tbody>\n",
+              "</table>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "import tabulate\n",
+        "from ga4gh.vrs.normalize import normalize\n",
+        "from ga4gh.vrs.extras.variation_normalizer_rest_dp import VariationNormalizerRESTDataProxy\n",
+        "vnorm = VariationNormalizerRESTDataProxy()\n",
+        "\n",
+        "#The postgres default port of 5432 is blocked outbound by binder and potentially other institutions. \n",
+        "#To circumvent users having to install UTA themsleves we created a rest data proxy for variation normalizer for the to_hgvs endpoint.\n",
+        "\n",
+        "# todo: this example should get changed to use normalized hgvs_g as input.\n",
+        "tlr.normalize = False\n",
+        "\n",
+        "# Round-trip test: HGVS → VR Allele → HGVS[]\n",
+        "header = \"check hgvs_orig sequence_id sequence_id_normalized hgvs_normalized\".split()\n",
+        "table = [header]\n",
+        "for hgvs_expr in (\n",
+        "    \"NC_000013.11:g.32936732_32936733del\",\n",
+        "    \"NC_000013.11:g.32936732_32936737del\",\n",
+        "    \"NC_000013.11:g.32936732_32936733insC\",\n",
+        "    \"NC_000013.11:g.32936732_32936733delinsC\",\n",
+        "    \"NC_000013.11:g.32936732_32936735delinsC\",\n",
+        "    \"NC_000013.11:g.32936732C>G\",\n",
+        "    \"NM_015102.3:n.2802C>T\",\n",
+        "    \"NC_000013.10:g.32331094_32331095dup\",\n",
+        "    \"NC_000013.10:g.32331092_32331093insTA\"\n",
+        "):\n",
+        "    a = tlr.translate_from(hgvs_expr, \"hgvs\")\n",
+        "    #he = tlr.translate_to(a, \"hgvs\")\n",
+        "    he = vnorm.to_hgvs(a)\n",
+        "    chk = \"✔\" if hgvs_expr in he else \"✘\"\n",
+        "    #print(f\"{chk} {hgvs_expr}\\n  → {ga4gh_identify(a)}\\n  → {he}\")\n",
+        "    a_norm = normalize(a, dp)\n",
+        "    row = [chk, hgvs_expr, ga4gh_identify(a), ga4gh_identify(a_norm), he[0] ]\n",
+        "    table += [row]\n",
+        "display(HTML(tabulate.tabulate(table, tablefmt='html')))"
+      ]
     }
-   ],
-   "source": [
-    "import tabulate\n",
-    "from ga4gh.vrs.normalize import normalize\n",
-    "from ga4gh.vrs.extras.variation_normalizer_rest_dp import VariationNormalizerRESTDataProxy\n",
-    "vnorm = VariationNormalizerRESTDataProxy()\n",
-    "\n",
-    "#The postgres default port of 5432 is blocked outbound by binder and potentially other institutions. \n",
-    "#To circumvent users having to install UTA themsleves we created a rest data proxy for variation normalizer for the to_hgvs endpoint.\n",
-    "\n",
-    "# todo: this example should get changed to use normalized hgvs_g as input.\n",
-    "tlr.normalize = False\n",
-    "\n",
-    "# Round-trip test: HGVS → VR Allele → HGVS[]\n",
-    "header = \"check hgvs_orig sequence_id sequence_id_normalized hgvs_normalized\".split()\n",
-    "table = [header]\n",
-    "for hgvs_expr in (\n",
-    "    \"NC_000013.11:g.32936732_32936733del\",\n",
-    "    \"NC_000013.11:g.32936732_32936737del\",\n",
-    "    \"NC_000013.11:g.32936732_32936733insC\",\n",
-    "    \"NC_000013.11:g.32936732_32936733delinsC\",\n",
-    "    \"NC_000013.11:g.32936732_32936735delinsC\",\n",
-    "    \"NC_000013.11:g.32936732C>G\",\n",
-    "    \"NM_015102.3:n.2802C>T\",\n",
-    "    \"NC_000013.10:g.32331094_32331095dup\",\n",
-    "    \"NC_000013.10:g.32331092_32331093insTA\"\n",
-    "):\n",
-    "    a = tlr.translate_from(hgvs_expr, \"hgvs\")\n",
-    "    #he = tlr.translate_to(a, \"hgvs\")\n",
-    "    he = vnorm.to_hgvs(a)\n",
-    "    chk = \"✔\" if hgvs_expr in he else \"✘\"\n",
-    "    #print(f\"{chk} {hgvs_expr}\\n  → {ga4gh_identify(a)}\\n  → {he}\")\n",
-    "    a_norm = normalize(a, dp)\n",
-    "    row = [chk, hgvs_expr, ga4gh_identify(a), ga4gh_identify(a_norm), he[0] ]\n",
-    "    table += [row]\n",
-    "display(HTML(tabulate.tabulate(table, tablefmt='html')))"
-   ]
-  }
- ],
- "metadata": {
-  "interpreter": {
-   "hash": "e3010397f827d762dd71da5e8c08c9d1e15db6c6cbe60e8a92c1e943686ce175"
+  ],
+  "metadata": {
+    "interpreter": {
+      "hash": "e3010397f827d762dd71da5e8c08c9d1e15db6c6cbe60e8a92c1e943686ce175"
+    },
+    "kernelspec": {
+      "display_name": "vrs-python",
+      "language": "python",
+      "name": "vrs-python"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.12"
+    }
   },
-  "kernelspec": {
-   "display_name": "vrs-python",
-   "language": "python",
-   "name": "vrs-python"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.12"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -109,15 +109,15 @@ class Translator:
     def _from_beacon(self, beacon_expr, assembly_name=None):
         """Parse beacon expression into VRS Allele
 
-        #>>> a = tlr.from_beacon("13 : 32936732 G > C")
+        #>>> a = tlr.from_beacon("19 : 44908822 C > T")
         #>>> a.as_dict()
         {'location': {'interval': {
-           'end': {'value': 32936732, 'type': Number},
-           'start': {'value': 32936731, 'type': Number},
+           'end': {'value': 44908822, 'type': Number},
+           'start': {'value': 44908821, 'type': Number},
            'type': 'SequenceInterval'},
-          'sequence_id': 'GRCh38:13 ',
+          'sequence_id': 'GRCh38:19',
           'type': 'SequenceLocation'},
-         'state': {'sequence': 'C', 'type': 'LiteralSequenceExpression'},
+         'state': {'sequence': 'T', 'type': 'LiteralSequenceExpression'},
          'type': 'Allele'}
 
         """
@@ -535,8 +535,8 @@ if __name__ == "__main__":
     expressions = [
         "bogus",
         "1-55516888-G-GA",
-        "13 : 32936732 G > C",
-        "NC_000013.11:g.32936732G>C",
+        "19 : 44908822 C > T",
+        "NC_000019.10:g.44908822C>T",
         "NM_000551.3:21:1:T", {
             "location": {
                 "interval": {

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -43,7 +43,7 @@ class Translator:
     """
 
     beacon_re = re.compile(r"(?P<chr>[^-]+)\s*:\s*(?P<pos>\d+)\s*(?P<ref>\w+)\s*>\s*(?P<alt>\w+)")
-    gnomad_re = re.compile(r"(?P<chr>[^-]+)-(?P<pos>\d+)-(?P<ref>(?i)[ACGTN]+)-(?P<alt>(?i)[ACGTN]+|\*|\.)")
+    gnomad_re = re.compile(r"(?P<chr>[^-]+)-(?P<pos>\d+)-(?P<ref>[ACGTN]+)-(?P<alt>[ACGTN]+|\*|\.)", re.IGNORECASE)
     hgvs_re = re.compile(r"[^:]+:[cgnpr]\.")
     spdi_re = re.compile(r"(?P<ac>[^:]+):(?P<pos>\d+):(?P<del_len_or_seq>\w*):(?P<ins_seq>\w*)")
 
@@ -196,7 +196,7 @@ class Translator:
 
         # validation checks
         valid_ref_seq, err_msg = self._is_valid_ref_seq(sequence_id, start, end, ref)
-        if not valid_ref_seq and require_validation:
+        if require_validation and not valid_ref_seq:
             raise ValidationError(err_msg)
 
         interval = models.SequenceInterval(start=models.Number(value=start),

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -16,7 +16,7 @@ from biocommons.seqrepo import SeqRepo
 from python_jsonschema_objects import ValidationError
 
 from ga4gh.vrs.dataproxy import SeqRepoDataProxy, SeqRepoRESTDataProxy
-from ga4gh.vrs.extras.translator import Translator
+from ga4gh.vrs.extras.translator import Translator, ValidationError as TranslatorValidationError
 
 
 
@@ -196,7 +196,7 @@ class VCFAnnotator:
         """
         try:
             vrs_obj = self.tlr._from_gnomad(vcf_coords, assembly_name=assembly)
-        except ValidationError as e:
+        except (ValidationError, TranslatorValidationError) as e:
             _logger.error("ValidationError when translating %s from gnomad: %s", vcf_coords, str(e))
         except KeyError as e:
             _logger.error("KeyError when translating %s from gnomad: %s", vcf_coords, str(e))

--- a/tests/extras/cassettes/test_annotate_vcf.yaml
+++ b/tests/extras/cassettes/test_annotate_vcf.yaml
@@ -11,6 +11,36 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=82663&end=82664
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:40 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
     uri: http://localhost:5000/seqrepo/1/metadata/GRCh38:chr19
   response:
     body:
@@ -35,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -77,7 +107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -107,7 +137,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=82663&end=82664
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -149,7 +209,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -179,7 +239,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -209,7 +269,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -239,7 +299,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -269,7 +329,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -299,7 +359,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=284349&end=284351
+  response:
+    body:
+      string: CA
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -341,7 +431,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -371,7 +461,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=284349&end=284351
+  response:
+    body:
+      string: CA
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -413,7 +533,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -443,7 +563,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -473,7 +593,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -503,7 +623,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -533,7 +653,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -563,7 +683,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -593,7 +713,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -623,7 +743,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -653,7 +773,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -683,7 +803,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -713,7 +833,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -743,7 +863,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -773,7 +893,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -803,7 +923,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -833,7 +953,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -863,7 +983,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -893,7 +1013,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -923,7 +1043,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -953,7 +1073,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -983,7 +1103,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1013,7 +1133,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=289463&end=289464
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1055,7 +1205,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1085,7 +1235,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=289463&end=289464
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1127,7 +1307,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1157,7 +1337,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1187,7 +1367,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1217,7 +1397,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1247,7 +1427,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1277,7 +1457,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:25 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1307,7 +1487,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1337,7 +1517,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=28946399&end=28946400
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1379,7 +1589,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1409,7 +1619,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=28946399&end=28946400
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1451,7 +1691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1481,7 +1721,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1511,7 +1751,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1541,7 +1781,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1571,7 +1811,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:40 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1601,7 +1841,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=490413&end=490416
+  response:
+    body:
+      string: ACT
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1643,7 +1913,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1673,7 +1943,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=490413&end=490416
+  response:
+    body:
+      string: ACT
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1715,7 +2015,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1745,7 +2045,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1775,7 +2075,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1805,7 +2105,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1835,7 +2135,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1865,7 +2165,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=54220023&end=54220024
+  response:
+    body:
+      string: G
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1907,7 +2237,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1937,7 +2267,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=54220023&end=54220024
+  response:
+    body:
+      string: G
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -1979,7 +2339,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2009,7 +2369,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2039,7 +2399,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2069,7 +2429,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2099,7 +2459,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2129,7 +2489,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=82663&end=82664
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2169,7 +2559,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2209,7 +2599,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2239,7 +2629,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=82663&end=82664
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2279,7 +2699,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2309,7 +2729,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2339,7 +2759,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2369,7 +2789,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2399,7 +2819,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2429,7 +2849,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=284349&end=284351
+  response:
+    body:
+      string: CA
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2469,7 +2919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2499,7 +2949,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=284349&end=284351
+  response:
+    body:
+      string: CA
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2539,7 +3019,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2569,7 +3049,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2599,7 +3079,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2629,7 +3109,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:41 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2659,7 +3139,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2689,7 +3169,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:26 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2719,7 +3199,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2749,7 +3229,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2779,7 +3259,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2809,7 +3289,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2839,7 +3319,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2869,7 +3349,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2899,7 +3379,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2929,7 +3409,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2959,7 +3439,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -2989,7 +3469,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3019,7 +3499,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3049,7 +3529,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3079,7 +3559,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3109,7 +3589,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3139,7 +3619,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=289463&end=289464
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3179,7 +3689,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3209,7 +3719,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=289463&end=289464
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3249,7 +3789,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3279,7 +3819,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3309,7 +3849,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3339,7 +3879,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3369,7 +3909,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3399,7 +3939,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3429,7 +3969,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3459,7 +3999,97 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=28946399&end=28946400
+  response:
+    body:
+      string: A
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:43 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=28946399&end=28946400
+  response:
+    body:
+      string: A
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:43 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=490413&end=490416
+  response:
+    body:
+      string: ACT
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3499,447 +4129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946399&end=28946400
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946398&end=28946399
-  response:
-    body:
-      string: G
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946400&end=28946401
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946400&end=28946401
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946399&end=28946399
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946400&end=28946400
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:27 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T05:11:23Z\",\n  \"aliases\": [\n    \"GRCh37:19\",\n
-        \   \"GRCh37:chr19\",\n    \"GRCh37.p10:19\",\n    \"GRCh37.p10:chr19\",\n
-        \   \"GRCh37.p11:19\",\n    \"GRCh37.p11:chr19\",\n    \"GRCh37.p12:19\",\n
-        \   \"GRCh37.p12:chr19\",\n    \"GRCh37.p13:19\",\n    \"GRCh37.p13:chr19\",\n
-        \   \"GRCh37.p2:19\",\n    \"GRCh37.p2:chr19\",\n    \"GRCh37.p5:19\",\n    \"GRCh37.p5:chr19\",\n
-        \   \"GRCh37.p9:19\",\n    \"GRCh37.p9:chr19\",\n    \"MD5:1aacd71f30db8e561810913e0b72636d\",\n
-        \   \"NCBI:NC_000019.9\",\n    \"refseq:NC_000019.9\",\n    \"SEGUID:DbxQSFOgAziBmfglM/SHER/3UoI\",\n
-        \   \"SHA1:0dbc504853a003388199f82533f487111ff75282\",\n    \"VMC:GS_ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n
-        \   \"sha512t24u:ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n    \"ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n
-        \   \"hs37-1kg:19\",\n    \"hs37d5:19\"\n  ],\n  \"alphabet\": \"ACGNT\",\n
-        \ \"length\": 59128983\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '820'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946399&end=28946400
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946398&end=28946399
-  response:
-    body:
-      string: G
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946400&end=28946401
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946400&end=28946401
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946399&end=28946399
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=28946400&end=28946400
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T05:11:23Z\",\n  \"aliases\": [\n    \"GRCh37:19\",\n
-        \   \"GRCh37:chr19\",\n    \"GRCh37.p10:19\",\n    \"GRCh37.p10:chr19\",\n
-        \   \"GRCh37.p11:19\",\n    \"GRCh37.p11:chr19\",\n    \"GRCh37.p12:19\",\n
-        \   \"GRCh37.p12:chr19\",\n    \"GRCh37.p13:19\",\n    \"GRCh37.p13:chr19\",\n
-        \   \"GRCh37.p2:19\",\n    \"GRCh37.p2:chr19\",\n    \"GRCh37.p5:19\",\n    \"GRCh37.p5:chr19\",\n
-        \   \"GRCh37.p9:19\",\n    \"GRCh37.p9:chr19\",\n    \"MD5:1aacd71f30db8e561810913e0b72636d\",\n
-        \   \"NCBI:NC_000019.9\",\n    \"refseq:NC_000019.9\",\n    \"SEGUID:DbxQSFOgAziBmfglM/SHER/3UoI\",\n
-        \   \"SHA1:0dbc504853a003388199f82533f487111ff75282\",\n    \"VMC:GS_ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n
-        \   \"sha512t24u:ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n    \"ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n
-        \   \"hs37-1kg:19\",\n    \"hs37d5:19\"\n  ],\n  \"alphabet\": \"ACGNT\",\n
-        \ \"length\": 59128983\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '820'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -3969,7 +4159,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=490413&end=490416
+  response:
+    body:
+      string: ACT
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4009,7 +4229,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4039,7 +4259,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4069,7 +4289,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4099,7 +4319,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4129,7 +4349,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4159,7 +4379,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4177,47 +4397,7 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T05:11:23Z\",\n  \"aliases\": [\n    \"GRCh37:19\",\n
-        \   \"GRCh37:chr19\",\n    \"GRCh37.p10:19\",\n    \"GRCh37.p10:chr19\",\n
-        \   \"GRCh37.p11:19\",\n    \"GRCh37.p11:chr19\",\n    \"GRCh37.p12:19\",\n
-        \   \"GRCh37.p12:chr19\",\n    \"GRCh37.p13:19\",\n    \"GRCh37.p13:chr19\",\n
-        \   \"GRCh37.p2:19\",\n    \"GRCh37.p2:chr19\",\n    \"GRCh37.p5:19\",\n    \"GRCh37.p5:chr19\",\n
-        \   \"GRCh37.p9:19\",\n    \"GRCh37.p9:chr19\",\n    \"MD5:1aacd71f30db8e561810913e0b72636d\",\n
-        \   \"NCBI:NC_000019.9\",\n    \"refseq:NC_000019.9\",\n    \"SEGUID:DbxQSFOgAziBmfglM/SHER/3UoI\",\n
-        \   \"SHA1:0dbc504853a003388199f82533f487111ff75282\",\n    \"VMC:GS_ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n
-        \   \"sha512t24u:ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n    \"ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n
-        \   \"hs37-1kg:19\",\n    \"hs37d5:19\"\n  ],\n  \"alphabet\": \"ACGNT\",\n
-        \ \"length\": 59128983\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '820'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220023&end=54220024
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=54220023&end=54220024
   response:
     body:
       string: T
@@ -4229,7 +4409,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4247,7 +4427,7 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220022&end=54220023
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh37:chr19?start=54220023&end=54220024
   response:
     body:
       string: T
@@ -4259,7 +4439,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4277,10 +4457,10 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220022&end=54220023
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=82663&end=82664
   response:
     body:
-      string: T
+      string: C
     headers:
       Connection:
       - close
@@ -4289,377 +4469,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220024&end=54220025
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220024&end=54220025
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220023&end=54220023
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220024&end=54220024
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T05:11:23Z\",\n  \"aliases\": [\n    \"GRCh37:19\",\n
-        \   \"GRCh37:chr19\",\n    \"GRCh37.p10:19\",\n    \"GRCh37.p10:chr19\",\n
-        \   \"GRCh37.p11:19\",\n    \"GRCh37.p11:chr19\",\n    \"GRCh37.p12:19\",\n
-        \   \"GRCh37.p12:chr19\",\n    \"GRCh37.p13:19\",\n    \"GRCh37.p13:chr19\",\n
-        \   \"GRCh37.p2:19\",\n    \"GRCh37.p2:chr19\",\n    \"GRCh37.p5:19\",\n    \"GRCh37.p5:chr19\",\n
-        \   \"GRCh37.p9:19\",\n    \"GRCh37.p9:chr19\",\n    \"MD5:1aacd71f30db8e561810913e0b72636d\",\n
-        \   \"NCBI:NC_000019.9\",\n    \"refseq:NC_000019.9\",\n    \"SEGUID:DbxQSFOgAziBmfglM/SHER/3UoI\",\n
-        \   \"SHA1:0dbc504853a003388199f82533f487111ff75282\",\n    \"VMC:GS_ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n
-        \   \"sha512t24u:ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n    \"ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX\",\n
-        \   \"hs37-1kg:19\",\n    \"hs37d5:19\"\n  ],\n  \"alphabet\": \"ACGNT\",\n
-        \ \"length\": 59128983\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '820'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220023&end=54220024
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220022&end=54220023
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220022&end=54220023
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220024&end=54220025
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220024&end=54220025
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220023&end=54220023
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.ItRDD47aMoioDCNW_occY5fWKZBKlxCX?start=54220024&end=54220024
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4701,7 +4511,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4731,7 +4541,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=82663&end=82664
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4773,7 +4613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4803,7 +4643,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:28 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4833,7 +4673,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4863,7 +4703,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4893,7 +4733,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4923,7 +4763,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=284349&end=284351
+  response:
+    body:
+      string: CA
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4965,7 +4835,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -4995,7 +4865,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=284349&end=284351
+  response:
+    body:
+      string: CA
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5037,7 +4937,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5067,7 +4967,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5097,7 +4997,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5127,7 +5027,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5157,7 +5057,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5187,7 +5087,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5217,7 +5117,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5247,7 +5147,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5277,7 +5177,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:43 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5307,7 +5207,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5337,7 +5237,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5367,7 +5267,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5397,7 +5297,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5427,7 +5327,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5457,7 +5357,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5487,7 +5387,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5517,7 +5417,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5547,7 +5447,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5577,7 +5477,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5607,7 +5507,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5637,7 +5537,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=289463&end=289464
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5679,7 +5609,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5709,7 +5639,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=289463&end=289464
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5751,7 +5711,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5781,7 +5741,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5811,7 +5771,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5841,7 +5801,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5871,7 +5831,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5901,7 +5861,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5931,7 +5891,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -5961,7 +5921,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=28946399&end=28946400
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6003,7 +5993,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6033,7 +6023,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=28946399&end=28946400
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6075,7 +6095,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6105,7 +6125,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6135,7 +6155,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6165,7 +6185,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6195,7 +6215,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6225,7 +6245,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=490413&end=490416
+  response:
+    body:
+      string: ACT
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6267,7 +6317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6297,7 +6347,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=490413&end=490416
+  response:
+    body:
+      string: ACT
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6339,7 +6419,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6369,7 +6449,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6399,7 +6479,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6429,7 +6509,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6459,7 +6539,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6489,7 +6569,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=54220023&end=54220024
+  response:
+    body:
+      string: G
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6531,7 +6641,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6561,7 +6671,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=54220023&end=54220024
+  response:
+    body:
+      string: G
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6603,7 +6743,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6633,7 +6773,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:29 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6663,7 +6803,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6693,7 +6833,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6723,7 +6863,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6753,7 +6893,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=82663&end=82664
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6795,7 +6965,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6825,7 +6995,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:44 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=82663&end=82664
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:44 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6867,7 +7067,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6897,7 +7097,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6927,7 +7127,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6957,7 +7157,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -6987,7 +7187,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7017,7 +7217,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=284349&end=284351
+  response:
+    body:
+      string: CA
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7059,7 +7289,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7089,7 +7319,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=284349&end=284351
+  response:
+    body:
+      string: CA
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '2'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7131,7 +7391,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7161,7 +7421,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7191,7 +7451,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7221,7 +7481,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7251,7 +7511,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7281,7 +7541,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7311,7 +7571,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7341,7 +7601,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7371,7 +7631,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7401,7 +7661,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7431,7 +7691,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7461,7 +7721,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7491,7 +7751,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7521,7 +7781,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7551,7 +7811,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7581,7 +7841,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7611,7 +7871,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7641,7 +7901,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7671,7 +7931,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7701,7 +7961,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7731,7 +7991,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=289463&end=289464
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7773,7 +8063,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7803,7 +8093,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=289463&end=289464
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7845,7 +8165,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7875,7 +8195,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7905,7 +8225,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7935,7 +8255,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7965,7 +8285,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -7995,7 +8315,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8025,7 +8345,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8055,7 +8375,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=28946399&end=28946400
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8097,7 +8447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8127,7 +8477,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=28946399&end=28946400
+  response:
+    body:
+      string: T
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8169,7 +8549,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:30 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8199,7 +8579,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8229,7 +8609,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8259,7 +8639,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8289,7 +8669,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8319,7 +8699,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=490413&end=490416
+  response:
+    body:
+      string: ACT
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8361,7 +8771,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8391,7 +8801,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:45 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=490413&end=490416
+  response:
+    body:
+      string: ACT
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8433,7 +8873,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8463,7 +8903,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8493,7 +8933,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8523,7 +8963,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8553,7 +8993,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8583,7 +9023,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=54220023&end=54220024
+  response:
+    body:
+      string: G
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8625,7 +9095,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8655,7 +9125,37 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:chr19?start=54220023&end=54220024
+  response:
+    body:
+      string: G
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8697,7 +9197,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8727,7 +9227,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8757,7 +9257,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8787,7 +9287,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8817,7 +9317,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -8847,2101 +9347,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=82663&end=82664
-  response:
-    body:
-      string: C
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=82663&end=82664
-  response:
-    body:
-      string: C
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=82662&end=82663
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=82664&end=82665
-  response:
-    body:
-      string: G
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=82663&end=82663
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=82664&end=82664
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284349&end=284351
-  response:
-    body:
-      string: CA
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '2'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284349&end=284351
-  response:
-    body:
-      string: CA
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '2'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284349&end=284350
-  response:
-    body:
-      string: C
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284351&end=284352
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284352&end=284353
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284353&end=284354
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284354&end=284355
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284355&end=284356
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284356&end=284357
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284357&end=284358
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284358&end=284359
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284359&end=284360
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284360&end=284361
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284361&end=284362
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284362&end=284363
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284363&end=284364
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284364&end=284365
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284365&end=284366
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284366&end=284367
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284350&end=284350
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=284351&end=284366
-  response:
-    body:
-      string: AAAAAAAAAAAAAAA
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '15'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:31 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=289463&end=289464
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=289463&end=289464
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=289463&end=289464
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=289464&end=289465
-  response:
-    body:
-      string: C
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=289465&end=289466
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=289466&end=289467
-  response:
-    body:
-      string: G
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=289464&end=289464
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=289464&end=289466
-  response:
-    body:
-      string: CA
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '2'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=28946399&end=28946400
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=28946399&end=28946400
-  response:
-    body:
-      string: T
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=28946398&end=28946399
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=28946400&end=28946401
-  response:
-    body:
-      string: G
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=28946399&end=28946399
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=28946400&end=28946400
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=490413&end=490416
-  response:
-    body:
-      string: ACT
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '3'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=490413&end=490416
-  response:
-    body:
-      string: ACT
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '3'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=490413&end=490414
-  response:
-    body:
-      string: A
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=490416&end=490417
-  response:
-    body:
-      string: G
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=490414&end=490414
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=490416&end=490416
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=54220023&end=54220024
-  response:
-    body:
-      string: G
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
-  response:
-    body:
-      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
-        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
-        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
-        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
-        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
-        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
-        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
-        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
-        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
-        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
-        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
-        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
-        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1035'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=54220023&end=54220024
-  response:
-    body:
-      string: G
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=54220022&end=54220023
-  response:
-    body:
-      string: C
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=54220024&end=54220025
-  response:
-    body:
-      string: C
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '1'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=54220023&end=54220023
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
-      Server:
-      - Werkzeug/2.2.2 Python/3.10.4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.28.1
-    method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=54220024&end=54220024
-  response:
-    body:
-      string: ''
-    headers:
-      Connection:
-      - close
-      Content-Length:
-      - '0'
-      Content-Type:
-      - text/plain; charset=utf-8
-      Date:
-      - Thu, 08 Dec 2022 16:55:32 GMT
+      - Fri, 13 Jan 2023 15:42:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:

--- a/tests/extras/cassettes/test_from_beacon.yaml
+++ b/tests/extras/cassettes/test_from_beacon.yaml
@@ -11,31 +11,31 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/GRCh38:13
+    uri: http://localhost:5000/seqrepo/1/metadata/GRCh38:19
   response:
     body:
-      string: "{\n  \"added\": \"2016-08-27T23:50:14Z\",\n  \"aliases\": [\n    \"GRCh38:13\",\n
-        \   \"GRCh38:chr13\",\n    \"GRCh38.p1:13\",\n    \"GRCh38.p1:chr13\",\n    \"GRCh38.p10:13\",\n
-        \   \"GRCh38.p10:chr13\",\n    \"GRCh38.p11:13\",\n    \"GRCh38.p11:chr13\",\n
-        \   \"GRCh38.p12:13\",\n    \"GRCh38.p12:chr13\",\n    \"GRCh38.p2:13\",\n
-        \   \"GRCh38.p2:chr13\",\n    \"GRCh38.p3:13\",\n    \"GRCh38.p3:chr13\",\n
-        \   \"GRCh38.p4:13\",\n    \"GRCh38.p4:chr13\",\n    \"GRCh38.p5:13\",\n    \"GRCh38.p5:chr13\",\n
-        \   \"GRCh38.p6:13\",\n    \"GRCh38.p6:chr13\",\n    \"GRCh38.p7:13\",\n    \"GRCh38.p7:chr13\",\n
-        \   \"GRCh38.p8:13\",\n    \"GRCh38.p8:chr13\",\n    \"GRCh38.p9:13\",\n    \"GRCh38.p9:chr13\",\n
-        \   \"MD5:a5437debe2ef9c9ef8f3ea2874ae1d82\",\n    \"NCBI:NC_000013.11\",\n
-        \   \"refseq:NC_000013.11\",\n    \"SEGUID:2oDBty0yKV9wHo7gg+Bt+fPgi5o\",\n
-        \   \"SHA1:da80c1b72d32295f701e8ee083e06df9f3e08b9a\",\n    \"VMC:GS__0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n
-        \   \"sha512t24u:_0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n    \"ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT\"\n
-        \ ],\n  \"alphabet\": \"ACGKNTY\",\n  \"length\": 114364328\n}\n"
+      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
+        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
+        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
+        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
+        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
+        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
+        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
+        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
+        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
+        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
+        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
+        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
+        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
     headers:
       Connection:
       - close
       Content-Length:
-      - '1002'
+      - '1035'
       Content-Type:
       - application/json
       Date:
-      - Mon, 19 Sep 2022 13:14:12 GMT
+      - Fri, 13 Jan 2023 15:27:53 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:

--- a/tests/extras/cassettes/test_from_gnomad.yaml
+++ b/tests/extras/cassettes/test_from_gnomad.yaml
@@ -23,7 +23,49 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 16 Jan 2023 16:02:46 GMT
+      - Mon, 16 Jan 2023 16:32:42 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/metadata/GRCh38:19
+  response:
+    body:
+      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
+        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
+        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
+        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
+        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
+        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
+        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
+        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
+        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
+        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
+        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
+        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
+        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1035'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 16 Jan 2023 16:32:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -53,7 +95,67 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 16 Jan 2023 16:02:46 GMT
+      - Mon, 16 Jan 2023 16:32:42 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:13?start=32936731&end=32936732
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Mon, 16 Jan 2023 16:32:42 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:13?start=32936731&end=32936732
+  response:
+    body:
+      string: C
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Mon, 16 Jan 2023 16:32:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -95,7 +197,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 16 Jan 2023 16:02:46 GMT
+      - Mon, 16 Jan 2023 16:32:42 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:

--- a/tests/extras/cassettes/test_from_gnomad.yaml
+++ b/tests/extras/cassettes/test_from_gnomad.yaml
@@ -23,7 +23,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Fri, 13 Jan 2023 15:27:53 GMT
+      - Mon, 16 Jan 2023 16:02:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -53,7 +53,49 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Fri, 13 Jan 2023 15:27:53 GMT
+      - Mon, 16 Jan 2023 16:02:46 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/metadata/GRCh38:13
+  response:
+    body:
+      string: "{\n  \"added\": \"2016-08-27T23:50:14Z\",\n  \"aliases\": [\n    \"GRCh38:13\",\n
+        \   \"GRCh38:chr13\",\n    \"GRCh38.p1:13\",\n    \"GRCh38.p1:chr13\",\n    \"GRCh38.p10:13\",\n
+        \   \"GRCh38.p10:chr13\",\n    \"GRCh38.p11:13\",\n    \"GRCh38.p11:chr13\",\n
+        \   \"GRCh38.p12:13\",\n    \"GRCh38.p12:chr13\",\n    \"GRCh38.p2:13\",\n
+        \   \"GRCh38.p2:chr13\",\n    \"GRCh38.p3:13\",\n    \"GRCh38.p3:chr13\",\n
+        \   \"GRCh38.p4:13\",\n    \"GRCh38.p4:chr13\",\n    \"GRCh38.p5:13\",\n    \"GRCh38.p5:chr13\",\n
+        \   \"GRCh38.p6:13\",\n    \"GRCh38.p6:chr13\",\n    \"GRCh38.p7:13\",\n    \"GRCh38.p7:chr13\",\n
+        \   \"GRCh38.p8:13\",\n    \"GRCh38.p8:chr13\",\n    \"GRCh38.p9:13\",\n    \"GRCh38.p9:chr13\",\n
+        \   \"MD5:a5437debe2ef9c9ef8f3ea2874ae1d82\",\n    \"NCBI:NC_000013.11\",\n
+        \   \"refseq:NC_000013.11\",\n    \"SEGUID:2oDBty0yKV9wHo7gg+Bt+fPgi5o\",\n
+        \   \"SHA1:da80c1b72d32295f701e8ee083e06df9f3e08b9a\",\n    \"VMC:GS__0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n
+        \   \"sha512t24u:_0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n    \"ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT\"\n
+        \ ],\n  \"alphabet\": \"ACGKNTY\",\n  \"length\": 114364328\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1002'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 16 Jan 2023 16:02:46 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:

--- a/tests/extras/cassettes/test_from_gnomad.yaml
+++ b/tests/extras/cassettes/test_from_gnomad.yaml
@@ -11,24 +11,24 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:.?start=140753335&end=140753336
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:19?start=44908821&end=44908822
   response:
     body:
-      string: ''
+      string: C
     headers:
       Connection:
       - close
       Content-Length:
-      - '0'
+      - '1'
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Fri, 13 Jan 2023 15:30:59 GMT
+      - Fri, 13 Jan 2023 15:27:53 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
-      code: 404
-      message: NOT FOUND
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -41,10 +41,10 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:7?start=140753335&end=140753336
+    uri: http://localhost:5000/seqrepo/1/sequence/GRCh38:13?start=32936731&end=32936732
   response:
     body:
-      string: A
+      string: C
     headers:
       Connection:
       - close
@@ -53,7 +53,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Fri, 13 Jan 2023 15:30:59 GMT
+      - Fri, 13 Jan 2023 15:27:53 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:

--- a/tests/extras/cassettes/test_from_hgvs.yaml
+++ b/tests/extras/cassettes/test_from_hgvs.yaml
@@ -11,6 +11,48 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
+    uri: http://localhost:5000/seqrepo/1/metadata/refseq:NC_000019.10
+  response:
+    body:
+      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
+        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
+        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
+        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
+        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
+        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
+        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
+        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
+        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
+        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
+        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
+        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
+        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1035'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Jan 2023 15:27:55 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
     uri: http://localhost:5000/seqrepo/1/metadata/refseq:NC_000013.11
   response:
     body:
@@ -35,7 +77,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 19 Sep 2022 13:14:13 GMT
+      - Fri, 13 Jan 2023 15:27:55 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -65,7 +107,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 19 Sep 2022 13:14:14 GMT
+      - Fri, 13 Jan 2023 15:27:55 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:

--- a/tests/extras/cassettes/test_hgvs[NC_000013.11:g.32936732=-expected0].yaml
+++ b/tests/extras/cassettes/test_hgvs[NC_000013.11:g.32936732=-expected0].yaml
@@ -23,7 +23,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 19 Sep 2022 13:14:14 GMT
+      - Fri, 13 Jan 2023 15:28:48 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 19 Sep 2022 13:14:14 GMT
+      - Fri, 13 Jan 2023 15:28:48 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -95,7 +95,49 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 19 Sep 2022 13:14:14 GMT
+      - Fri, 13 Jan 2023 15:28:48 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT
+  response:
+    body:
+      string: "{\n  \"added\": \"2016-08-27T23:50:14Z\",\n  \"aliases\": [\n    \"GRCh38:13\",\n
+        \   \"GRCh38:chr13\",\n    \"GRCh38.p1:13\",\n    \"GRCh38.p1:chr13\",\n    \"GRCh38.p10:13\",\n
+        \   \"GRCh38.p10:chr13\",\n    \"GRCh38.p11:13\",\n    \"GRCh38.p11:chr13\",\n
+        \   \"GRCh38.p12:13\",\n    \"GRCh38.p12:chr13\",\n    \"GRCh38.p2:13\",\n
+        \   \"GRCh38.p2:chr13\",\n    \"GRCh38.p3:13\",\n    \"GRCh38.p3:chr13\",\n
+        \   \"GRCh38.p4:13\",\n    \"GRCh38.p4:chr13\",\n    \"GRCh38.p5:13\",\n    \"GRCh38.p5:chr13\",\n
+        \   \"GRCh38.p6:13\",\n    \"GRCh38.p6:chr13\",\n    \"GRCh38.p7:13\",\n    \"GRCh38.p7:chr13\",\n
+        \   \"GRCh38.p8:13\",\n    \"GRCh38.p8:chr13\",\n    \"GRCh38.p9:13\",\n    \"GRCh38.p9:chr13\",\n
+        \   \"MD5:a5437debe2ef9c9ef8f3ea2874ae1d82\",\n    \"NCBI:NC_000013.11\",\n
+        \   \"refseq:NC_000013.11\",\n    \"SEGUID:2oDBty0yKV9wHo7gg+Bt+fPgi5o\",\n
+        \   \"SHA1:da80c1b72d32295f701e8ee083e06df9f3e08b9a\",\n    \"VMC:GS__0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n
+        \   \"sha512t24u:_0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n    \"ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT\"\n
+        \ ],\n  \"alphabet\": \"ACGKNTY\",\n  \"length\": 114364328\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1002'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 13 Jan 2023 15:28:48 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -125,7 +167,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 19 Sep 2022 13:14:14 GMT
+      - Fri, 13 Jan 2023 15:28:48 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -165,20 +207,20 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Mon, 19 Sep 2022 13:14:17 GMT
+      - Fri, 13 Jan 2023 15:28:51 GMT
       Keep-Alive:
       - timeout=4, max=40
       NCBI-PHID:
-      - 322C565FBBD04345000027318D2324BD.1.1.m_5
+      - 939B1CD00866D48500004C75540CE92C.1.1.m_5
       NCBI-SID:
-      - 2E1608FAFC3E1BF6_6341SID
+      - E46CBC9A79C75AF2_D8E7SID
       Referrer-Policy:
       - origin-when-cross-origin
       Server:
       - Finatra
       Set-Cookie:
-      - ncbi_sid=2E1608FAFC3E1BF6_6341SID; domain=.nih.gov; path=/; expires=Tue, 19
-        Sep 2023 13:14:18 GMT
+      - ncbi_sid=E46CBC9A79C75AF2_D8E7SID; domain=.nih.gov; path=/; expires=Sat, 13
+        Jan 2024 15:28:51 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -187,8 +229,6 @@ interactions:
       - '3'
       X-RateLimit-Remaining:
       - '2'
-      X-Test-Test:
-      - test42
       X-UA-Compatible:
       - IE=Edge
       X-XSS-Protection:

--- a/tests/extras/cassettes/test_to_spdi.yaml
+++ b/tests/extras/cassettes/test_to_spdi.yaml
@@ -11,31 +11,31 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT
+    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
   response:
     body:
-      string: "{\n  \"added\": \"2016-08-27T23:50:14Z\",\n  \"aliases\": [\n    \"GRCh38:13\",\n
-        \   \"GRCh38:chr13\",\n    \"GRCh38.p1:13\",\n    \"GRCh38.p1:chr13\",\n    \"GRCh38.p10:13\",\n
-        \   \"GRCh38.p10:chr13\",\n    \"GRCh38.p11:13\",\n    \"GRCh38.p11:chr13\",\n
-        \   \"GRCh38.p12:13\",\n    \"GRCh38.p12:chr13\",\n    \"GRCh38.p2:13\",\n
-        \   \"GRCh38.p2:chr13\",\n    \"GRCh38.p3:13\",\n    \"GRCh38.p3:chr13\",\n
-        \   \"GRCh38.p4:13\",\n    \"GRCh38.p4:chr13\",\n    \"GRCh38.p5:13\",\n    \"GRCh38.p5:chr13\",\n
-        \   \"GRCh38.p6:13\",\n    \"GRCh38.p6:chr13\",\n    \"GRCh38.p7:13\",\n    \"GRCh38.p7:chr13\",\n
-        \   \"GRCh38.p8:13\",\n    \"GRCh38.p8:chr13\",\n    \"GRCh38.p9:13\",\n    \"GRCh38.p9:chr13\",\n
-        \   \"MD5:a5437debe2ef9c9ef8f3ea2874ae1d82\",\n    \"NCBI:NC_000013.11\",\n
-        \   \"refseq:NC_000013.11\",\n    \"SEGUID:2oDBty0yKV9wHo7gg+Bt+fPgi5o\",\n
-        \   \"SHA1:da80c1b72d32295f701e8ee083e06df9f3e08b9a\",\n    \"VMC:GS__0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n
-        \   \"sha512t24u:_0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n    \"ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT\"\n
-        \ ],\n  \"alphabet\": \"ACGKNTY\",\n  \"length\": 114364328\n}\n"
+      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
+        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
+        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
+        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
+        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
+        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
+        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
+        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
+        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
+        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
+        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
+        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
+        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
     headers:
       Connection:
       - close
       Content-Length:
-      - '1002'
+      - '1035'
       Content-Type:
       - application/json
       Date:
-      - Mon, 19 Sep 2022 13:14:14 GMT
+      - Fri, 13 Jan 2023 15:28:15 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT?start=32936731&end=32936732
+    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=44908821&end=44908822
   response:
     body:
       string: C
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 19 Sep 2022 13:14:14 GMT
+      - Fri, 13 Jan 2023 15:28:15 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:
@@ -83,31 +83,151 @@ interactions:
       User-Agent:
       - python-requests/2.28.1
     method: GET
-    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT
+    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=44908820&end=44908821
   response:
     body:
-      string: "{\n  \"added\": \"2016-08-27T23:50:14Z\",\n  \"aliases\": [\n    \"GRCh38:13\",\n
-        \   \"GRCh38:chr13\",\n    \"GRCh38.p1:13\",\n    \"GRCh38.p1:chr13\",\n    \"GRCh38.p10:13\",\n
-        \   \"GRCh38.p10:chr13\",\n    \"GRCh38.p11:13\",\n    \"GRCh38.p11:chr13\",\n
-        \   \"GRCh38.p12:13\",\n    \"GRCh38.p12:chr13\",\n    \"GRCh38.p2:13\",\n
-        \   \"GRCh38.p2:chr13\",\n    \"GRCh38.p3:13\",\n    \"GRCh38.p3:chr13\",\n
-        \   \"GRCh38.p4:13\",\n    \"GRCh38.p4:chr13\",\n    \"GRCh38.p5:13\",\n    \"GRCh38.p5:chr13\",\n
-        \   \"GRCh38.p6:13\",\n    \"GRCh38.p6:chr13\",\n    \"GRCh38.p7:13\",\n    \"GRCh38.p7:chr13\",\n
-        \   \"GRCh38.p8:13\",\n    \"GRCh38.p8:chr13\",\n    \"GRCh38.p9:13\",\n    \"GRCh38.p9:chr13\",\n
-        \   \"MD5:a5437debe2ef9c9ef8f3ea2874ae1d82\",\n    \"NCBI:NC_000013.11\",\n
-        \   \"refseq:NC_000013.11\",\n    \"SEGUID:2oDBty0yKV9wHo7gg+Bt+fPgi5o\",\n
-        \   \"SHA1:da80c1b72d32295f701e8ee083e06df9f3e08b9a\",\n    \"VMC:GS__0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n
-        \   \"sha512t24u:_0wi-qoDrvram155UmcSC-zA5ZK4fpLT\",\n    \"ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT\"\n
-        \ ],\n  \"alphabet\": \"ACGKNTY\",\n  \"length\": 114364328\n}\n"
+      string: G
     headers:
       Connection:
       - close
       Content-Length:
-      - '1002'
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:28:15 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=44908822&end=44908823
+  response:
+    body:
+      string: G
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:28:15 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=44908821&end=44908821
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:28:15 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl?start=44908822&end=44908822
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Fri, 13 Jan 2023 15:28:15 GMT
+      Server:
+      - Werkzeug/2.2.2 Python/3.10.4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.1
+    method: GET
+    uri: http://localhost:5000/seqrepo/1/metadata/ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl
+  response:
+    body:
+      string: "{\n  \"added\": \"2016-08-24T08:19:02Z\",\n  \"aliases\": [\n    \"Ensembl:19\",\n
+        \   \"ensembl:19\",\n    \"GRCh38:19\",\n    \"GRCh38:chr19\",\n    \"GRCh38.p1:19\",\n
+        \   \"GRCh38.p1:chr19\",\n    \"GRCh38.p10:19\",\n    \"GRCh38.p10:chr19\",\n
+        \   \"GRCh38.p11:19\",\n    \"GRCh38.p11:chr19\",\n    \"GRCh38.p12:19\",\n
+        \   \"GRCh38.p12:chr19\",\n    \"GRCh38.p2:19\",\n    \"GRCh38.p2:chr19\",\n
+        \   \"GRCh38.p3:19\",\n    \"GRCh38.p3:chr19\",\n    \"GRCh38.p4:19\",\n    \"GRCh38.p4:chr19\",\n
+        \   \"GRCh38.p5:19\",\n    \"GRCh38.p5:chr19\",\n    \"GRCh38.p6:19\",\n    \"GRCh38.p6:chr19\",\n
+        \   \"GRCh38.p7:19\",\n    \"GRCh38.p7:chr19\",\n    \"GRCh38.p8:19\",\n    \"GRCh38.p8:chr19\",\n
+        \   \"GRCh38.p9:19\",\n    \"GRCh38.p9:chr19\",\n    \"MD5:b0eba2c7bb5c953d1e06a508b5e487de\",\n
+        \   \"NCBI:NC_000019.10\",\n    \"refseq:NC_000019.10\",\n    \"SEGUID:AHxM5/L8jIX08UhBBkKXkiO5rhY\",\n
+        \   \"SHA1:007c4ce7f2fc8c85f4f148410642979223b9ae16\",\n    \"VMC:GS_IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n
+        \   \"sha512t24u:IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\",\n    \"ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl\"\n
+        \ ],\n  \"alphabet\": \"ACGNT\",\n  \"length\": 58617616\n}\n"
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1035'
       Content-Type:
       - application/json
       Date:
-      - Mon, 19 Sep 2022 13:14:14 GMT
+      - Fri, 13 Jan 2023 15:28:15 GMT
       Server:
       - Werkzeug/2.2.2 Python/3.10.4
     status:

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -111,6 +111,9 @@ def test_from_gnomad(tlr):
     # Ref != Actual ref
     assert not tlr._from_gnomad("13-32936732-G-C")
 
+    # require_validation set to False
+    assert tlr._from_gnomad("13-32936732-G-C", require_validation=False)
+
 @pytest.mark.vcr
 def test_from_hgvs(tlr):
     assert tlr._from_hgvs(snv_inputs["hgvs"]).as_dict() == snv_output

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ga4gh.vrs import models
+from ga4gh.vrs.extras.translator import ValidationError
 
 snv_inputs = {
     "hgvs": "NC_000019.10:g.44908822C>T",
@@ -109,10 +110,19 @@ def test_from_gnomad(tlr):
     assert not tlr._from_gnomad("13-32936732-helloworld-C")
 
     # Ref != Actual ref
-    assert not tlr._from_gnomad("13-32936732-G-C")
+    invalid_var = "13-32936732-G-C"
+    error_msg = "Expected reference sequence G on GRCh38:13 at positions (32936731, 32936732) but found C"
+
+    with pytest.raises(ValidationError) as e:
+        tlr._from_gnomad(invalid_var)
+    assert str(e.value) == error_msg
+
+    with pytest.raises(ValidationError) as e:
+        tlr.translate_from(invalid_var, fmt="gnomad")
+    assert str(e.value) == error_msg
 
     # require_validation set to False
-    assert tlr._from_gnomad("13-32936732-G-C", require_validation=False)
+    assert tlr._from_gnomad(invalid_var, require_validation=False)
 
 @pytest.mark.vcr
 def test_from_hgvs(tlr):

--- a/tests/extras/test_translator.py
+++ b/tests/extras/test_translator.py
@@ -3,24 +3,24 @@ import pytest
 from ga4gh.vrs import models
 
 snv_inputs = {
-    "hgvs": "NC_000013.11:g.32936732G>C",
-    "beacon": "13 : 32936732 G > C",
-    "spdi": "NC_000013.11:32936731:1:C",
-    "gnomad": "13-32936732-G-C"
+    "hgvs": "NC_000019.10:g.44908822C>T",
+    "beacon": "19 : 44908822 C > T",
+    "spdi": "NC_000019.10:44908821:1:T",
+    "gnomad": "19-44908822-C-T"
 }
 
 snv_output = {
     "location": {
         "interval": {
-            "end": {"value": 32936732, "type": "Number"},
-            "start": {"value": 32936731, "type": "Number"},
+            "end": {"value": 44908822, "type": "Number"},
+            "start": {"value": 44908821, "type": "Number"},
             "type": "SequenceInterval"
         },
-        "sequence_id": "ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+        "sequence_id": "ga4gh:SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
         "type": "SequenceLocation"
     },
     "state": {
-        "sequence": "C",
+        "sequence": "T",
         "type": "LiteralSequenceExpression"
     },
     "type": "Allele"
@@ -105,6 +105,11 @@ def test_from_beacon(tlr):
 def test_from_gnomad(tlr):
     assert tlr._from_gnomad(snv_inputs["gnomad"]).as_dict() == snv_output
 
+    # Invalid input. Ref does not match regex
+    assert not tlr._from_gnomad("13-32936732-helloworld-C")
+
+    # Ref != Actual ref
+    assert not tlr._from_gnomad("13-32936732-G-C")
 
 @pytest.mark.vcr
 def test_from_hgvs(tlr):

--- a/tests/extras/test_vcf_annotation.py
+++ b/tests/extras/test_vcf_annotation.py
@@ -75,4 +75,4 @@ def test_get_vrs_object_invalid_input(vcf_annotator, caplog):
 
     # No ALT
     vcf_annotator._get_vrs_object("7-140753336-A-.", {}, [], "GRCh38")
-    assert "None was returned when translating 7-140753336-A-. from gnomad" in caplog.text
+    assert "ValidationError when translating 7-140753336-A-. from gnomad" in caplog.text


### PR DESCRIPTION
Close #147 

- Update regex for input str
    - Based off of the [The Variant Call Format Specification](https://samtools.github.io/hts-specs/VCFv4.3.pdf) that @wesleygoar sent me:
    <img width="1495" alt="Screen Shot 2023-01-13 at 10 56 12 AM" src="https://user-images.githubusercontent.com/42851808/212362829-86b9fae4-035d-42a9-9590-0ba4d0ee8c87.png">
- Validate that expected reference sequence matches actual reference sequence
- Cassettes were automatically generated
- Updated translator test to match latest [VRS docs example](https://vrs.ga4gh.org/en/latest/impl-guide/example.html) since the previous test had an invalid reference sequence