### PR TITLE
cicd: fix action caching key

### DIFF
--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Reece added this several years ago, but there's no `requirements.txt` file in the repo, so this doesn't do anything. Tying it to `pyproject.toml` does mean that you could have some unnecessary cache invalidations e.g. if some style configs change, but that's probably ok (and an improvement over the status quo).