### PR TITLE
feat: VRS 1.3 digests may be computed for Alleles and Sequence Locations

### DIFF
--- a/src/ga4gh/core/identifiers.py
+++ b/src/ga4gh/core/identifiers.py
@@ -122,7 +122,7 @@ def parse_ga4gh_identifier(ir):
         raise ValueError(ir) from e
 
 
-def ga4gh_identify(vro, in_place='default'):
+def ga4gh_identify(vro, in_place='default', as_version=None):
     """
     Return the GA4GH digest-based id for the object, as a CURIE
     (string).  Returns None if object is not identifiable.
@@ -158,14 +158,14 @@ def ga4gh_identify(vro, in_place='default'):
                 do_compute = not vro.has_valid_ga4gh_id()
 
         if do_compute:
-            obj_id = vro.get_or_create_ga4gh_identifier(in_place)
+            obj_id = vro.get_or_create_ga4gh_identifier(in_place, as_version=as_version)
 
         return obj_id
 
     return None
 
 
-def ga4gh_digest(vro: BaseModel, overwrite=False):
+def ga4gh_digest(vro: BaseModel, overwrite=False, as_version=None):
     """
     Return the GA4GH digest for the object.
 
@@ -181,7 +181,10 @@ def ga4gh_digest(vro: BaseModel, overwrite=False):
 
     """
     if vro.is_ga4gh_identifiable():  # Only GA4GH identifiable objects are GA4GH digestible
-        return vro.get_or_create_digest(overwrite)
+        if as_version is None:
+            return vro.get_or_create_digest(overwrite)
+        else:
+            return vro.compute_digest(as_version=as_version)
     else:
         return None
 
@@ -210,9 +213,12 @@ def collapse_identifiable_values(obj: dict) -> dict:
     return obj
 
 
-def ga4gh_serialize(obj: BaseModel) -> Optional[bytes]:
+def ga4gh_serialize(obj: BaseModel, as_version=None) -> Optional[bytes]:
     """
     TODO find a way to output identify_all without the 'digest' fields on subobjects,
     without traversing the whole tree again in collapse_identifiable_values.
     """
-    return obj.model_dump_json().encode("utf-8")
+    if as_version is None:
+        return obj.model_dump_json().encode("utf-8")
+    else:
+        return obj.ga4gh_serialize_as_version(as_version)

--- a/src/ga4gh/core/identifiers.py
+++ b/src/ga4gh/core/identifiers.py
@@ -137,6 +137,10 @@ def ga4gh_identify(vro, in_place='default', as_version=None):
     - 'never': the vro.id field will not be edited in-place,
         even when empty
 
+    If 'as_version' is set to a version string, other parameters are 
+    ignored and an identifier returned following the conventions of 
+    the VRS version indicated by 'as_version'.
+
     TODO update example for VRS 2.0
     >>> import ga4gh.vrs
     >>> ival = ga4gh.vrs.models.SimpleInterval(start=44908821, end=44908822)
@@ -169,7 +173,9 @@ def ga4gh_digest(vro: BaseModel, overwrite=False, as_version=None):
     """
     Return the GA4GH digest for the object.
 
-    do_compact: bool - true if object compaction should be performed during serialization
+    If 'as_version' is set to a version string, other parameters 
+    are ignored and a digest returned following the conventions of 
+    the VRS version indicated by 'as_version'.
 
     TODO update example
 
@@ -215,8 +221,11 @@ def collapse_identifiable_values(obj: dict) -> dict:
 
 def ga4gh_serialize(obj: BaseModel, as_version=None) -> Optional[bytes]:
     """
-    TODO find a way to output identify_all without the 'digest' fields on subobjects,
-    without traversing the whole tree again in collapse_identifiable_values.
+    Serializes an object for use in computed digest computation.
+
+    If a VRS version string is specified for the 'as_version' parameter,
+    the returned serialization follows the convention of the specified
+    VRS version.
     """
     if as_version is None:
         return obj.model_dump_json().encode("utf-8")

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -511,12 +511,12 @@ class Allele(_VariationBase):
     )
 
     def ga4gh_serialize_as_version(self, as_version):
-        location_id = self.location.compute_ga4gh_identifier(as_version=as_version)
-        sequence = self.state.sequence
+        location_digest = self.location.compute_digest(as_version=as_version)
+        sequence = get_pydantic_root(self.state.sequence)
         if sequence is None:
             raise ValueError('State sequence attribute must be defined.')
         if as_version == '1.3':
-            f'{{"location":"{location_id}","state":{{"sequence":"{sequence}","type":"LiteralSequenceExpression"}},"type":"Allele"}}'
+            return f'{{"location":"{location_digest}","state":{{"sequence":"{sequence}","type":"LiteralSequenceExpression"}},"type":"Allele"}}'
         else:
             raise ValueError(f'Serializing as version {as_version} not supported for this class.')
 

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -564,7 +564,6 @@ class CisPhasedBlock(_VariationBase):
 
     class ga4gh(_Ga4ghIdentifiableObject.ga4gh):
         prefix = 'CPB'
