### PR TITLE
feat: make VRS schema release info accessible in VRS-Python

### DIFF
--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -21,6 +21,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        fetch-tags: true
+        fetch-depth: 1
     - uses: actions/cache@v4
       with:
         path: ~/.cache/pip

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+from setuptools import setup
+from pathlib import Path
+import subprocess
+
+
+class VrsSubmoduleFetchError(Exception):
+    """Raise for errors during submodule metadata extraction"""
+
+
+def get_vrs_submodule_info():
+    """Retrieve the commit hash and tag from the vrs submodule."""
+    try:
+        try:
+            tag = subprocess.check_output(
+                ["git", "describe", "--tags", "--abbrev=0"], cwd="submodules/vrs", text=True
+            ).strip()
+        except subprocess.CalledProcessError:
+            raise VrsSubmoduleFetchError
+        return tag
+    except Exception as e:
+        raise VrsSubmoduleFetchError from e
+
+
+def write_metadata_file():
+    """Generate a Python module with submodule metadata."""
+    tag = get_vrs_submodule_info()
+    metadata_path = Path("src/ga4gh/vrs/submodule_metadata.py")
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(
+        f"# Auto-generated metadata from VRS schema submodule\n"
+        f"VRS_RELEASE = '{tag}'\n"
+    )
+
+
+write_metadata_file()
+
+# Use setuptools for the actual build (delegates to pyproject.toml)
+setup()

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,9 @@ class VrsSubmoduleFetchError(Exception):
 def get_vrs_submodule_info():
     """Retrieve the commit hash and tag from the vrs submodule."""
     try:
-        try:
-            tag = subprocess.check_output(
-                ["git", "describe", "--tags", "--abbrev=0"], cwd="submodules/vrs", text=True
-            ).strip()
-        except subprocess.CalledProcessError:
-            raise VrsSubmoduleFetchError
-        return tag
+        return subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0"], cwd="submodules/vrs", text=True
+        ).strip()
     except Exception as e:
         raise VrsSubmoduleFetchError from e
 

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,10 @@ def _get_vrs_submodule_info() -> tuple[str, str, int]:
         commit = subprocess.check_output(
             ["git", "rev-parse", "HEAD"], cwd=vrs_path, text=True
         ).strip()
-        print("hey i'm debugging here")
-        subprocess.run(["git", "fetch", "--tags"])
-        print("hey i'm debugging here")
+        subprocess.run(["git", "fetch", "--tags"], cwd=vrs_path)
         tag = subprocess.check_output(
             ["git", "describe", "--tags", "--abbrev=0"], cwd=vrs_path, text=True
         ).strip()
