### PR TITLE
docs: fix UTA readme formatting and wording

### DIFF
--- a/docs/setup_help/uta_installation.md
+++ b/docs/setup_help/uta_installation.md
@@ -2,11 +2,8 @@
 
         su wag002adm # replace with your admin account name`
 
-2.  Start PostgreSQL:
+2.  Start PostgreSQL. This will be OS and package manager/installation dependent; these commands assume an ARM Mac and PostgreSQL installed via Homebrew.
 
-        # OS and package manager dependent;
-        # these commands and file locations assume an ARM Mac environment
-        # and PostgreSQL installation with homebrew
         pg_ctl -D /opt/homebrew/var/postgres start
         ps aux | grep postgres # check that postgres processes are running
 

--- a/docs/setup_help/uta_installation.md
+++ b/docs/setup_help/uta_installation.md
@@ -4,49 +4,46 @@
 
 2.  Start PostgreSQL:
 
-    # OS and package manager dependent;
-
-    # these commands and file locations assume an ARM Mac environment
-
-    # and PostgreSQL installation with homebrew
-
-    pg_ctl -D /opt/homebrew/var/postgres start
-    ps aux | grep postgres # check that postgres processes are running
+        # OS and package manager dependent;
+        # these commands and file locations assume an ARM Mac environment
+        # and PostgreSQL installation with homebrew
+        pg_ctl -D /opt/homebrew/var/postgres start
+        ps aux | grep postgres # check that postgres processes are running
 
 3.  Start `psql` and open the `postgres` database, which is the database PostgreSQL uses to store roles, permissions, and structure:
 
-    psql postgres
+        psql postgres
 
 4.  Create roles for the application, give login and CREATEDB permissions:
 
-    CREATE ROLE uta_admin WITH LOGIN CREATEDB;
-    CREATE ROLE anonymous WITH LOGIN CREATEDB;
+        CREATE ROLE uta_admin WITH LOGIN CREATEDB;
+        CREATE ROLE anonymous WITH LOGIN CREATEDB;
 
 5.  In `psql`, verify that the above users exist:
 
-    \du
+        \du
 
 6.  In `psql`, create the UTA database:
 
-    CREATE DATABASE uta;
+        CREATE DATABASE uta;
 
 7.  In `psql`, grant privileges to manage `uta` to `uta_admin`:
 
-    GRANT ALL PRIVILEGES ON DATABASE uta TO uta_admin;
+        GRANT ALL PRIVILEGES ON DATABASE uta TO uta_admin;
 
 8.  Exit `psql`:
 
-    \q
+        \q
 
 9.  Download the UTA database and place it in the `uta` PostgreSQL database that you created before (**This step takes around 5 hours** -- see optional instructions below for quick installation instructions):
 
-    export UTA_VERSION=uta_20210129.pgd.gz
-    curl -O http://dl.biocommons.org/uta/$UTA_VERSION
-    gzip -cdq ${UTA_VERSION} | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
+        export UTA_VERSION=uta_20210129.pgd.gz
+        curl -O http://dl.biocommons.org/uta/$UTA_VERSION
+        gzip -cdq ${UTA_VERSION} | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
 
 10. Set the UTA address environment variable (frequent users would be advised to add this to their login configs):
 
-    export UTA_DB_URL=postgresql://uta_admin@localhost:5432/uta/uta_20210129
+        export UTA_DB_URL=postgresql://uta_admin@localhost:5432/uta/uta_20210129
 
 ### Optional:
 
@@ -56,13 +53,14 @@ If you wanted to wait for the 5 hour update till later please follow these steps
 
 9. Download the UTA database and place it in the `uta` PostgreSQL database that you created before:
 
-   export UTA_VERSION=uta_20210129.pgd.gz
-   curl -O http://dl.biocommons.org/uta/$UTA_VERSION
-   gzip -cdq ${UTA_VERSION} | grep -v "^REFRESH MATERIALIZED VIEW" | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
+        export UTA_VERSION=uta_20210129.pgd.gz
+        curl -O http://dl.biocommons.org/uta/$UTA_VERSION
+        gzip -cdq ${UTA_VERSION} | grep -v "^REFRESH MATERIALIZED VIEW" | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
 
 10. Log back into `psql` and manually refresh the materialized views:
 