-        priorPrefix = {'1.3': 'VH'}
         keys = [
             'members',
             'type'

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -232,7 +232,9 @@ class _Ga4ghIdentifiableObject(_ValueObject):
 
     def compute_digest(self, store=True, as_version=None) -> str:
         """A sha512t24u digest created using the VRS Computed Identifier algorithm.
-        Stores the digest in the object if store is True.
+        Stores the digest in the object if store is True. If 'as_version' is set to
+        a version string, other parameters are ignored and a digest returned
+        following the conventions of the VRS version indicated by 'as_version'.
         """
         if as_version is None:
             digest = sha512t24u(self.model_dump_json().encode("utf-8"))
@@ -259,6 +261,10 @@ class _Ga4ghIdentifiableObject(_ValueObject):
             even when empty
 
         Digests will be recalculated even if present if recompute is True.
+
+        If 'as_version' is set to a version string, other parameters are 
+        ignored and an identifier returned following the conventions of 
+        the VRS version indicated by 'as_version'.
         """
         if as_version is not None:
             return self.compute_ga4gh_identifier(as_version=as_version)
@@ -279,7 +285,12 @@ class _Ga4ghIdentifiableObject(_ValueObject):
             return self.compute_ga4gh_identifier(recompute)
 
     def compute_ga4gh_identifier(self, recompute=False, as_version=None):
-        """Returns a GA4GH Computed Identifier"""
+        """Returns a GA4GH Computed Identifier.
+        
+        If 'as_version' is set to a version string, other parameters are
+        ignored and a computed identifier returned following the conventions 
+        of the VRS version indicated by 'as_version'.
+        """
         if as_version is None:
             self.get_or_create_digest(recompute)
             return f'{CURIE_NAMESPACE}{CURIE_SEP}{self.ga4gh.prefix}{GA4GH_PREFIX_SEP}{self.digest}'
@@ -446,6 +457,8 @@ class SequenceLocation(_Ga4ghIdentifiableObject):
     sequence: Optional[SequenceString] = Field(None, description="The literal sequence encoded by the `sequenceReference` at these coordinates.")
 
     def ga4gh_serialize_as_version(self, as_version):
+        """This method will return a serialized string following the conventions for
+        SequenceLocation serialization as defined in the VRS version specified by 'as_version`."""
         if as_version == '1.3':
             out = list()
             for value in [self.start,self.end]:
@@ -511,6 +524,8 @@ class Allele(_VariationBase):
     )
 
     def ga4gh_serialize_as_version(self, as_version):
+        """This method will return a serialized string following the conventions for
+        Allele serialization as defined in the VRS version specified by 'as_version`."""
         location_digest = self.location.compute_digest(as_version=as_version)
         sequence = get_pydantic_root(self.state.sequence)
         if sequence is None:

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -262,8 +262,8 @@ class _Ga4ghIdentifiableObject(_ValueObject):
 
         Digests will be recalculated even if present if recompute is True.
 
-        If 'as_version' is set to a version string, other parameters are 
-        ignored and an identifier returned following the conventions of 
+        If 'as_version' is set to a version string, other parameters are
+        ignored and an identifier returned following the conventions of
         the VRS version indicated by 'as_version'.
         """
         if as_version is not None:
@@ -286,9 +286,9 @@ class _Ga4ghIdentifiableObject(_ValueObject):
 
     def compute_ga4gh_identifier(self, recompute=False, as_version=None):
         """Returns a GA4GH Computed Identifier.
-        
+
         If 'as_version' is set to a version string, other parameters are
-        ignored and a computed identifier returned following the conventions 
+        ignored and a computed identifier returned following the conventions
         of the VRS version indicated by 'as_version'.
         """
         if as_version is None:
@@ -475,7 +475,7 @@ class SequenceLocation(_Ga4ghIdentifiableObject):
                 else:
                     raise ValueError(f'{value} is not int or list.')
                 out.append(result)
-            return f'{{"interval":{{"end":{out[1]},"start":{out[0]},"type":"SequenceInterval"}},"sequence_id":"{self.sequenceReference.refgetAccession.split('.')[1]}","type":"SequenceLocation"}}'
+            return f'{{"interval":{{"end":{out[1]},"start":{out[0]},"type":"SequenceInterval"}},"sequence_id":"{self.sequenceReference.refgetAccession.split(".")[1]}","type":"SequenceLocation"}}'
         else:
             raise ValueError(f'Serializing as version {as_version} not supported for this class.')
 

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -10,10 +10,25 @@ import yaml
 from ga4gh.core import ga4gh_serialize, ga4gh_digest, ga4gh_identify
 from ga4gh.vrs import models
 
+def ga4gh_1_3_identify(*args, **kwargs):
+    kwargs['as_version'] = '1.3'
+    return ga4gh_identify(*args, **kwargs)
+
+def ga4gh_1_3_digest(*args, **kwargs):
+    kwargs['as_version'] = '1.3'
+    return ga4gh_digest(*args, **kwargs)
+
+def ga4gh_1_3_serialize(*args, **kwargs):
+    kwargs['as_version'] = '1.3'
+    return ga4gh_serialize(*args, **kwargs)
+
 fxs = {
     "ga4gh_serialize": lambda o: ga4gh_serialize(o).decode() if ga4gh_serialize(o) else None,
     "ga4gh_digest": ga4gh_digest,
     "ga4gh_identify": ga4gh_identify,
+    "ga4gh_1_3_digest": ga4gh_1_3_digest,
+    "ga4gh_1_3_identify": ga4gh_1_3_identify,
+    "ga4gh_1_3_serialize": ga4gh_1_3_serialize
 }
 
 validation_fn = os.path.join(os.path.dirname(__file__), "data", "models.yaml")


### PR DESCRIPTION
Note: tests only pass for Python 3.12 due to changes in f-string implementation introduced in 3.12. These should be addressed before merge.

closes #382 