### PR TITLE
feat: add inclusion of "NT" prefixed refseq accessions to hgvs tools

### DIFF
--- a/src/ga4gh/vrs/dataproxy.py
+++ b/src/ga4gh/vrs/dataproxy.py
@@ -88,6 +88,7 @@ class _DataProxy(ABC):
             "refseq:NG_": "g",
             "refseq:NC_00": "g",
             "refseq:NW_": "g",
+            "refseq:NT_": "g",
             "refseq:NR_": "n",
             "refseq:NP_": "p",
             "refseq:XM_": "c",

--- a/src/ga4gh/vrs/utils/hgvs_tools.py
+++ b/src/ga4gh/vrs/utils/hgvs_tools.py
@@ -210,7 +210,7 @@ class HgvsTools():
             if ns.startswith("GRC") and namespace is None:
                 continue
 
-            if not (any(accession.startswith(pfx) for pfx in ("NM", "NP", "NC", "NG", "NR", "NW", "XM", "XR", "XP"))):
+            if not (any(accession.startswith(pfx) for pfx in ("NM", "NP", "NC", "NG", "NR", "NW", "NT", "XM", "XR", "XP"))):
                 continue
 
             sequence_type = self.data_proxy.extract_sequence_type(alias)


### PR DESCRIPTION
fix for #380 