-    REFRESH MATERIALIZED VIEW uta_20210129.exon_set_exons_fp_mv;
-    REFRESH MATERIALIZED VIEW uta_20210129.tx_exon_set_summary_mv;
-    REFRESH MATERIALIZED VIEW uta_20210129.tx_def_summary_mv;
-    REFRESH MATERIALIZED VIEW uta_20210129.tx_similarity_mv; // This step will take 5 or more hours
+        REFRESH MATERIALIZED VIEW uta_20210129.exon_set_exons_fp_mv;
+        REFRESH MATERIALIZED VIEW uta_20210129.tx_exon_set_summary_mv;
+        REFRESH MATERIALIZED VIEW uta_20210129.tx_def_summary_mv;
+        REFRESH MATERIALIZED VIEW uta_20210129.tx_similarity_mv; // This step will take 5 or more hours
+

--- a/docs/setup_help/uta_installation.md
+++ b/docs/setup_help/uta_installation.md
@@ -54,10 +54,15 @@ If you wanted to wait for the 5 hour update till later please follow these steps
         curl -O http://dl.biocommons.org/uta/$UTA_VERSION
         gzip -cdq ${UTA_VERSION} | grep -v "^REFRESH MATERIALIZED VIEW" | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
 
-10. Log back into `psql` and manually refresh the materialized views:
+10. Log back onto the `uta` database as `uta_admin` in `psql`:
 
+        psql uta uta_admin
+
+11. Manually refresh the materialized views:
+
+        // this will take 5+ hours
         REFRESH MATERIALIZED VIEW uta_20210129.exon_set_exons_fp_mv;
         REFRESH MATERIALIZED VIEW uta_20210129.tx_exon_set_summary_mv;
         REFRESH MATERIALIZED VIEW uta_20210129.tx_def_summary_mv;
-        REFRESH MATERIALIZED VIEW uta_20210129.tx_similarity_mv; // This step will take 5 or more hours
+        REFRESH MATERIALIZED VIEW uta_20210129.tx_similarity_mv;
 

