### PR TITLE
fix: make descriptions/examples available in JSON schema output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     jsonschema>=4.17.3
     numpy
     pyyaml
-    pydantic == 2.*
+    pydantic>=2.1
 setup_requires =
     cython
     pytest-runner

--- a/src/ga4gh/core/_internal/models.py
+++ b/src/ga4gh/core/_internal/models.py
@@ -35,16 +35,21 @@ class Code(RootModel):
 
     root: constr(pattern=r'\S+( \S+)*') = Field(
         ...,
-        description='Indicates that the value is taken from a set of controlled strings defined elsewhere. Technically, a code is restricted to a string which has at least one character and no leading or  trailing whitespace, and where there is no whitespace other than single spaces in the contents.',
-        example='ENSG00000139618',
+        json_schema_extra={
+            'examples': ['ENSG00000139618'],
+        },
     )
 
 
 class IRI(RootModel):
-    root: str = Field(
-        ...,
-        description='An IRI Reference (either an IRI or a relative-reference), according to `RFC3986 section 4.1  <https://datatracker.ietf.org/doc/html/rfc3986#section-4.1>` and `RFC3987 section 2.1 <https://datatracker.ietf.org/doc/html/rfc3987#section-2.1>`. MAY be a JSON Pointer as an IRI fragment, as  described by `RFC6901 section 6 <https://datatracker.ietf.org/doc/html/rfc6901#section-6>`.',
-    )
+    """An IRI Reference (either an IRI or a relative-reference), according to
+    `RFC3986 section 4.1  <https://datatracker.ietf.org/doc/html/rfc3986#section-4.1>`
+    and `RFC3987 section 2.1 <https://datatracker.ietf.org/doc/html/rfc3987#section-2.1>`.
+    MAY be a JSON Pointer as an IRI fragment, as  described by
+    `RFC6901 section 6 <https://datatracker.ietf.org/doc/html/rfc6901#section-6>`.
+    """
+
+    root: str = Field(...)
 
 
 class Extension(BaseModel):
@@ -227,7 +232,6 @@ class Condition(RootModel):
 
     root: Union[Disease, Phenotype, TraitSet] = Field(
         ...,
-        description='A disease or other medical disorder.',
         discriminator='type',
     )
 
@@ -239,7 +243,6 @@ class TherapeuticProcedure(RootModel):
 
     root: Union[CombinationTherapy, TherapeuticAction, TherapeuticAgent, TherapeuticSubstituteGroup] = Field(
         ...,
-        description='An action or administration of therapeutic agents to produce an effect that is intended to alter or stop a pathologic process.',
         discriminator='type',
     )
 

