### PR TITLE
 test: pin urllib3 version until vcrpy is updated 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = [
     {name = "Andreas Prlic", email = "andreas.prlic@gmail.com"},
     {name = "Alex Wagner", email = "alex.wagner@nationwidechildrens.org"},
 ]
-readme = "README.md"
 description = "GA4GH Variation Representation Specification (VRS) reference implementation"
+readme = "README.md"
 license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ extras = [
     "click",
 ]
 dev = [
+    # testing
+    "urllib3==2.2.3",
     # tests
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,14 +51,13 @@ extras = [
     "click",
 ]
 dev = [
-    # testing
-    "urllib3==2.2.3",
     # tests
     "pytest",
     "pytest-cov",
     "pytest-vcr",
     "vcrpy",
     "pyyaml",
+    "urllib3<2.3.0",  # TODO pending resolution of issue #472
     # style
     "pre-commit>=4.0.1",
     "pylint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = [
     {name = "Andreas Prlic", email = "andreas.prlic@gmail.com"},
     {name = "Alex Wagner", email = "alex.wagner@nationwidechildrens.org"},
 ]
-description = "GA4GH Variation Representation Specification (VRS) reference implementation"
 readme = "README.md"
+description = "GA4GH Variation Representation Specification (VRS) reference implementation"
 license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
address #472 -- see explanation there. pin a non-most-recent urllib3 version until `vcrpy` merges the PR fixing compatibility.
