### PR TITLE
docs: update readme for vrs branch tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ correspondences between the packages may be summarized as:
 - **develop ~ develop**: The vrs-python develop branch tracks the vrs develop branch.
 - **0.6 ~ 1.1**: vrs-python 0.6 branch tracks the vrs 1.1 branch.
 - **0.7 ~ 1.2**: vrs-python 0.7 branch tracks the vrs 1.2 branch.
-- **0.8 ~ main**: vrs-python 0.8 branch tracks the vrs main (dev) branch.
+- **0.8 ~ 1.3**: vrs-python 0.8 branch tracks the vrs 1.3 branch.
 - **0.9 ~ metaschema-update**: vrs-python 0.9 branch tracks the vrs metaschema-update branch.
 
 ⚠ **Developers: See the development section below for recommendations for using submodules


### PR DESCRIPTION
I also updated the VRS branch in [this](https://github.com/ga4gh/vrs-python/commit/ede302940dd32cda83a87149439a3a595fac867d) commit. 

@ahwagner We already have some tags / pypi releases for 0.8. Not sure how you want us to handle this. Should 0.10 VRS-Python branch track VRS main (dev) branch 