### PR TITLE
fix: ensure extra fields present in jsonschema

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     jsonschema>=4.17.3
     numpy
     pyyaml
-    pydantic == 2.*
+    pydantic~=2.1
 setup_requires =
     cython
     pytest-runner

--- a/src/ga4gh/core/_internal/models.py
+++ b/src/ga4gh/core/_internal/models.py
@@ -35,15 +35,18 @@ class Code(RootModel):
 
     root: constr(pattern=r'\S+( \S+)*') = Field(
         ...,
-        description='Indicates that the value is taken from a set of controlled strings defined elsewhere. Technically, a code is restricted to a string which has at least one character and no leading or  trailing whitespace, and where there is no whitespace other than single spaces in the contents.',
-        example='ENSG00000139618',
+        json_schema_extra={
+            'description': 'Indicates that the value is taken from a set of controlled strings defined elsewhere. Technically, a code is restricted to a string which has at least one character and no leading or  trailing whitespace, and where there is no whitespace other than single spaces in the contents.',
+            'example': 'ENSG00000139618',
+        }
     )
 
 
 class IRI(RootModel):
     root: str = Field(
         ...,
-        description='An IRI Reference (either an IRI or a relative-reference), according to `RFC3986 section 4.1  <https://datatracker.ietf.org/doc/html/rfc3986#section-4.1>` and `RFC3987 section 2.1 <https://datatracker.ietf.org/doc/html/rfc3987#section-2.1>`. MAY be a JSON Pointer as an IRI fragment, as  described by `RFC6901 section 6 <https://datatracker.ietf.org/doc/html/rfc6901#section-6>`.',
+        json_schema_extra={'description': 'An IRI Reference (either an IRI or a relative-reference), according to `RFC3986 section 4.1  <https://datatracker.ietf.org/doc/html/rfc3986#section-4.1>` and `RFC3987 section 2.1 <https://datatracker.ietf.org/doc/html/rfc3987#section-2.1>`. MAY be a JSON Pointer as an IRI fragment, as  described by `RFC6901 section 6 <https://datatracker.ietf.org/doc/html/rfc6901#section-6>`.',
+        }
     )
 
 
@@ -227,7 +230,7 @@ class Condition(RootModel):
 
     root: Union[Disease, Phenotype, TraitSet] = Field(
         ...,
-        description='A disease or other medical disorder.',
+        json_schema_extra={'description': 'A disease or other medical disorder.'},
         discriminator='type',
     )
 
@@ -239,7 +242,7 @@ class TherapeuticProcedure(RootModel):
 
     root: Union[CombinationTherapy, TherapeuticAction, TherapeuticAgent, TherapeuticSubstituteGroup] = Field(
         ...,
-        description='An action or administration of therapeutic agents to produce an effect that is intended to alter or stop a pathologic process.',
+        json_schema_extra={'description': 'An action or administration of therapeutic agents to produce an effect that is intended to alter or stop a pathologic process.'},
         discriminator='type',
     )
 

--- a/src/ga4gh/vrs/_internal/models.py
+++ b/src/ga4gh/vrs/_internal/models.py
@@ -201,7 +201,9 @@ class Expression(BaseModel):
 class Range(RootModel):
     root: List[Optional[int]] = Field(
         ...,
-        description='An inclusive range of values bounded by one or more integers.',
+        json_schema_extra={
+            'description': 'An inclusive range of values bounded by one or more integers.'
+        },
         max_length=2,
         min_length=2,
     )
@@ -210,14 +212,18 @@ class Range(RootModel):
 class Residue(RootModel):
     root: constr(pattern=r'[A-Z*\-]') = Field(
         ...,
-        description='A character representing a specific residue (i.e., molecular species) or groupings of these ("ambiguity codes"), using [one-letter IUPAC abbreviations](https://en.wikipedia.org/wiki/International_Union_of_Pure_and_Applied_Chemistry#Amino_acid_and_nucleotide_base_codes) for nucleic acids and amino acids.',
+        json_schema_extra={
+            'description': 'A character representing a specific residue (i.e., molecular species) or groupings of these ("ambiguity codes"), using [one-letter IUPAC abbreviations](https://en.wikipedia.org/wiki/International_Union_of_Pure_and_Applied_Chemistry#Amino_acid_and_nucleotide_base_codes) for nucleic acids and amino acids.'
+        },
     )
 
 
 class SequenceString(RootModel):
     root: constr(pattern=r'^[A-Z*\-]*$') = Field(
         ...,
-        description='A character string of Residues that represents a biological sequence using the conventional sequence order (5’-to-3’ for nucleic acid sequences, and amino-to-carboxyl for amino acid sequences). IUPAC ambiguity codes are permitted in Sequence Strings.',
+        json_schema_extra={
+            'description': 'A character string of Residues that represents a biological sequence using the conventional sequence order (5’-to-3’ for nucleic acid sequences, and amino-to-carboxyl for amino acid sequences). IUPAC ambiguity codes are permitted in Sequence Strings.'
+        },
     )
 
 
@@ -413,7 +419,11 @@ class MolecularVariation(RootModel):
     """A variation on a contiguous molecule."""
 
     root: Union[Allele, Haplotype] = Field(
-        ..., description='A variation on a contiguous molecule.', discriminator='type'
+        ...,
+        json_schema_extra={
+            'description': 'A variation on a contiguous molecule.'
+        },
+        discriminator='type'
     )
 
 
@@ -446,14 +456,18 @@ class Genotype(_VariationBase):
 
 class SequenceExpression(RootModel):
     root: Union[LiteralSequenceExpression, ReferenceLengthExpression] = Field(
-        ..., description='An expression describing a Sequence.', discriminator='type'
+        ...,
+        json_schema_extra={'description': 'An expression describing a Sequence.'},
+        discriminator='type'
     )
 
 
 class Location(RootModel):
     root: SequenceLocation = Field(
         ...,
-        description='A contiguous segment of a biological sequence.',
+        json_schema_extra={
+            'description': 'A contiguous segment of a biological sequence.'
+        },
         discriminator='type',
     )
 
@@ -461,7 +475,9 @@ class Location(RootModel):
 class Variation(RootModel):
     root: Union[Allele, CopyNumberChange, CopyNumberCount, Genotype, Haplotype] = Field(
         ...,
-        description='A representation of the state of one or more biomolecules.',
+        json_schema_extra={
+            'description': 'A representation of the state of one or more biomolecules.'
+        },
         discriminator='type',
     )
 
@@ -473,7 +489,9 @@ class SystemicVariation(RootModel):
 
     root: Union[CopyNumberChange, CopyNumberCount, Genotype] = Field(
         ...,
-        description='A Variation of multiple molecules in the context of a system, e.g. a genome, sample, or homologous chromosomes.',
+        json_schema_extra={
+            'description': 'A Variation of multiple molecules in the context of a system, e.g. a genome, sample, or homologous chromosomes.'
+        },
         discriminator='type',
     )
 


### PR DESCRIPTION
Not really sure why, but when `RootModel` classes are used as attributes in Pydantic models, the `model_json_schema` method seems to get very picky about how things like descriptions and examples are provided. Specifically, it wants them under the `json_schema_extra` param -- otherwise, they won't show up in the JSON schema produced by libraries like FastAPI. This PR makes this change (which coincidentally also silences a sort of annoying warning that starts appearing in more recent Pydantic v2 versions).