### PR TITLE
ci: python-cqa should run on 0.8 branch

### DIFF
--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -1,11 +1,6 @@
 name: Python CQA
 
-on:
-  push:
-    branches: [ main, "0.8" ]
-  pull_request:
-    branches: [ main, "0.8" ]
-
+on: [push, pull_request]
 
 # TODO: separate lint and test jobs; lint first, test "needs" lint
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobs

--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -2,9 +2,9 @@ name: Python CQA
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "0.8" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, "0.8" ]
 
 
 # TODO: separate lint and test jobs; lint first, test "needs" lint


### PR DESCRIPTION
Or we can just change to `on: [push, pull_request]` like we do in our other vicc repos