### PR TITLE
feat: add enum for `as_version` + add restrictions to `ga4gh_serialize_as_version`

### DIFF
--- a/src/ga4gh/core/__init__.py
+++ b/src/ga4gh/core/__init__.py
@@ -9,7 +9,8 @@ from .enderef import ga4gh_enref, ga4gh_deref
 from .identifiers import (
     ga4gh_digest, ga4gh_identify, ga4gh_serialize, is_ga4gh_identifier,
     parse_ga4gh_identifier, VrsObjectIdentifierIs, use_ga4gh_compute_identifier_when,
-    CURIE_NAMESPACE, CURIE_SEP, GA4GH_PREFIX_SEP, GA4GH_IR_REGEXP, GA4GH_DIGEST_REGEXP
+    CURIE_NAMESPACE, CURIE_SEP, GA4GH_PREFIX_SEP, GA4GH_IR_REGEXP, GA4GH_DIGEST_REGEXP,
+    PrevVrsVersion
 )
 from .pydantic import (
     is_pydantic_instance, is_curie_type, is_ga4gh_identifiable, is_literal, pydantic_copy
@@ -32,6 +33,7 @@ __all__ = [
     "GA4GH_PREFIX_SEP",
     "GA4GH_IR_REGEXP",
     "GA4GH_DIGEST_REGEXP",
+    "PrevVrsVersion",
     "is_pydantic_instance",
     "is_curie_type",
     "is_ga4gh_identifiable",

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -7,19 +7,19 @@ import os
 import pytest
 import yaml
 
-from ga4gh.core import ga4gh_serialize, ga4gh_digest, ga4gh_identify
+from ga4gh.core import ga4gh_serialize, ga4gh_digest, ga4gh_identify, PrevVrsVersion, entity_models
 from ga4gh.vrs import models
 
 def ga4gh_1_3_identify(*args, **kwargs):
-    kwargs['as_version'] = '1.3'
+    kwargs['as_version'] = PrevVrsVersion.V1_3
     return ga4gh_identify(*args, **kwargs)
 
 def ga4gh_1_3_digest(*args, **kwargs):
-    kwargs['as_version'] = '1.3'
+    kwargs['as_version'] = PrevVrsVersion.V1_3
     return ga4gh_digest(*args, **kwargs)
 
 def ga4gh_1_3_serialize(*args, **kwargs):
-    kwargs['as_version'] = '1.3'
+    kwargs['as_version'] = PrevVrsVersion.V1_3
     return ga4gh_serialize(*args, **kwargs)
 
 fxs = {
@@ -60,3 +60,39 @@ def test_validation(cls, data, fn, exp):
     o = getattr(models, cls)(**data)
     fx = fxs[fn]
     assert fx(o) == exp
+
+
+def test_prev_vrs_version():
+    """Ensure that support to previous VRS digest/identifiers works correctly"""
+    loc = models.SequenceLocation(start=44908821, end=44908822, sequenceReference=models.SequenceReference(refgetAccession="SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"))
+
+    # string representation should work as well
+    ga4gh_identify(loc, as_version="1.3")
+
+    invalid_vrs_version = "0.0"
+    invalid_vrs_version_msg = f"Expected `PrevVrsVersion`, but got {invalid_vrs_version}"
+
+    loc_no_seq_ref = models.SequenceLocation(start=44908821, end=44908822)
+    loc_iri = models.SequenceLocation(start=44908821, end=44908822, sequenceReference=entity_models.IRI("sequenceReferences.json#example1"))
+    allele_rle_no_seq = models.Allele(location=loc, state=models.ReferenceLengthExpression(length=11, repeatSubunitLength=3))
+    allele_le = models.Allele(location=loc, state=models.LengthExpression(length=2))
+    loc_seq_ref_msg = "Must provide `sequenceReference` and it must be a valid `SequenceReference`"
+    for ga4gh_func in [ga4gh_identify, ga4gh_digest, ga4gh_serialize]:
+        with pytest.raises(ValueError, match=invalid_vrs_version_msg):
+            ga4gh_func(loc, as_version=invalid_vrs_version_msg)
+
+        with pytest.raises(ValueError, match=loc_seq_ref_msg):
+            ga4gh_func(loc_no_seq_ref, as_version=PrevVrsVersion.V1_3)
+
+        with pytest.raises(ValueError, match=loc_seq_ref_msg):
+            ga4gh_func(loc_iri, as_version=PrevVrsVersion.V1_3)
+
+        with pytest.raises(ValueError, match="State sequence attribute must be defined."):
+            ga4gh_func(allele_rle_no_seq, as_version=PrevVrsVersion.V1_3)
+
+        allele_rlse_seq = allele_rle_no_seq.model_copy(deep=True)
+        allele_rlse_seq.state.sequence = "C"
+        assert ga4gh_func(allele_rlse_seq, as_version=PrevVrsVersion.V1_3)
+
+        with pytest.raises(ValueError, match="Only `LiteralSequenceExpression` and `ReferenceLengthExpression` are supported for previous versions of VRS"):
+            ga4gh_func(allele_le, as_version=PrevVrsVersion.V1_3)


### PR DESCRIPTION
Building off of #382 and #427

* Add `PrevVrsVersion` enum to store previous versions of VRS that is supported for computing digests/identifiers
* Updates function signatures + docstrings for ga4gh digest/serialize/identifier
* Adds restrictions to `ga4gh_serialize_as_version`
  * For `SequenceLocation`: `sequenceReference` must be provided and must be a valid `SequenceReference` obj
  * For `Allele`: Only `LiteralSequenceExpression` and `ReferenceLengthExpression` are supported and must provide a `sequence` nonnull attribute.