### PR TITLE
Only attempt to create allele if values were extracted

### DIFF
--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -302,7 +302,10 @@ class AlleleTranslator(_Translator):
 
     def _from_hgvs(self, hgvs_expr: str, **kwargs):
         allele_values = self.hgvs_tools.extract_allele_values(hgvs_expr)
-        return self._create_allele(allele_values, **kwargs)
+        if allele_values:
+            return self._create_allele(allele_values, **kwargs)
+        else:
+            return None
 
     def _from_spdi(self, spdi_expr, **kwargs):
         """Parse SPDI expression in to a GA4GH Allele

--- a/tests/extras/test_allele_translator.py
+++ b/tests/extras/test_allele_translator.py
@@ -208,6 +208,12 @@ duplication_output_normalized = {
     "type": "Allele"
 }
 
+def test_from_invalid(tlr):
+    try:
+        tlr.translate_from("BRAF amplication")
+        assert "Expected exception to be thrown" is None
+    except ValueError as e:
+        assert e.args[0] == "Unable to parse data as beacon, gnomad, hgvs, spdi, vrs"
 
 @pytest.mark.vcr
 def test_from_beacon(tlr):


### PR DESCRIPTION
See #400 

Updated `_from_hgvs()` to only call `_create_allele()` is value extraction was successful. Otherwise returns `None` to indicate description could not be parsed as HGVS.