### PR TITLE
cicd: try having release run on ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       branch_name: ${{ steps.get_branch_name.outputs.name }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Get branch name
@@ -23,11 +23,11 @@ jobs:
     needs: get_branch
     if: needs.get_branch.outputs.branch_name == '0.8'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Update submodules


### PR DESCRIPTION
We're having issues where the release job is hanging when pushing a tag. It might be due to using an old version of ubuntu-latest. Not sure if anything else needs to be changed