### PR TITLE
feat!: enhance annotator CLI options

### DIFF
--- a/docs/extras/vcf_annotator.md
+++ b/docs/extras/vcf_annotator.md
@@ -20,10 +20,10 @@ The tool uses a SeqRepo data proxy. By default, the local instance at `/usr/loca
 Example of how to run:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 ```
 
-`--vcf_in` specifies the path of the input VCF file to annotate. `--vcf_out` specifies the path of the output annotated VCF file. The `--vrs_pickle_out` specifies the path of the output pickle file containing VRS data (Both vcf_out and vrs_pickle_out are optional, but at least one __must__ be provided).
+Pass the path of the input VCF file as the argument to the script. Use either `--vcf_out` to specify the path of the output annotated VCF file, or `--vrs_pickle_out` to specify the path of the output pickle file containing VRS data (both `vcf_out` and `vrs_pickle_out` are optional, but at least one __must__ be provided).
 
 ### Use local SeqRepo Data Proxy with different
 
@@ -32,7 +32,7 @@ You can change the root directory of SeqRepo by using `seqrepo_root_dir`.
 To use the local SeqRepo data proxy with SeqRepo root directory at `vrs-python/seqrepo/latest`:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
+python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
 ```
 
 ### Use the REST SeqRepo Data Proxy with default base url
@@ -42,7 +42,7 @@ You can change the data proxy type by using: `--seqrepo_dp_type` (options are `l
 To use the REST SeqRepo data proxy at default url: `http://localhost:5000/seqrepo`:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
