### PR TITLE
build: fix broken long_description reference

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,8 @@
 [metadata]
 name = ga4gh.vrs
 home_page = https://github.com/ga4gh/vrs-python
-long_description = file:README.rst
-long_description_content_type = text/x-rst; charset=UTF-8
+long_description = file:README.md
+long_description_content_type = text/markdown; charset=UTF-8
 description = "GA4GH Variation Representation Specification (VRS) reference implementation (https://github.com/ga4gh/vrs-python/)"
 #description-content-type = text/x-rst; charset=UTF-8
 license_file = LICENSE


### PR DESCRIPTION
The PyPI page (https://pypi.org/project/ga4gh.vrs/) currently lacks a description because the filename provided to setuptools is old. This should fix it (checked locally with Twine)