--- a/src/ga4gh/vrs/_internal/models.py
+++ b/src/ga4gh/vrs/_internal/models.py
@@ -189,6 +189,7 @@ class Expression(BaseModel):
     Variation object. Common examples of expressions for the description of molecular
     variation include the HGVS and ISCN nomenclatures.
     """
+
     model_config = ConfigDict(
         use_enum_values=True
     )
@@ -199,26 +200,32 @@ class Expression(BaseModel):
 
 
 class Range(RootModel):
+    """An inclusive range of values bounded by one or more integers."""
+
     root: List[Optional[int]] = Field(
         ...,
-        description='An inclusive range of values bounded by one or more integers.',
         max_length=2,
         min_length=2,
     )
 
 
 class Residue(RootModel):
-    root: constr(pattern=r'[A-Z*\-]') = Field(
-        ...,
-        description='A character representing a specific residue (i.e., molecular species) or groupings of these ("ambiguity codes"), using [one-letter IUPAC abbreviations](https://en.wikipedia.org/wiki/International_Union_of_Pure_and_Applied_Chemistry#Amino_acid_and_nucleotide_base_codes) for nucleic acids and amino acids.',
-    )
+    """A character representing a specific residue (i.e., molecular species) or
+    groupings of these ("ambiguity codes"), using
+    [one-letter IUPAC abbreviations](https://en.wikipedia.org/wiki/International_Union_of_Pure_and_Applied_Chemistry#Amino_acid_and_nucleotide_base_codes) for nucleic acids and amino acids.
+    """
+
+    root: constr(pattern=r'[A-Z*\-]') = Field(...)
 
 
 class SequenceString(RootModel):
-    root: constr(pattern=r'^[A-Z*\-]*$') = Field(
-        ...,
-        description='A character string of Residues that represents a biological sequence using the conventional sequence order (5’-to-3’ for nucleic acid sequences, and amino-to-carboxyl for amino acid sequences). IUPAC ambiguity codes are permitted in Sequence Strings.',
-    )
+    """A character string of Residues that represents a biological sequence using the
+    conventional sequence order (5’-to-3’ for nucleic acid sequences, and
+    amino-to-carboxyl for amino acid sequences). IUPAC ambiguity codes are permitted in
+    Sequence Strings.
+    """
+
+    root: constr(pattern=r'^[A-Z*\-]*$') = Field(...)
 
 
 class SequenceReference(_ValueObject):
@@ -412,9 +419,7 @@ class GenotypeMember(_ValueObject):
 class MolecularVariation(RootModel):
     """A variation on a contiguous molecule."""
 
-    root: Union[Allele, Haplotype] = Field(
-        ..., description='A variation on a contiguous molecule.', discriminator='type'
-    )
+    root: Union[Allele, Haplotype] = Field(..., discriminator='type')
 
 
 class Genotype(_VariationBase):
@@ -445,23 +450,24 @@ class Genotype(_VariationBase):
 
 
 class SequenceExpression(RootModel):
+    """An expression describing a Sequence."""
+
     root: Union[LiteralSequenceExpression, ReferenceLengthExpression] = Field(
-        ..., description='An expression describing a Sequence.', discriminator='type'
+        ..., discriminator='type'
     )
 
 
 class Location(RootModel):
-    root: SequenceLocation = Field(
-        ...,
-        description='A contiguous segment of a biological sequence.',
-        discriminator='type',
-    )
+    """A contiguous segment of a biological sequence."""
+
+    root: SequenceLocation = Field(..., discriminator='type')
 
 
 class Variation(RootModel):
+    """A representation of the state of one or more biomolecules."""
+
     root: Union[Allele, CopyNumberChange, CopyNumberCount, Genotype, Haplotype] = Field(
         ...,
-        description='A representation of the state of one or more biomolecules.',
         discriminator='type',
     )
 


### PR DESCRIPTION
This PR makes two changes

1) it provides the `Code` example within `json_schema_extra` rather than the `example` keyword. This resolves a small but annoying deprecation warning. It also requires ticking up the Pydantic pin that just got changed a few days ago, though.

2) It handles `descriptions` in `RootModels` to ensure that they're included in the generated JSON schema output (as used by applications like FastAPI).  Currently, we supply descriptions to primitive-y types like `Condition` and `Code` using the `description` keyword. Counterintuitively, that argument doesn't actually get used in the JSON schema output, as far as I can tell. Instead, Pydantic first checks if there's a description in the `json_schema_extra` arg, and if not, it just uses the class docstring (otherwise, no description).

The simple way out is to just take the description text and supply them as docstrings. This, however, includes a bunch of unsightly newlines and extra spaces. Alternatively, we could include descriptions a second time, but under `json_schema_extra=`, not `description=`.

```python
from pprint import PrettyPrinter
from pydantic import BaseModel, RootModel, Field

class RootClassFirst(RootModel):
    """Docstring description"""
    root: str = Field(
        ...,
        description="Arg description",
        json_schema_extra={"description": "JSONschema description"}
    )

class RootClassSecond(RootModel):
    """Docstring description"""
    root: str = Field(..., description="Arg description")

class RootClassThird(RootModel):
    root: str = Field(..., description="Arg description")

class Container(BaseModel):
    one: RootClassFirst = Field(..., description="container arg description")
    two: RootClassSecond = Field(..., description="container arg description", json_schema_extra={"description": "container json schema description"})
    three: RootClassThird = Field(..., )
    four: RootClassSecond = Field(..., )


instance = Container(one="a", two="b", three="c", four="d")
ppr = PrettyPrinter(indent=2)
ppr.pprint(instance.model_json_schema())
```

```
[ 2-alpha ⚙ venv] ~/code/vrs-python % python3 scratch.py
{ '$defs': { 'RootClassFirst': { 'description': 'JSONschema description',
                                 'title': 'RootClassFirst',
                                 'type': 'string'},
             'RootClassSecond': { 'description': 'Docstring description',
                                  'title': 'RootClassSecond',
                                  'type': 'string'},
             'RootClassThird': {'title': 'RootClassThird', 'type': 'string'}},
  'properties': { 'four': {'$ref': '#/$defs/RootClassSecond'},
                  'one': { 'allOf': [{'$ref': '#/$defs/RootClassFirst'}],
                           'description': 'container arg description'},
                  'three': {'$ref': '#/$defs/RootClassThird'},
                  'two': { 'allOf': [{'$ref': '#/$defs/RootClassSecond'}],
                           'description': 'container json schema description'}},
  'required': ['one', 'two', 'three', 'four'],
  'title': 'Container',
  'type': 'object'}
```