### PR TITLE
feat!: declare annotator CLI as console entrypoint

### DIFF
--- a/docs/extras/vcf_annotator.md
+++ b/docs/extras/vcf_annotator.md
@@ -10,7 +10,7 @@ The examples run from the root of the vrs-python directory and assumes that `inp
 To see the help page:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --help
+vrs-annotate-vcf --help
 ```
 
 ### Use local SeqRepo Data Proxy with default root directory
@@ -20,7 +20,7 @@ The tool uses a SeqRepo data proxy. By default, the local instance at `/usr/loca
 Example of how to run:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 ```
 
 Pass the path of the input VCF file as the argument to the script. Use either `--vcf_out` to specify the path of the output annotated VCF file, or `--vrs_pickle_out` to specify the path of the output pickle file containing VRS data (both `vcf_out` and `vrs_pickle_out` are optional, but at least one __must__ be provided).
@@ -32,7 +32,7 @@ You can change the root directory of SeqRepo by using `seqrepo_root_dir`.
 To use the local SeqRepo data proxy with SeqRepo root directory at `vrs-python/seqrepo/latest`:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
+vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
 ```
 
 ### Use the REST SeqRepo Data Proxy with default base url
@@ -42,7 +42,7 @@ You can change the data proxy type by using: `--seqrepo_dp_type` (options are `l
 To use the REST SeqRepo data proxy at default url: `http://localhost:5000/seqrepo`:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
+vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
 ```
 
 ### Use the REST SeqRepo Data Proxy with different base url
@@ -50,7 +50,7 @@ You can change the SeqRepo REST base url by using: `--seqrepo_base_url`.
 
 To use the REST SeqRepo data proxy, at custom url: `http://custom.url:5000/seqrepo`:
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
+vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
 ```
 
 ### Other Options

--- a/docs/extras/vcf_annotator.md
+++ b/docs/extras/vcf_annotator.md
@@ -10,7 +10,7 @@ The examples run from the root of the vrs-python directory and assumes that `inp
 To see the help page:
 
 ```commandline
-vrs-annotate --help
+vrs-annotate vcf --help
 ```
 
 ### Use local SeqRepo Data Proxy with default root directory
@@ -20,7 +20,7 @@ The tool uses a SeqRepo data proxy. By default, the local instance at `/usr/loca
 Example of how to run:
 
 ```commandline
-vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 ```
 
 Pass the path of the input VCF file as the argument to the script. Use either `--vcf_out` to specify the path of the output annotated VCF file, or `--vrs_pickle_out` to specify the path of the output pickle file containing VRS data (both `vcf_out` and `vrs_pickle_out` are optional, but at least one __must__ be provided).
@@ -32,7 +32,7 @@ You can change the root directory of SeqRepo by using `seqrepo_root_dir`.
 To use the local SeqRepo data proxy with SeqRepo root directory at `vrs-python/seqrepo/latest`:
 
 ```commandline
-vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
+vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
 ```
 
 ### Use the REST SeqRepo Data Proxy with default base url
@@ -42,7 +42,7 @@ You can change the data proxy type by using: `--seqrepo_dp_type` (options are `l
 To use the REST SeqRepo data proxy at default url: `http://localhost:5000/seqrepo`:
 
 ```commandline
-vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
+vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
 ```
 
 ### Use the REST SeqRepo Data Proxy with different base url
@@ -50,7 +50,7 @@ You can change the SeqRepo REST base url by using: `--seqrepo_base_url`.
 
 To use the REST SeqRepo data proxy, at custom url: `http://custom.url:5000/seqrepo`:
 ```commandline
-vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
+vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
 ```
 
 ### Other Options

--- a/docs/extras/vcf_annotator.md
+++ b/docs/extras/vcf_annotator.md
@@ -10,7 +10,7 @@ The examples run from the root of the vrs-python directory and assumes that `inp
 To see the help page:
 
 ```commandline
-vrs-annotate-vcf --help
+vrs-annotate --help
 ```
 
 ### Use local SeqRepo Data Proxy with default root directory
@@ -20,7 +20,7 @@ The tool uses a SeqRepo data proxy. By default, the local instance at `/usr/loca
 Example of how to run:
 
 ```commandline
-vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 ```
 
 Pass the path of the input VCF file as the argument to the script. Use either `--vcf_out` to specify the path of the output annotated VCF file, or `--vrs_pickle_out` to specify the path of the output pickle file containing VRS data (both `vcf_out` and `vrs_pickle_out` are optional, but at least one __must__ be provided).
@@ -32,7 +32,7 @@ You can change the root directory of SeqRepo by using `seqrepo_root_dir`.
 To use the local SeqRepo data proxy with SeqRepo root directory at `vrs-python/seqrepo/latest`:
 
 ```commandline
-vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
+vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
 ```
 
 ### Use the REST SeqRepo Data Proxy with default base url