+python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
 ```
 
 ### Use the REST SeqRepo Data Proxy with different base url
@@ -50,7 +50,7 @@ You can change the SeqRepo REST base url by using: `--seqrepo_base_url`.
 
 To use the REST SeqRepo data proxy, at custom url: `http://custom.url:5000/seqrepo`:
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
+python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
 ```
 
 ### Other Options

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -37,11 +37,10 @@ class SeqRepoProxyType(str, Enum):
 
 
 @click.command()
-@click.option(  # TODO make argument
-    "--vcf_in",
-    required=True,
-    type=click.Path(exists=True, dir_okay=False, readable=True, allow_dash=False, path_type=pathlib.Path),
-    help="The path for the input VCF file to annotate"
+@click.argument(
+    "vcf_in",
+    nargs=1,
+    type=click.Path(exists=True, readable=True, dir_okay=False, path_type=pathlib.Path)
 )
 @click.option(
     "--vcf_out",
@@ -113,19 +112,17 @@ def annotate_click(  # pylint: disable=too-many-arguments
     vrs_attributes: bool, seqrepo_dp_type: SeqRepoProxyType, seqrepo_root_dir: pathlib.Path,
     seqrepo_base_url: str, assembly: str, skip_ref: bool, require_validation: bool
 ) -> None:
-    """Annotate VCF file via click
+    """Annotate file located at VCF_IN.
 
-    Example arguments:
-
-    --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+        python3 src/ga4gh/vrs/extras/vcf_annotation.py input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
     """
     annotator = VCFAnnotator(seqrepo_dp_type, seqrepo_base_url, str(seqrepo_root_dir.absolute()))
+    vcf_out_str = str(vcf_out.absolute()) if vcf_out is not None else vcf_out
+    vrs_pkl_out_str = str(vrs_pickle_out.absolute()) if vrs_pickle_out is not None else vrs_pickle_out
     start = timer()
     msg = f"Annotating {vcf_in} with the VCF Annotator..."
     _logger.info(msg)
     click.echo(msg)
-    vcf_out_str = str(vcf_out.absolute()) if vcf_out is not None else vcf_out
-    vrs_pkl_out_str = str(vrs_pickle_out.absolute()) if vrs_pickle_out is not None else vrs_pickle_out
     annotator.annotate(
         str(vcf_in.absolute()), vcf_out=vcf_out_str, vrs_pickle_out=vrs_pkl_out_str,
         vrs_attributes=vrs_attributes, assembly=assembly,

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -112,7 +112,7 @@ def annotate_click(  # pylint: disable=too-many-arguments
     vrs_attributes: bool, seqrepo_dp_type: SeqRepoProxyType, seqrepo_root_dir: pathlib.Path,
     seqrepo_base_url: str, assembly: str, skip_ref: bool, require_validation: bool
 ) -> None:
-    """Annotate file located at VCF_IN.
+    """Extract VRS objects from VCF located at VCF_IN.
 
         python3 src/ga4gh/vrs/extras/vcf_annotation.py input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
     """

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -46,21 +46,21 @@ class SeqRepoProxyType(str, Enum):
     "--vcf_out",
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=pathlib.Path),
-    help=("The path for the output VCF file. If not provided, must provide "
+    help=("Declare save location for output annotated VCF. If not provided, must provide "
           "--vrs_pickle_out.")
 )
 @click.option(
     "--vrs_pickle_out",
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=pathlib.Path),
-    help=("The path for the output VCF pickle file. If not provided, must provide "
-          "--vcf_out")
+    help=("Declare save location for output VCF pickle. If not provided, must provide "
+          "--vcf_out.")
 )
 @click.option(
     "--vrs_attributes",
     is_flag=True,
     default=False,
-    help="Will include VRS_Start, VRS_End, VRS_State fields in the INFO field.",
+    help="Include VRS_Start, VRS_End, and VRS_State fields in the VCF output INFO field.",
 )
 @click.option(
     "--seqrepo_dp_type",
@@ -68,7 +68,7 @@ class SeqRepoProxyType(str, Enum):
     default=SeqRepoProxyType.LOCAL,
     type=click.Choice([v.value for v in SeqRepoProxyType.__members__.values()],
                       case_sensitive=True),
-    help="The type of the SeqRepo Data Proxy to use",
+    help="Specify type of SeqRepo dataproxy to use.",
     show_default=True,
     show_choices=True
 )
@@ -77,14 +77,14 @@ class SeqRepoProxyType(str, Enum):
     required=False,
     default=pathlib.Path("/usr/local/share/seqrepo/latest"),
     type=click.Path(path_type=pathlib.Path),
-    help="The root directory for local SeqRepo instance",
+    help="Define root directory for local SeqRepo instance, if --seqrepo_dp_type=local.",
     show_default=True
 )
 @click.option(
     "--seqrepo_base_url",
     required=False,
     default="http://localhost:5000/seqrepo",
-    help="The base url for SeqRepo REST API",
+    help="Specify base URL for SeqRepo REST API, if --seqrepo_dp_type=rest.",
     show_default=True
 )
 @click.option(
@@ -92,7 +92,7 @@ class SeqRepoProxyType(str, Enum):
     required=False,
     default="GRCh38",
     show_default=True,
-    help="The assembly that the `vcf_in` data uses.",
+    help="Specify assembly that was used to create VCF at `vcf_in`.",
     type=str
 )
 @click.option(
@@ -105,7 +105,7 @@ class SeqRepoProxyType(str, Enum):
     "--require_validation",
     is_flag=True,
     default=False,
-    help="Require validation checks to pass in order to return a VRS object"
+    help="Require validation checks to pass to annotate a record with a VRS object."
 )
 def annotate_click(  # pylint: disable=too-many-arguments
     vcf_in: pathlib.Path, vcf_out: Optional[pathlib.Path], vrs_pickle_out: Optional[pathlib.Path],

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -65,7 +65,7 @@ class SeqRepoProxyType(str, Enum):
 @click.option(
     "--seqrepo_dp_type",
     required=False,
-    default=SeqRepoProxyType.LOCAL,
+    default=SeqRepoProxyType.LOCAL.value,
     type=click.Choice([v.value for v in SeqRepoProxyType.__members__.values()],
                       case_sensitive=True),
     help="The type of the SeqRepo Data Proxy to use",

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -65,7 +65,7 @@ class SeqRepoProxyType(str, Enum):
 @click.option(
     "--seqrepo_dp_type",
     required=False,
-    default=SeqRepoProxyType.LOCAL.value,
+    default=SeqRepoProxyType.LOCAL,
     type=click.Choice([v.value for v in SeqRepoProxyType.__members__.values()],
                       case_sensitive=True),
     help="The type of the SeqRepo Data Proxy to use",

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -61,7 +61,6 @@ class SeqRepoProxyType(str, Enum):
     is_flag=True,
     default=False,
     help="Will include VRS_Start, VRS_End, VRS_State fields in the INFO field.",
-    show_default=True
 )
 @click.option(
     "--seqrepo_dp_type",
@@ -99,14 +98,12 @@ class SeqRepoProxyType(str, Enum):
     "--skip_ref",
     is_flag=True,
     default=False,
-    show_default=True,
     help="Skip VRS computation for REF alleles."
 )
 @click.option(
     "--require_validation",
     is_flag=True,
     default=False,
-    show_default=True,
     help="Require validation checks to pass in order to return a VRS object"
 )
 def annotate_click(  # pylint: disable=too-many-arguments


### PR DESCRIPTION
* Make the input VCF path an [argument](https://click.palletsprojects.com/en/8.1.x/arguments/) rather than an [option](https://click.palletsprojects.com/en/8.1.x/options/). I think this better matches the intent of the tool (and it was the only required option, so might as well make it an arg, right?). Left it at `nargs=1` but I think there's a case for making it `nargs=-1`.
* pathlike args should be `click.Path`/`pathlib.Path`. Add additional configurations, like the input file must exist and the output files must be writable. Didn't make changes further up the stack because I wanted to confine this PR to just the Click interface.
* remove some superfluous/inactive configs
* Touch up help text