### PR TITLE
chore: update uta docker image to uta_20210129b

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,12 @@ services:
     network_mode: bridge
     ports:
       - 5000:5000
-  
+
   uta:
     # Test:
-    # psql -XAt postgres://anonymous@localhost/uta -c 'select count(*) from transcript'
-    # 249909
-    image: biocommons/uta:uta_20180821
+    # psql -XAt postgres://anonymous@localhost/uta -c 'select count(*) from uta_20210129b.transcript'
+    # 314227
+    image: biocommons/uta:uta_20210129b
     volumes:
       - uta_vol:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
close #253