### PR TITLE
cicd: fix release when multiple branches track same tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
         id: get_branch_name
         run: |
           raw=$(git branch -r --contains ${{ github.ref }})
-          branch=${raw##*/}
-          echo "::set-output name=name::$branch"
+          branch=$(echo "$raw" | grep "origin/main" | sed "s|origin/||" | xargs)
+          echo "name=$branch" >> "$GITHUB_OUTPUT"
   build:
     name: Build distribution
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our current approach can break when there are multiple branches that track the same tag:

```shell
$ echo $raw
origin/issue-380 origin/main origin/pypi-release-action origin/release origin/vcf-annotator-readme-update
$ branch=${raw##*/}
$ echo $branch
vcf-annotator-readme-update
```

@theferrit32 thanks for pointing out the multiple branches issue! I think this will fix the release action