--- a/docs/setup_help/uta_installation.md
+++ b/docs/setup_help/uta_installation.md
@@ -1,33 +1,68 @@
-1. Switch to your admin account #Skip if your user already has sudo permissions
-   1. `su wag002adm` # replace with your admin account name
-2. Start postgres
-   1. `pg_ctl -D /opt/homebrew/var/postgres start`
-   2. `ps aux | grep postgres` #to make sure that this process is running
-3. Start psql and open database postgres, which is the database postgres uses itself to store roles, permissions, and structure:
-   1. `psql postgres`
-4. Create roles for the application, give login and CREATEDB permissions:
-   1. `CREATE ROLE uta_admin WITH LOGIN CREATEDB;`
-   2. `CREATE ROLE anonymous WITH LOGIN CREATEDB;`
-5. List the users using the command 
-   1. `\du`
-6. Create the UTA Database object
-   1. `CREATE DATABASE uta;`
-7. Grant privileges to manage the database to uta_admin
-   1. `GRANT ALL PRIVILEGES ON DATABASE uta TO uta_admin;`
-8. Exit postgres
-   1. `\q`
-9. Download the UTA database and place it in the uta database object that you created before (**This step takes around 5 hours**). 
-   1. `export UTA_VERSION=uta_20210129.pgd.gz\ncurl -O http://dl.biocommons.org/uta/$UTA_VERSION\ngzip -cdq ${UTA_VERSION} | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432`
-10. Set your UTA path
-    1. `export UTA_DB_URL=postgresql://uta_admin@localhost:5432/uta/uta_20210129`
-###Optional installation step
-11. If you wanted to wait for the 5 hour update till later please follow these steps instead:
-12. Download the UTA database and place it in the uta database object that you created before.
-    1. `export UTA_VERSION=uta_20210129.pgd.gz
-curl -O http://dl.biocommons.org/uta/$UTA_VERSION
-gzip -cdq ${UTA_VERSION} | grep -v "^REFRESH MATERIALIZED VIEW" | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432`
-13. Run the refresh materialized view commands
-    1. `REFRESH MATERIALIZED VIEW uta_20210129.exon_set_exons_fp_mv;`
-    2. `REFRESH MATERIALIZED VIEW uta_20210129.tx_exon_set_summary_mv;`
-    3. `REFRESH MATERIALIZED VIEW uta_20210129.tx_def_summary_mv;`
-    4. `REFRESH MATERIALIZED VIEW uta_20210129.tx_similarity_mv;` #**This step will take 5 or more hours**
+1.  Switch to your admin account (Skip if your user already has `sudo` permissions):
+
+        su wag002adm # replace with your admin account name`
+
+2.  Start PostgreSQL:
+
+    # OS and package manager dependent;
+
+    # these commands and file locations assume an ARM Mac environment
+
+    # and PostgreSQL installation with homebrew
+
+    pg_ctl -D /opt/homebrew/var/postgres start
+    ps aux | grep postgres # check that postgres processes are running
+
+3.  Start `psql` and open the `postgres` database, which is the database PostgreSQL uses to store roles, permissions, and structure:
+
+    psql postgres
+
+4.  Create roles for the application, give login and CREATEDB permissions:
+
+    CREATE ROLE uta_admin WITH LOGIN CREATEDB;
+    CREATE ROLE anonymous WITH LOGIN CREATEDB;
+
+5.  In `psql`, verify that the above users exist:
+
+    \du
+
+6.  In `psql`, create the UTA database:
+
+    CREATE DATABASE uta;
+
+7.  In `psql`, grant privileges to manage `uta` to `uta_admin`:
+
+    GRANT ALL PRIVILEGES ON DATABASE uta TO uta_admin;
+
+8.  Exit `psql`:
+
+    \q
+
+9.  Download the UTA database and place it in the `uta` PostgreSQL database that you created before (**This step takes around 5 hours** -- see optional instructions below for quick installation instructions):
+
+    export UTA_VERSION=uta_20210129.pgd.gz
+    curl -O http://dl.biocommons.org/uta/$UTA_VERSION
+    gzip -cdq ${UTA_VERSION} | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
+
+10. Set the UTA address environment variable (frequent users would be advised to add this to their login configs):
+
+    export UTA_DB_URL=postgresql://uta_admin@localhost:5432/uta/uta_20210129
+
+### Optional:
+
+The majority of the load times described above come from refreshing materialized views. To delay this step, or avoid it entirely, you may optionally do the following instead:
+
+If you wanted to wait for the 5 hour update till later please follow these steps instead:
+
+9. Download the UTA database and place it in the `uta` PostgreSQL database that you created before:
+
+   export UTA_VERSION=uta_20210129.pgd.gz
+   curl -O http://dl.biocommons.org/uta/$UTA_VERSION
+   gzip -cdq ${UTA_VERSION} | grep -v "^REFRESH MATERIALIZED VIEW" | psql -h localhost -U uta_admin --echo-errors --single-transaction -v ON_ERROR_STOP=1 -d uta -p 5432
+
+10. Log back into `psql` and manually refresh the materialized views:
+
+    REFRESH MATERIALIZED VIEW uta_20210129.exon_set_exons_fp_mv;
+    REFRESH MATERIALIZED VIEW uta_20210129.tx_exon_set_summary_mv;
+    REFRESH MATERIALIZED VIEW uta_20210129.tx_def_summary_mv;
+    REFRESH MATERIALIZED VIEW uta_20210129.tx_similarity_mv; // This step will take 5 or more hours


### PR DESCRIPTION
Noticed a few minor issues in the UTA setup instructions, most notably that some newline chars were getting added into a command where a literal newline was probably intended.