-        print("hey i'm debugging here")
         distance =  subprocess.check_output(
             ["git", "rev-list", f"{tag}..HEAD", "--count"],
             cwd=vrs_path,

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ def _get_vrs_submodule_info() -> tuple[str, str, int]:
         commit = subprocess.check_output(
             ["git", "rev-parse", "HEAD"], cwd=vrs_path, text=True
         ).strip()
+        subprocess.run(["git", "fetch", "--tags"])
         tag = subprocess.check_output(
             ["git", "describe", "--tags", "--abbrev=0"], cwd=vrs_path, text=True
         ).strip()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def _get_vrs_submodule_info() -> tuple[str, str, int]:
         commit = subprocess.check_output(
             ["git", "rev-parse", "HEAD"], cwd=vrs_path, text=True
         ).strip()
-        subprocess.run(["git", "fetch", "--tags"], cwd=vrs_path)
+        subprocess.run(["git", "fetch", "--all", "--tags"], cwd=vrs_path)
         tag = subprocess.check_output(
             ["git", "describe", "--tags", "--abbrev=0"], cwd=vrs_path, text=True
         ).strip()

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,17 @@ def _get_vrs_submodule_info() -> tuple[str, str, int]:
     """
     try:
         vrs_path = "submodules/vrs"
+        print("debug 1")
         commit = subprocess.check_output(
             ["git", "rev-parse", "HEAD"], cwd=vrs_path, text=True
         ).strip()
+        print("debug 2")
         subprocess.run(["git", "fetch", "--all", "--tags"], cwd=vrs_path)
+        print("debug 3")
         tag = subprocess.check_output(
             ["git", "describe", "--tags", "--abbrev=0"], cwd=vrs_path, text=True
         ).strip()
+        print("debug 4")
         distance =  subprocess.check_output(
             ["git", "rev-list", f"{tag}..HEAD", "--count"],
             cwd=vrs_path,

--- a/setup.py
+++ b/setup.py
@@ -7,24 +7,41 @@ class VrsSubmoduleFetchError(Exception):
     """Raise for errors during submodule metadata extraction"""
 
 
-def get_vrs_submodule_info():
-    """Retrieve the commit hash and tag from the vrs submodule."""
+def _get_vrs_submodule_info() -> tuple[str, str, int]:
+    """Retrieve the commit hash and tag from the vrs submodule.
+
+    :return: tuple containing commit hash, latest version tag, and rev distance between them
+    """
     try:
-        return subprocess.check_output(
-            ["git", "describe", "--tags", "--abbrev=0"], cwd="submodules/vrs", text=True
+        vrs_path = "submodules/vrs"
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=vrs_path, text=True
         ).strip()
+        tag = subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0"], cwd=vrs_path, text=True
+        ).strip()
+        distance =  subprocess.check_output(
+            ["git", "rev-list", f"{tag}..HEAD", "--count"],
+            cwd=vrs_path,
+            text=True,
+        ).strip()
+        return commit, tag, int(distance)
     except Exception as e:
         raise VrsSubmoduleFetchError from e
 
 
 def write_metadata_file():
     """Generate a Python module with submodule metadata."""
-    tag = get_vrs_submodule_info()
+    commit, tag, distance = _get_vrs_submodule_info()
     metadata_path = Path("src/ga4gh/vrs/submodule_metadata.py")
     metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    if distance == 0:
+        version = tag
+    else:
+        version = f"{tag}.dev{distance}+g{commit}"
     metadata_path.write_text(
         f"# Auto-generated metadata from VRS schema submodule\n"
-        f"VRS_RELEASE = '{tag}'\n"
+        f"VRS_VERSION = '{version}'\n"
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,13 @@ def _get_vrs_submodule_info() -> tuple[str, str, int]:
         commit = subprocess.check_output(
             ["git", "rev-parse", "HEAD"], cwd=vrs_path, text=True
         ).strip()
+        print("hey i'm debugging here")
         subprocess.run(["git", "fetch", "--tags"])
+        print("hey i'm debugging here")
         tag = subprocess.check_output(
             ["git", "describe", "--tags", "--abbrev=0"], cwd=vrs_path, text=True
         ).strip()
+        print("hey i'm debugging here")
         distance =  subprocess.check_output(
             ["git", "rev-list", f"{tag}..HEAD", "--count"],
             cwd=vrs_path,

--- a/src/ga4gh/vrs/submodule_metadata.py
+++ b/src/ga4gh/vrs/submodule_metadata.py
@@ -1,0 +1,2 @@
+# Auto-generated metadata for VRS submodule
+VRS_TAG = '2.0.0.connect.2024-04.1'

--- a/src/ga4gh/vrs/submodule_metadata.py
+++ b/src/ga4gh/vrs/submodule_metadata.py
@@ -1,2 +1,2 @@
-# Auto-generated metadata for VRS submodule
-VRS_TAG = '2.0.0.connect.2024-04.1'
+# Auto-generated metadata from VRS schema submodule
+VRS_VERSION = '2.0.0.connect.2024-04.1.dev83+gcf968d24a37cefca5a2f363f0e2f36741cd12ad5'


### PR DESCRIPTION
(draft: don't worry about reviewing yet)

close https://github.com/ga4gh/vrs-python/issues/85

* use a hook during setup to grab the most recent release tag from the VRS submodule, then write it as an importable Python module (not necessarily the most elegant way to do this, but I think it's the only realistic option)
* This draft uses the scheme used by [setuptools-scm](https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme) to append commit hash/rev distance when the most recent tag isn't applied to the checked-out commit. I assume that the VRS submodule is tied to a branch and not a tag/commit due to its development status, and maybe this will be unnecessary once that stabilizes.
* very, very low priority. Was just something I was thinking about yesterday.

Current status: for the life of me, I cannot get this to work in CI/CD. Seems to be something about how the GitHub checkout action works and what it does and doesn't get from the `.git` folder. Not sure how to move forward.