### PR TITLE
chore: remove pylint warning for overgeneral-exceptions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -150,5 +150,5 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception


### PR DESCRIPTION
close #159 