### PR TITLE
build(deps): remove jsonschema dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,6 @@ install_requires =
     bioutils
     canonicaljson
     coloredlogs
-    jsonschema>=4.17.3
     numpy
     pyyaml
     pydantic == 2.*


### PR DESCRIPTION
[This commit](https://github.com/ga4gh/vrs-python/commit/76a3c72ef869927699fa22ee73bf9830280bb2ab) introduced a dependency on `jsonschema` because it was required by `python-jsonschema-objects` but they didn't pin it themselves, for some reason. I think we can get rid of it entirely now that we're on Pydantic (or at least, tests pass and it doesn't seem to be used anywhere...)