### PR TITLE
fix: add oneOf property check to Haplotype.members

### DIFF
--- a/src/ga4gh/vrs/_internal/models.py
+++ b/src/ga4gh/vrs/_internal/models.py
@@ -23,7 +23,7 @@ import inspect
 import sys
 import typing
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel, constr
+from pydantic import BaseModel, ConfigDict, Field, RootModel, constr, field_validator
 
 from ga4gh.core._internal.pydantic import (
     is_identifiable,
@@ -327,6 +327,14 @@ class Haplotype(_VariationBase):
         description='A list of Alleles (or IRI references to `Alleles`) that comprise a Haplotype. Since each `Haplotype` member MUST be an `Allele`, and all members MUST share a common `SequenceReference`, implementations MAY use a compact representation of Haplotype that omits type and `SequenceReference` information in individual Haplotype members. Implementations MUST transform compact `Allele` representations into an `Allele` when computing GA4GH identifiers.',
         min_length=2,
     )
+
+    @field_validator("members")
+    @classmethod
+    def one_of_check(cls, v):
+        """oneOf property check on members"""
+        if len(set(map(type, v))) != 1:
+            raise ValueError("List must be one of `Allele` or `IRI`")
+        return v
 
     class ga4gh(_Ga4ghIdentifiableObject.ga4gh):
         prefix = 'HT'

--- a/tests/test_vrs2.py
+++ b/tests/test_vrs2.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ga4gh.core import (
     sha512t24u,
     ga4gh_digest,
@@ -152,6 +154,13 @@ def test_haplotype():
     assert sha512t24u(haplotype_serialized) == 'fFR5oRpeD8Cuq2hfs3bXd1rgJUQrQA26'
     assert ga4gh_digest(haplotype_431012) == 'fFR5oRpeD8Cuq2hfs3bXd1rgJUQrQA26'
     assert ga4gh_identify(haplotype_431012) == 'ga4gh:HT.fFR5oRpeD8Cuq2hfs3bXd1rgJUQrQA26'
+
+    # Test where members do not pass oneOf property check
+    with pytest.raises(ValueError) as e:
+        models.Haplotype(
+            members=[allele_383650, models.IRI("variants.json#/1")]
+        )
+    assert "List must be one of `Allele` or `IRI`" in str(e)
 
 
 def test_genotype():


### PR DESCRIPTION
https://github.com/ga4gh/vrs/blob/0c9498d4eae1e868ac0b49b7e480fd6a3d67468c/schema/vrs-source.yaml#L169-L177

```yaml
      members:
        type: array
        ordered: false
        minItems: 2
        uniqueItems: true
        items:
          oneOf:
          - $ref: "#/$defs/Allele"
          - $refCurie: gks.core:IRI
```

We were not making the oneOf property check. I believe this is the only place where we had `oneOf` for items but didn't make the check. 