### PR TITLE
feat!: enhance annotator CLI options

### DIFF
--- a/docs/extras/vcf_annotator.md
+++ b/docs/extras/vcf_annotator.md
@@ -20,10 +20,10 @@ The tool uses a SeqRepo data proxy. By default, the local instance at `/usr/loca
 Example of how to run:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 ```
 
-`--vcf_in` specifies the path of the input VCF file to annotate. `--vcf_out` specifies the path of the output annotated VCF file. The `--vrs_pickle_out` specifies the path of the output pickle file containing VRS data (Both vcf_out and vrs_pickle_out are optional, but at least one __must__ be provided).
+Pass the path of the input VCF file as the argument to the script. Use either `--vcf_out` to specify the path of the output annotated VCF file, or `--vrs_pickle_out` to specify the path of the output pickle file containing VRS data (both `vcf_out` and `vrs_pickle_out` are optional, but at least one __must__ be provided).
 
 ### Use local SeqRepo Data Proxy with different
 
@@ -32,7 +32,7 @@ You can change the root directory of SeqRepo by using `seqrepo_root_dir`.
 To use the local SeqRepo data proxy with SeqRepo root directory at `vrs-python/seqrepo/latest`:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
+python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_root_dir vrs-python/seqrepo/latest
 ```
 
 ### Use the REST SeqRepo Data Proxy with default base url
@@ -42,7 +42,7 @@ You can change the data proxy type by using: `--seqrepo_dp_type` (options are `l
 To use the REST SeqRepo data proxy at default url: `http://localhost:5000/seqrepo`:
 
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
+python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest
 ```
 
 ### Use the REST SeqRepo Data Proxy with different base url
@@ -50,7 +50,7 @@ You can change the SeqRepo REST base url by using: `--seqrepo_base_url`.
 
 To use the REST SeqRepo data proxy, at custom url: `http://custom.url:5000/seqrepo`:
 ```commandline
-python3 -m src.ga4gh.vrs.extras.vcf_annotation --vcf_in input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
+python3 -m src.ga4gh.vrs.extras.vcf_annotation input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl --seqrepo_dp_type rest --seqrepo_base_url http://custom.url:5000/seqrepo
 ```
 
 ### Other Options

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -121,7 +121,9 @@ def annotate_click(  # pylint: disable=too-many-arguments
 ) -> None:
     """Extract VRS objects from VCF located at VCF_IN.
 
-        python3 src/ga4gh/vrs/extras/vcf_annotation.py input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+        $ python3 src/ga4gh/vrs/extras/vcf_annotation.py input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+
+    Note that at least one of --vcf_out or --vrs_pickle_out must be selected and defined.
     """
     annotator = VCFAnnotator(seqrepo_dp_type, seqrepo_base_url, str(seqrepo_root_dir.absolute()))
     vcf_out_str = str(vcf_out.absolute()) if vcf_out is not None else vcf_out

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -104,7 +104,7 @@ class SeqRepoProxyType(str, Enum):
     "--require_validation",
     is_flag=True,
     default=False,
-    help="Require validation checks to pass to annotate a record with a VRS object."
+    help="Require validation checks to pass to construct a VRS object."
 )
 @click.option(
     "--silent",
@@ -117,7 +117,7 @@ def annotate_click(  # pylint: disable=too-many-arguments
     vcf_in: pathlib.Path, vcf_out: pathlib.Path | None, vrs_pickle_out: pathlib.Path | None,
     vrs_attributes: bool, seqrepo_dp_type: SeqRepoProxyType, seqrepo_root_dir: pathlib.Path,
     seqrepo_base_url: str, assembly: str, skip_ref: bool, require_validation: bool,
-    silent: bool
+    silent: bool,
 ) -> None:
     """Extract VRS objects from VCF located at VCF_IN.
 

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -91,7 +91,7 @@ class SeqRepoProxyType(str, Enum):
     required=False,
     default="GRCh38",
     show_default=True,
-    help="Specify assembly that was used to create VCF at `vcf_in`.",
+    help="Specify assembly that was used to create input VCF.",
     type=str
 )
 @click.option(


### PR DESCRIPTION
* Make the input VCF path an [argument](https://click.palletsprojects.com/en/8.1.x/arguments/) rather than an [option](https://click.palletsprojects.com/en/8.1.x/options/). I think this better matches the intent of the tool (and it was the only required option, so might as well make it an arg, right?). Left it at `nargs=1` but I think there's a case for making it `nargs=-1`... but going 1 -> -1 wouldn't be a breaking change imo so I think it's fine to put that decision off.
* pathlike args should be `click.Path`/`pathlib.Path`. Add additional configurations, like the input file must exist and the output files must be writable. Didn't make changes further up the stack because I wanted to confine this PR to just the Click interface.
* remove some superfluous/inactive configs
* Touch up help text