@@ -42,7 +42,7 @@ You can change the data proxy type by using: `--seqrepo_dp_type` (options are `l
 To use the REST SeqRepo data proxy at default url: `http://localhost:5000/seqrepo`:
 
 ```commandline
-vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
+vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
 ```
 
 ### Use the REST SeqRepo Data Proxy with different base url
@@ -50,7 +50,7 @@ You can change the SeqRepo REST base url by using: `--seqrepo_base_url`.
 
 To use the REST SeqRepo data proxy, at custom url: `http://custom.url:5000/seqrepo`:
 ```commandline
-vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
+vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
 ```
 
 ### Other Options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ Changelog = "https://github.com/ga4gh/vrs-python/releases"
 Source = "https://github.com/ga4gh/vrs-python"
 "Bug Tracker" = "https://github.com/ga4gh/vrs-python/issues"
 
+[project.scripts]
+vrs-annotate-vcf = "ga4gh.vrs.extras.vcf_annotation:cli"
+
 [build-system]
 requires = ["setuptools>=65.3", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ Source = "https://github.com/ga4gh/vrs-python"
 "Bug Tracker" = "https://github.com/ga4gh/vrs-python/issues"
 
 [project.scripts]
-vrs-annotate-vcf = "ga4gh.vrs.extras.vcf_annotation:_cli"
+vrs-annotate = "ga4gh.vrs.extras.vcf_annotation:_cli"
 
 [build-system]
 requires = ["setuptools>=65.3", "setuptools_scm>=8"]

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -1,6 +1,6 @@
 """Annotate VCFs with VRS
 
-    $ vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+    $ vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 
 """
 import pathlib
@@ -120,7 +120,7 @@ def _cli(  # pylint: disable=too-many-arguments
 ) -> None:
     """Extract VRS objects from VCF located at VCF_IN.
 
-        $ vrs-annotate-vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+        $ vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 
     Note that at least one of --vcf_out or --vrs_pickle_out must be selected and defined.
     """

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -1,6 +1,6 @@
 """Annotate VCFs with VRS
 
-    $ vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+    $ vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 
 """
 import pathlib
@@ -125,7 +125,7 @@ def _annotate_vcf_cli(  # pylint: disable=too-many-arguments
 ) -> None:
     """Extract VRS objects from VCF located at VCF_IN.
 
-        $ vrs-annotate input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+        $ vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 
     Note that at least one of --vcf_out or --vrs_pickle_out must be selected and defined.
     """

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -3,6 +3,7 @@
 Example of how to run from root of vrs-python directory:
 python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz \
     --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+# TODO update that
 """
 import logging
 import pickle
@@ -109,7 +110,7 @@ class SeqRepoProxyType(str, Enum):
     show_default=True,
     help="Require validation checks to pass in order to return a VRS object"
 )
-def annotate_click(  # pylint: disable=too-many-arguments
+def cli(  # pylint: disable=too-many-arguments
     vcf_in: str, vcf_out: Optional[str], vrs_pickle_out: Optional[str],
     vrs_attributes: bool, seqrepo_dp_type: SeqRepoProxyType, seqrepo_root_dir: str,
     seqrepo_base_url: str, assembly: str, skip_ref: bool, require_validation: bool
@@ -118,7 +119,7 @@ def annotate_click(  # pylint: disable=too-many-arguments
 
     Example arguments:
 
-    --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+    --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl  # TODO update that
     """
     annotator = VCFAnnotator(seqrepo_dp_type, seqrepo_base_url, seqrepo_root_dir)
     start = timer()
@@ -411,9 +412,3 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
                 )
 
         return vrs_field_data
-
-
-if __name__ == "__main__":
-    # python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz \
-    #    --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
-    annotate_click()  # pylint: disable=no-value-for-parameter

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -33,8 +33,13 @@ class SeqRepoProxyType(str, Enum):
     LOCAL = "local"
     REST = "rest"
 
+@click.group()
+def _cli() -> None:
+    """Annotate input files with VRS variation objects."""
 
-@click.command()
+
+
+@_cli.command(name="vcf")
 @click.argument(
     "vcf_in",
     nargs=1,
@@ -112,7 +117,7 @@ class SeqRepoProxyType(str, Enum):
     default=False,
     help="Suppress messages printed to stdout"
 )
-def _cli(  # pylint: disable=too-many-arguments
+def _annotate_vcf_cli(  # pylint: disable=too-many-arguments
     vcf_in: pathlib.Path, vcf_out: pathlib.Path | None, vrs_pickle_out: pathlib.Path | None,
     vrs_attributes: bool, seqrepo_dp_type: SeqRepoProxyType, seqrepo_root_dir: pathlib.Path,
     seqrepo_base_url: str, assembly: str, skip_ref: bool, require_validation: bool,


### PR DESCRIPTION
Declare the annotator `click` function as a console entry point, enabling `vrs-annotate input.vcf --vcf_out=out.vcf` rather than `python3 src/ga4gh/vrs/extras/vcf_annotation.py input.vcf --vcf_out=out.vcf`.

Open to suggestions on the command name. I'd prefer a structure more along the lines of `vrs-annotate vcf input.vcf --vcf_out=out.vcf` (i.e., `vrs-annotate` is the command, `vcf` is a subcommand) if we think there's a chance that other filetypes could be annotated in the future (in that case, we may want to alter the module name as well). Alternatively, though, the subcommand might be superfluous if the file argument has a suffix indicating the filetype.