### PR TITLE
fix: use start/end constraints for `digest` and `refgetAccession` fields

### DIFF
--- a/src/ga4gh/vrs/_internal/models.py
+++ b/src/ga4gh/vrs/_internal/models.py
@@ -233,7 +233,7 @@ class SequenceReference(_ValueObject):
     )
 
     type: Literal['SequenceReference'] = Field('SequenceReference', description='MUST be "SequenceReference"')
-    refgetAccession: constr(pattern=r'SQ.[0-9A-Za-z_\-]{32}') = Field(
+    refgetAccession: constr(pattern=r'^SQ.[0-9A-Za-z_\-]{32}$') = Field(
         ...,
         description='A `GA4GH RefGet <http://samtools.github.io/hts-specs/refget.html>` identifier for the referenced sequence, using the sha512t24u digest.',
     )

--- a/src/ga4gh/vrs/_internal/models.py
+++ b/src/ga4gh/vrs/_internal/models.py
@@ -167,7 +167,7 @@ class _ValueObject(_Entity):
     See https://en.wikipedia.org/wiki/Value_object for more on Value Objects.
     """
 
-    digest: Optional[constr(pattern=r'[0-9A-Za-z_\-]{32}')] = Field(
+    digest: Optional[constr(pattern=r'^[0-9A-Za-z_\-]{32}$')] = Field(
         None,
         description='A sha512t24u digest created using the VRS Computed Identifier algorithm.',
     )

--- a/tests/test_vrs2.py
+++ b/tests/test_vrs2.py
@@ -1,3 +1,6 @@
+from pydantic import ValidationError
+import pytest
+
 from ga4gh.core import (
     sha512t24u,
     ga4gh_digest,
@@ -36,7 +39,7 @@ allele_383650_dict = {
         "type": "SequenceLocation",
         "sequenceReference": {
             "type": "SequenceReference",
-            "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
+            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
         },
         "start": 128325834,
         "end": 128325835
@@ -52,7 +55,7 @@ allele_417816_dict = {
         "type": "SequenceLocation",
         "sequenceReference": {
             "type": "SequenceReference",
-            "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
+            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
         },
         "start": 128325809,
         "end": 128325810
@@ -68,7 +71,7 @@ allele_280320_dict = {
         "type": "SequenceLocation",
         "sequenceReference": {
             "type": "SequenceReference",
-            "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
+            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
         },
         "start": 128322879,
         "end": 128322891
@@ -146,6 +149,25 @@ def test_vr():
     # a3 = vrs_deref(a2, vros)
     # assert a == a3
 
+    with pytest.raises(ValidationError):
+        models.Allele(**{
+            "type": "Allele",
+            "location": {
+                "type": "SequenceLocation",
+                "sequenceReference": {
+                    "type": "SequenceReference",
+                    "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
+                },
+                "start": 128325834,
+                "end": 128325835
+            },
+            "state": {
+                "type": "LiteralSequenceExpression",
+                "sequence": "T"
+            }
+        })
+
+
 
 def test_haplotype():
     assert haplotype_431012.model_dump(exclude_none=True) == haplotype_431012_dict
@@ -196,7 +218,7 @@ def test_enref():
         'type': 'SequenceLocation',
         'sequenceReference': {
             'type': 'SequenceReference',
-            'refgetAccession': 'ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI'
+            'refgetAccession': 'SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI'
         },
         'start': 128325834,
         'end': 128325835})

--- a/tests/test_vrs2.py
+++ b/tests/test_vrs2.py
@@ -156,6 +156,7 @@ def test_vr():
                 "type": "SequenceLocation",
                 "sequenceReference": {
                     "type": "SequenceReference",
+                    # refgetAccession can't include a namespace prefix
                     "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
                 },
                 "start": 128325834,
@@ -173,7 +174,7 @@ def test_vr():
                 "type": "SequenceLocation",
                 "sequenceReference": {
                     "type": "SequenceReference",
-                    "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
+                    "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
                 },
                 "start": 128325834,
                 "end": 128325835
@@ -182,7 +183,8 @@ def test_vr():
                 "type": "LiteralSequenceExpression",
                 "sequence": "T"
             },
-            "digest": "this-should-fail:734G5mtNwe40do8F6GKuqQP4QxyjBqVp"
+            # digest can't include a namespace prefix
+            "digest": "ga4gh:734G5mtNwe40do8F6GKuqQP4QxyjBqVp"
         })
 
 

--- a/tests/test_vrs2.py
+++ b/tests/test_vrs2.py
@@ -166,6 +166,24 @@ def test_vr():
                 "sequence": "T"
             }
         })
+    with pytest.raises(ValidationError):
+        models.Allele(**{
+            "type": "Allele",
+            "location": {
+                "type": "SequenceLocation",
+                "sequenceReference": {
+                    "type": "SequenceReference",
+                    "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
+                },
+                "start": 128325834,
+                "end": 128325835
+            },
+            "state": {
+                "type": "LiteralSequenceExpression",
+                "sequence": "T"
+            },
+            "digest": "ga4gh:734G5mtNwe40do8F6GKuqQP4QxyjBqVp"
+        })
 
 
 

--- a/tests/test_vrs2.py
+++ b/tests/test_vrs2.py
@@ -182,7 +182,7 @@ def test_vr():
                 "type": "LiteralSequenceExpression",
                 "sequence": "T"
             },
-            "digest": "ga4gh:734G5mtNwe40do8F6GKuqQP4QxyjBqVp"
+            "digest": "this-should-fail:734G5mtNwe40do8F6GKuqQP4QxyjBqVp"
         })
 
 


### PR DESCRIPTION
close #327 