### PR TITLE
style: lint and format with ruff

### DIFF
--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -2,13 +2,26 @@ name: Python CQA
 
 on: [push, pull_request]
 
-
-# TODO: separate lint and test jobs; lint first, test "needs" lint
-# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobs
-
 jobs:
-  test:
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v5
+      - name: Update pip and setuptools
+        run: |
+          python -m pip install --upgrade pip setuptools
+      - name: Install dependencies
+        run: pip install -e '.[dev]'
+      - name: Check style
+        run: python3 -m ruff check --output-format=github
+      - name: Check formatting
+        run: python3 -m ruff format --check
+
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -16,7 +29,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     env:
       SEQREPO_ROOT_DIR: ./tests/data/seqrepo/latest
-
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -3,7 +3,6 @@ name: Python CQA
 on: [push, pull_request]
 
 jobs:
-
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +22,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs:
+      - lint
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -57,9 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        - cmd: "end-of-file-fixer"
-        - cmd: "trailing-whitespace"
-        - cmd: "mixed-line-ending"
+        cmd:
+          - "end-of-file-fixer"
+          - "trailing-whitespace"
+          - "mixed-line-ending"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -55,7 +55,14 @@ jobs:
 
   precommit_hooks:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        - cmd: "end-of-file-fixer"
+        - cmd: "trailing-whitespace"
+        - cmd: "mixed-line-ending"
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: ${{ matrix.cmd }} --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,10 @@ repos:
         args: [ --allow-missing-credentials ]
       - id: mixed-line-ending
         args: [ --fix=lf ]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.4  # ruff version
+    hooks:
+      - id: ruff-format
+      - id: ruff
+        args: [ --fix, --exit-non-zero-on-fix ]
 minimum_pre_commit_version: 4.0.1

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ else
 endif
 XRM=xargs -0${_XRM_R} rm
 
-PKG=ga4gh.vrs
-PKGD=$(subst .,/,${PKG})
 PYV:=3.12
 VEDIR=venv/${PYV}
 
@@ -89,18 +87,15 @@ doctest:
 ############################################################################
 #= UTILITY TARGETS
 
-# N.B. Although code is stored in github, I use hg and hg-git on the command line
-#=> reformat: reformat code with yapf and commit
-.PHONY: reformat
-reformat:
-	@if ! git diff --cached --exit-code; then echo "Repository not clean" 1>&2; exit 1; fi
-	yapf -i -r "${PKGD}" tests
-	git commit -a -m "reformatted with yapf"
+#=> reformat: reformat code with ruff
+.PHONY: format
+format:
+	python3 -m ruff format
 
 #=> lint -- static analysis check
 .PHONY: lint
 lint:
-	pylint src/ga4gh/{core,vrs} | tee $@
+	python3 -m ruff check --fix
 
 #=> docs -- make sphinx docs
 .PHONY: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,10 @@ exclude = [
     "ANN101",
     "ANN2",
 ]
+"src/ga4gh/vrs/extras/object_store.py" = [
+    "ANN",
+    "D",
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ testpaths = ["tests", "src"]
 doctest_optionflags = "ALLOW_UNICODE ALLOW_BYTES ELLIPSIS IGNORE_EXCEPTION_DETAIL NORMALIZE_WHITESPACE"
 
 [tool.ruff]
-line-length = 120
 src = ["src"]
 exclude = ["docs", "misc", "notebooks", "submodules"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ ignore = [
     "S321",
     "PLC0206",
 ]
+exclude = [
+    "src/ga4gh/vrs/models.py",  # there be monsters here
+]
 
 [tool.ruff.lint.per-file-ignores]
 # ANN001 - missing-type-function-argument
@@ -197,6 +200,9 @@ ignore = [
     "ANN001",
     "ANN201",
     "ANN202",
+]
+"src/ga4gh/vrs/extras/vcf_annotation.py" = [
+    "PTH123",  # see https://github.com/ga4gh/vrs-python/issues/482
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,12 @@ ignore = [
     "INP001",
     "SLF001",
 ]
+"src/ga4gh/vrs/utils/hgvs_tools.py" = [
+    "ANN001",
+    "ANN201",
+    "ANN202",
+    "D102",
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,11 @@ ignore = [
     "ANN202",
     "D102",
 ]
+"src/ga4gh/vrs/normalize.py" = [
+    "ANN001",
+    "ANN201",
+    "ANN202",
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,7 @@ dev = [
     "pyyaml",
     # style
     "pre-commit>=4.0.1",
-    "pylint",
-    "yapf",
+    "ruff~=0.9.4",
     # docs
     "sphinx",
     "sphinx_rtd_theme",
@@ -96,9 +95,98 @@ addopts = "--cov-report=term-missing --cov=ga4gh"
 testpaths = ["tests", "src"]
 doctest_optionflags = "ALLOW_UNICODE ALLOW_BYTES ELLIPSIS IGNORE_EXCEPTION_DETAIL NORMALIZE_WHITESPACE"
 
-[tool.yapf]
-based_on_style = "pep8"
-column_limit = 120
-spaces_before_comment = 4
-split_before_logical_operator = true
-split_before_named_assigns = true
+[tool.ruff]
+line-length = 120
+src = ["src"]
+exclude = ["docs", "misc", "notebooks", "submodules"]
+
+[tool.ruff.lint]
+select = [
+    "F",  # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "E", "W",  # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "I",  # https://docs.astral.sh/ruff/rules/#isort-i
+    "N",  # https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "D",  # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "UP",  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "ANN",  # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "ASYNC",  # https://docs.astral.sh/ruff/rules/#flake8-async-async
+    "S",  # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+    "B",  # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "A",  # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+    "C4",  # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "DTZ",  # https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz
+    "T10",  # https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz
+    "EM",  # https://docs.astral.sh/ruff/rules/#flake8-errmsg-em
+    "LOG",  # https://docs.astral.sh/ruff/rules/#flake8-logging-log
+    "G",  # https://docs.astral.sh/ruff/rules/#flake8-logging-format-g
+    "INP",  # https://docs.astral.sh/ruff/rules/#flake8-no-pep420-inp
+    "PIE",  # https://docs.astral.sh/ruff/rules/#flake8-pie-pie
+    "T20",  # https://docs.astral.sh/ruff/rules/#flake8-print-t20
+    "PT",  # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
+    "Q",  # https://docs.astral.sh/ruff/rules/#flake8-quotes-q
+    "RSE",  # https://docs.astral.sh/ruff/rules/#flake8-raise-rse
+    "RET",  # https://docs.astral.sh/ruff/rules/#flake8-return-ret
+    "SLF",  # https://docs.astral.sh/ruff/rules/#flake8-self-slf
+    "SLOT",  # https://docs.astral.sh/ruff/rules/#flake8-slots-slot
+    "SIM",  # https://docs.astral.sh/ruff/rules/#flake8-simplify-sim
+    "ARG",  # https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg
+    "PTH",  # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "PGH",  # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
+    "PLC",  # https://docs.astral.sh/ruff/rules/#convention-c
+    "PLE",  # https://docs.astral.sh/ruff/rules/#error-e_1
+    "TRY",  # https://docs.astral.sh/ruff/rules/#tryceratops-try
+    "PERF",  # https://docs.astral.sh/ruff/rules/#perflint-perf
+    "FURB",  # https://docs.astral.sh/ruff/rules/#refurb-furb
+    "RUF",  # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
+]
+fixable = ["ALL"]
+# ANN003 - missing-type-kwargs
+# D203 - one-blank-line-before-class
+# D205 - blank-line-after-summary
+# D206 - indent-with-spaces*
+# D213 - multi-line-summary-second-line
+# D300 - triple-single-quotes*
+# D400 - ends-in-period
+# D415 - ends-in-punctuation
+# E111 - indentation-with-invalid-multiple*
+# E114 - indentation-with-invalid-multiple-comment*
+# E117 - over-indented*
+# E501 - line-too-long*
+# W191 - tab-indentation*
+# S321 - suspicious-ftp-lib-usage
+# PLC0206 - dict-index-missing-items
+# *ignored for compatibility with formatter
+ignore = [
+    "ANN003",
+    "D203", "D205", "D206", "D213", "D300", "D400", "D415",
+    "E111", "E114", "E117", "E501",
+    "W191",
+    "S321",
+    "PLC0206",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# ANN001 - missing-type-function-argument
+# ANN2 - missing-return-type
+# D100 - undocumented-public-module
+# D102 - undocumented-public-class
+# D103 - undocumented-public-function
+# S101 - assert
+# B011 - assert-false
+# INP001 - implicit-namespace-package
+"tests/*" = [
+    "ANN001",
+    "ANN2",
+    "D100",
+    "D102",
+    "D103",
+    "S101",
+    "B011",
+    "INP001"
+]
+
+[tool.ruff.lint.flake8-annotations]
+mypy-init-return = true
+
+[tool.ruff.format]
+docstring-code-format = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,10 @@ exclude = [
     "ANN",
     "D",
 ]
+"src/ga4gh/vrs/enderef.py" = [
+    "ANN",
+    "D",
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dev = [
     "pyyaml",
     # style
     "pre-commit>=4.0.1",
-    "ruff~=0.9.4",
+    "ruff==0.9.4",
     # docs
     "sphinx",
     "sphinx_rtd_theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ select = [
     "RUF",  # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
 ]
 fixable = ["ALL"]
+# ANN002 - missing-type-args
 # ANN003 - missing-type-kwargs
 # D203 - one-blank-line-before-class
 # D205 - blank-line-after-summary
@@ -157,7 +158,7 @@ fixable = ["ALL"]
 # PLC0206 - dict-index-missing-items
 # *ignored for compatibility with formatter
 ignore = [
-    "ANN003",
+    "ANN002", "ANN003",
     "D203", "D205", "D206", "D213", "D300", "D400", "D415",
     "E111", "E114", "E117", "E501",
     "W191",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,9 @@ exclude = [
 "src/ga4gh/core/pydantic.py" = [
     "ANN401",
 ]
+"src/ga4gh/core/models.py" = [
+    "UP007",
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ ignore = [
 # S101 - assert
 # B011 - assert-false
 # INP001 - implicit-namespace-package
+# SLF001 - private-member-access
 "tests/*" = [
     "ANN001",
     "ANN2",
@@ -183,7 +184,8 @@ ignore = [
     "D103",
     "S101",
     "B011",
-    "INP001"
+    "INP001",
+    "SLF001",
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,11 @@ exclude = [
 "src/ga4gh/vrs/extras/vcf_annotation.py" = [
     "PTH123",  # see https://github.com/ga4gh/vrs-python/issues/482
 ]
+"src/ga4gh/vrs/extras/translator.py" = [
+    "ANN001",
+    "ANN101",
+    "ANN2",
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,9 @@ exclude = [
 "src/ga4gh/vrs/dataproxy.py" = [
     "B019",
 ]
+"src/ga4gh/core/pydantic.py" = [
+    "ANN401",
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,9 @@ exclude = [
     "ANN",
     "D",
 ]
+"src/ga4gh/vrs/dataproxy.py" = [
+    "B019",
+]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true

--- a/src/ga4gh/core/__init__.py
+++ b/src/ga4gh/core/__init__.py
@@ -1,25 +1,25 @@
 """Python support used across GA4GH projects"""
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
+import ga4gh.core.models as core_models
 from ga4gh.core.digests import sha512t24u
-from ga4gh.core.enderef import ga4gh_enref, ga4gh_deref
+from ga4gh.core.enderef import ga4gh_deref, ga4gh_enref
 from ga4gh.core.identifiers import (
+    CURIE_NAMESPACE,
+    CURIE_SEP,
+    GA4GH_DIGEST_REGEXP,
+    GA4GH_IR_REGEXP,
+    GA4GH_PREFIX_SEP,
+    PrevVrsVersion,
+    VrsObjectIdentifierIs,
     ga4gh_digest,
     ga4gh_identify,
     ga4gh_serialize,
     is_ga4gh_identifier,
-    VrsObjectIdentifierIs,
     use_ga4gh_compute_identifier_when,
-    CURIE_NAMESPACE,
-    CURIE_SEP,
-    GA4GH_PREFIX_SEP,
-    GA4GH_IR_REGEXP,
-    GA4GH_DIGEST_REGEXP,
-    PrevVrsVersion,
 )
-from ga4gh.core.pydantic import is_pydantic_instance, is_curie_type, pydantic_copy
-from ga4gh.core import models as core_models
+from ga4gh.core.pydantic import is_curie_type, is_pydantic_instance, pydantic_copy
 
 __all__ = [
     "CURIE_NAMESPACE",

--- a/src/ga4gh/core/__init__.py
+++ b/src/ga4gh/core/__init__.py
@@ -1,20 +1,24 @@
-"""Python support used across GA4GH projects
-
-"""
+"""Python support used across GA4GH projects"""
 
 from importlib.metadata import version, PackageNotFoundError
 
 from .digests import sha512t24u
 from .enderef import ga4gh_enref, ga4gh_deref
 from .identifiers import (
-    ga4gh_digest, ga4gh_identify, ga4gh_serialize, is_ga4gh_identifier,
-    VrsObjectIdentifierIs, use_ga4gh_compute_identifier_when,
-    CURIE_NAMESPACE, CURIE_SEP, GA4GH_PREFIX_SEP, GA4GH_IR_REGEXP, GA4GH_DIGEST_REGEXP,
-    PrevVrsVersion
+    ga4gh_digest,
+    ga4gh_identify,
+    ga4gh_serialize,
+    is_ga4gh_identifier,
+    VrsObjectIdentifierIs,
+    use_ga4gh_compute_identifier_when,
+    CURIE_NAMESPACE,
+    CURIE_SEP,
+    GA4GH_PREFIX_SEP,
+    GA4GH_IR_REGEXP,
+    GA4GH_DIGEST_REGEXP,
+    PrevVrsVersion,
 )
-from .pydantic import (
-    is_pydantic_instance, is_curie_type, pydantic_copy
-)
+from .pydantic import is_pydantic_instance, is_curie_type, pydantic_copy
 from . import models as core_models
 
 __all__ = [
@@ -41,7 +45,7 @@ __all__ = [
 
 try:
     __version__ = version(__name__)
-except PackageNotFoundError:    # pragma: nocover
+except PackageNotFoundError:  # pragma: nocover
     __version__ = "unknown"
 finally:
     del version, PackageNotFoundError

--- a/src/ga4gh/core/__init__.py
+++ b/src/ga4gh/core/__init__.py
@@ -2,9 +2,9 @@
 
 from importlib.metadata import version, PackageNotFoundError
 
-from .digests import sha512t24u
-from .enderef import ga4gh_enref, ga4gh_deref
-from .identifiers import (
+from ga4gh.core.digests import sha512t24u
+from ga4gh.core.enderef import ga4gh_enref, ga4gh_deref
+from ga4gh.core.identifiers import (
     ga4gh_digest,
     ga4gh_identify,
     ga4gh_serialize,
@@ -18,29 +18,29 @@ from .identifiers import (
     GA4GH_DIGEST_REGEXP,
     PrevVrsVersion,
 )
-from .pydantic import is_pydantic_instance, is_curie_type, pydantic_copy
-from . import models as core_models
+from ga4gh.core.pydantic import is_pydantic_instance, is_curie_type, pydantic_copy
+from ga4gh.core import models as core_models
 
 __all__ = [
-    "sha512t24u",
-    "ga4gh_enref",
-    "ga4gh_deref",
-    "ga4gh_digest",
-    "ga4gh_identify",
-    "ga4gh_serialize",
-    "is_ga4gh_identifier",
-    "VrsObjectIdentifierIs",
-    "use_ga4gh_compute_identifier_when",
     "CURIE_NAMESPACE",
     "CURIE_SEP",
-    "GA4GH_PREFIX_SEP",
-    "GA4GH_IR_REGEXP",
     "GA4GH_DIGEST_REGEXP",
+    "GA4GH_IR_REGEXP",
+    "GA4GH_PREFIX_SEP",
     "PrevVrsVersion",
-    "is_pydantic_instance",
-    "is_curie_type",
-    "pydantic_copy",
+    "VrsObjectIdentifierIs",
     "core_models",
+    "ga4gh_deref",
+    "ga4gh_digest",
+    "ga4gh_enref",
+    "ga4gh_identify",
+    "ga4gh_serialize",
+    "is_curie_type",
+    "is_ga4gh_identifier",
+    "is_pydantic_instance",
+    "pydantic_copy",
+    "sha512t24u",
+    "use_ga4gh_compute_identifier_when",
 ]
 
 try:

--- a/src/ga4gh/core/digests.py
+++ b/src/ga4gh/core/digests.py
@@ -21,7 +21,7 @@ def sha512t24u(blob):
         * encode using base64url encoding
 
     Examples:
-    >>> sha512t24u(b'')
+    >>> sha512t24u(b"")
     'z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXc'
 
     >>> sha512t24u(b"ACGT")

--- a/src/ga4gh/core/digests.py
+++ b/src/ga4gh/core/digests.py
@@ -9,8 +9,8 @@ import base64
 import hashlib
 
 
-def sha512t24u(blob):
-    """generate a base64url-encode, truncated SHA-512 digest for given
+def sha512t24u(blob: bytes) -> str:
+    """Generate a base64url-encode, truncated SHA-512 digest for given
     binary data
 
     The sha512t24u digest is a convention for constructing and
@@ -28,7 +28,6 @@ def sha512t24u(blob):
     'aKF498dAxcJAqme6QYQ7EZ07-fiw8Kw2'
 
     """
-
     digest_size = 24
     digest = hashlib.sha512(blob).digest()
     tdigest_b64us = base64.urlsafe_b64encode(digest[:digest_size])

--- a/src/ga4gh/core/enderef.py
+++ b/src/ga4gh/core/enderef.py
@@ -8,14 +8,11 @@ typically be generated from the schema by
 build_class_referable_attribute_map() in .models.py.
 
 """
+
 import logging
 
 from .identifiers import ga4gh_identify, is_ga4gh_identifier
-from .pydantic import (
-    is_pydantic_instance,
-    is_curie_type,
-    get_pydantic_root,
-    pydantic_copy)
+from .pydantic import is_pydantic_instance, is_curie_type, get_pydantic_root, pydantic_copy
 
 _logger = logging.getLogger(__name__)
 
@@ -32,6 +29,7 @@ def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False):
     (or None), referenced objects will not be stored.
 
     """
+
     def _id_and_store(o):
         _id = ga4gh_identify(o)
         if _id and object_store is not None:
@@ -47,7 +45,7 @@ def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False):
                 setattr(o, ran, [_enref(o2) for o2 in v])
             elif isinstance(v, str):
                 pass
-            elif is_curie_type(v):    # already a reference
+            elif is_curie_type(v):  # already a reference
                 assert is_ga4gh_identifier(v), "Identifiable attribute CURIE is contains an invalid identifier"
             elif v is not None:
                 _id = _id_and_store(v)
@@ -77,6 +75,7 @@ def ga4gh_deref(o, cra_map, object_store):
     Raises KeyError if any object cannot be dereferenced
 
     """
+
     def _deref(o):
         """depth-first recursive, in-place deref of object; returns id of object"""
         if o.type not in cra_map:
@@ -93,7 +92,7 @@ def ga4gh_deref(o, cra_map, object_store):
                 dereffed_identifier = object_store[str(v)]
                 setattr(o, ran, _deref(dereffed_identifier))
             else:
-                pass    # some object; pass as-is
+                pass  # some object; pass as-is
 
         return o
 

--- a/src/ga4gh/core/enderef.py
+++ b/src/ga4gh/core/enderef.py
@@ -12,7 +12,12 @@ build_class_referable_attribute_map() in .models.py.
 import logging
 
 from .identifiers import ga4gh_identify, is_ga4gh_identifier
-from .pydantic import get_pydantic_root, is_curie_type, is_pydantic_instance, pydantic_copy
+from .pydantic import (
+    get_pydantic_root,
+    is_curie_type,
+    is_pydantic_instance,
+    pydantic_copy,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -46,7 +51,9 @@ def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False) -> tup
             elif isinstance(v, str):
                 pass
             elif is_curie_type(v):  # already a reference
-                assert is_ga4gh_identifier(v), "Identifiable attribute CURIE is contains an invalid identifier"  # noqa: S101
+                assert is_ga4gh_identifier(v), (  # noqa: S101
+                    "Identifiable attribute CURIE is contains an invalid identifier"
+                )
             elif v is not None:
                 _id = _id_and_store(v)
                 if _id:

--- a/src/ga4gh/core/enderef.py
+++ b/src/ga4gh/core/enderef.py
@@ -12,12 +12,12 @@ build_class_referable_attribute_map() in .models.py.
 import logging
 
 from .identifiers import ga4gh_identify, is_ga4gh_identifier
-from .pydantic import is_pydantic_instance, is_curie_type, get_pydantic_root, pydantic_copy
+from .pydantic import get_pydantic_root, is_curie_type, is_pydantic_instance, pydantic_copy
 
 _logger = logging.getLogger(__name__)
 
 
-def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False):
+def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False) -> tuple:  # noqa: ANN001
     """Recursively convert "referable attributes" from inlined to
     referenced form.  Returns a new object.
 
@@ -30,13 +30,13 @@ def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False):
 
     """
 
-    def _id_and_store(o):
+    def _id_and_store(o):  # noqa: ANN202 ANN001
         _id = ga4gh_identify(o)
         if _id and object_store is not None:
             object_store[_id] = o
         return _id
 
-    def _enref(o):
+    def _enref(o):  # noqa: ANN202 ANN001
         """depth-first recursive, in-place enref of object; returns id of object"""
         ref_att_names = cra_map.get(o.type, [])
         for ran in ref_att_names:
@@ -46,7 +46,7 @@ def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False):
             elif isinstance(v, str):
                 pass
             elif is_curie_type(v):  # already a reference
-                assert is_ga4gh_identifier(v), "Identifiable attribute CURIE is contains an invalid identifier"
+                assert is_ga4gh_identifier(v), "Identifiable attribute CURIE is contains an invalid identifier"  # noqa: S101
             elif v is not None:
                 _id = _id_and_store(v)
                 if _id:
@@ -55,9 +55,11 @@ def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False):
         return _id_and_store(o)
 
     if not is_pydantic_instance(o):
-        raise ValueError("Called ga4gh_enref() with non-pydantic instance")
+        msg = "Called ga4gh_enref() with non-pydantic instance"
+        raise ValueError(msg)
     if not o.is_ga4gh_identifiable():
-        raise ValueError("Called ga4gh_enref() with non-identifiable object")
+        msg = "Called ga4gh_enref() with non-identifiable object"
+        raise ValueError(msg)
 
     # in-place replacement on object copy
     o = pydantic_copy(o)
@@ -65,7 +67,7 @@ def ga4gh_enref(o, cra_map, object_store=None, return_id_obj_tuple=False):
     return (_id, o) if return_id_obj_tuple else o
 
 
-def ga4gh_deref(o, cra_map, object_store):
+def ga4gh_deref(o, cra_map, object_store):  # noqa: ANN201 ANN001
     """Convert "referable attributes" in-place from referenced to inlined
     form.
 
@@ -76,10 +78,10 @@ def ga4gh_deref(o, cra_map, object_store):
 
     """
 
-    def _deref(o):
+    def _deref(o):  # noqa: ANN202 ANN001
         """depth-first recursive, in-place deref of object; returns id of object"""
         if o.type not in cra_map:
-            _logger.warning(f"{o.type} not in cra_map {cra_map}")
+            _logger.warning("%s not in cra_map %s", o.type, cra_map)
             return o
 
         ref_att_names = cra_map[o.type]
@@ -97,9 +99,11 @@ def ga4gh_deref(o, cra_map, object_store):
         return o
 
     if not is_pydantic_instance(o):
-        raise ValueError("Called ga4gh_deref() with non-pydantic instance")
+        msg = "Called ga4gh_deref() with non-pydantic instance"
+        raise ValueError(msg)
     if not o.is_ga4gh_identifiable():
-        raise ValueError("Called ga4gh_deref() with non-identifiable object")
+        msg = "Called ga4gh_deref() with non-identifiable object"
+        raise ValueError(msg)
 
     # in-place replacement on object copy
     o = pydantic_copy(o)

--- a/src/ga4gh/core/identifiers.py
+++ b/src/ga4gh/core/identifiers.py
@@ -15,17 +15,17 @@ For that reason, they are implemented here in one file.
 
 """
 
-from canonicaljson import encode_canonical_json
 import contextvars
 import re
 from contextlib import ContextDecorator
 from enum import Enum, IntEnum
-from typing import Optional
+
+from canonicaljson import encode_canonical_json
 from pydantic import BaseModel
 
 from ga4gh.core.pydantic import get_pydantic_root
 
-__all__ = "ga4gh_digest ga4gh_identify ga4gh_serialize is_ga4gh_identifier".split()
+__all__= ["ga4gh_digest", "ga4gh_identify", "ga4gh_serialize", "is_ga4gh_identifier"]
 
 CURIE_NAMESPACE = "ga4gh"
 CURIE_SEP = ":"
@@ -38,8 +38,7 @@ NS_W_SEP = f"{CURIE_NAMESPACE}{CURIE_SEP}"
 
 
 class VrsObjectIdentifierIs(IntEnum):
-    """
-    Defines the state for when the `ga4gh_identify` method should compute
+    """Defines the state for when the `ga4gh_identify` method should compute
     an identifier ('id' attribute) for the specified object.  The options are:
       ANY - Always compute the identifier (this is the default behavior)
       GA4GH_INVALID - Compute the identifier if it is missing or is present but syntactically invalid
@@ -64,7 +63,7 @@ class PrevVrsVersion(str, Enum):
     V1_3 = "1.3"
 
     @classmethod
-    def validate(cls, version):
+    def validate(cls, version) -> None:  # noqa: ANN001
         if version is not None and version not in cls.__members__.values():
             err_msg = f"Expected `PrevVrsVersion`, but got {version}"
             raise ValueError(err_msg)
@@ -73,9 +72,8 @@ class PrevVrsVersion(str, Enum):
 ga4gh_compute_identifier_when = contextvars.ContextVar("ga4gh_compute_identifier_when")
 
 
-class use_ga4gh_compute_identifier_when(ContextDecorator):
-    """
-    Context manager that defines when to compute identifiers
+class use_ga4gh_compute_identifier_when(ContextDecorator):  # noqa: N801
+    """Context manager that defines when to compute identifiers
     for all operations within the context.  For example:
 
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.GA4GH_INVALID):
@@ -91,15 +89,15 @@ class use_ga4gh_compute_identifier_when(ContextDecorator):
         self.when = when
         self.token = None
 
-    def __enter__(self):
+    def __enter__(self):  # noqa: ANN204
         self.token = ga4gh_compute_identifier_when.set(self.when)
 
-    def __exit__(self, exc_type, exc, exc_tb):
+    def __exit__(self, exc_type, exc, exc_tb):  # noqa: ANN204 ANN001
         ga4gh_compute_identifier_when.reset(self.token)
 
 
-def is_ga4gh_identifier(ir):
-    """
+def is_ga4gh_identifier(ir: str) -> bool:
+    """Check whether a string is a valid GA4GH identifier
 
     >>> is_ga4gh_identifier("ga4gh:SQ.0123abcd")
     True
@@ -114,7 +112,7 @@ def is_ga4gh_identifier(ir):
     return str(get_pydantic_root(ir)).startswith(NS_W_SEP)
 
 
-def ga4gh_identify(vro, in_place: str = "default", as_version: PrevVrsVersion | None = None) -> str | None:
+def ga4gh_identify(vro, in_place: str = "default", as_version: PrevVrsVersion | None = None) -> str | None:  # noqa: ANN001
     """Return the GA4GH digest-based id for the object, as a CURIE
     (string).  Returns None if object is not identifiable.
 
@@ -188,14 +186,12 @@ def ga4gh_digest(vro: BaseModel, overwrite: bool = False, as_version: PrevVrsVer
     if vro.is_ga4gh_identifiable():
         if as_version is None:
             return vro.get_or_create_digest(overwrite)
-        else:
-            return vro.compute_digest(as_version=as_version)
-    else:
-        return None
+        return vro.compute_digest(as_version=as_version)
+    return None
 
 
-def ga4gh_serialize(obj: BaseModel, as_version: PrevVrsVersion | None = None) -> Optional[bytes]:
-    """Serializes an object for use in computed digest computation.
+def ga4gh_serialize(obj: BaseModel, as_version: PrevVrsVersion | None = None) -> bytes | None:
+    """Serialize an object for use in computed digest computation.
 
     If ``as_version`` is provided, the returned serialization follows
     the conventions of the VRS version indicated by ``as_version_``.
@@ -204,5 +200,4 @@ def ga4gh_serialize(obj: BaseModel, as_version: PrevVrsVersion | None = None) ->
 
     if as_version is None:
         return encode_canonical_json(obj.ga4gh_serialize())
-    else:
-        return obj.ga4gh_serialize_as_version(as_version)
+    return obj.ga4gh_serialize_as_version(as_version)

--- a/src/ga4gh/core/identifiers.py
+++ b/src/ga4gh/core/identifiers.py
@@ -14,6 +14,7 @@ For example, here is a call path for ga4gh_identify called on an Allele:
 For that reason, they are implemented here in one file.
 
 """
+
 from canonicaljson import encode_canonical_json
 import contextvars
 import re
@@ -113,7 +114,7 @@ def is_ga4gh_identifier(ir):
     return str(get_pydantic_root(ir)).startswith(NS_W_SEP)
 
 
-def ga4gh_identify(vro, in_place: str = 'default', as_version: PrevVrsVersion | None = None) -> str | None:
+def ga4gh_identify(vro, in_place: str = "default", as_version: PrevVrsVersion | None = None) -> str | None:
     """Return the GA4GH digest-based id for the object, as a CURIE
     (string).  Returns None if object is not identifiable.
 
@@ -133,7 +134,11 @@ def ga4gh_identify(vro, in_place: str = 'default', as_version: PrevVrsVersion | 
 
     >>> from ga4gh.core import ga4gh_identify
     >>> import ga4gh.vrs
-    >>> location = ga4gh.vrs.models.SequenceLocation(start=44908821, end=44908822, sequenceReference=ga4gh.vrs.models.SequenceReference(refgetAccession="SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"))
+    >>> location = ga4gh.vrs.models.SequenceLocation(
+    ...     start=44908821,
+    ...     end=44908822,
+    ...     sequenceReference=ga4gh.vrs.models.SequenceReference(refgetAccession="SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"),
+    ... )
     >>> ga4gh_identify(location)
     'ga4gh:SL.4t6JnYWqHwYw9WzBT_lmWBb3tLQNalkT'
     """
@@ -170,7 +175,11 @@ def ga4gh_digest(vro: BaseModel, overwrite: bool = False, as_version: PrevVrsVer
 
     >>> from ga4gh.core import ga4gh_digest
     >>> import ga4gh.vrs
-    >>> location = ga4gh.vrs.models.SequenceLocation(start=44908821, end=44908822, sequenceReference=ga4gh.vrs.models.SequenceReference(refgetAccession="SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"))
+    >>> location = ga4gh.vrs.models.SequenceLocation(
+    ...     start=44908821,
+    ...     end=44908822,
+    ...     sequenceReference=ga4gh.vrs.models.SequenceReference(refgetAccession="SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"),
+    ... )
     >>> ga4gh_digest(location)
     '4t6JnYWqHwYw9WzBT_lmWBb3tLQNalkT'
     """

--- a/src/ga4gh/core/identifiers.py
+++ b/src/ga4gh/core/identifiers.py
@@ -112,7 +112,11 @@ def is_ga4gh_identifier(ir: str) -> bool:
     return str(get_pydantic_root(ir)).startswith(NS_W_SEP)
 
 
-def ga4gh_identify(vro, in_place: str = "default", as_version: PrevVrsVersion | None = None) -> str | None:  # noqa: ANN001
+def ga4gh_identify(
+    vro,  # noqa: ANN001
+    in_place: str = "default",
+    as_version: PrevVrsVersion | None = None,
+) -> str | None:
     """Return the GA4GH digest-based id for the object, as a CURIE
     (string).  Returns None if object is not identifiable.
 
@@ -135,7 +139,9 @@ def ga4gh_identify(vro, in_place: str = "default", as_version: PrevVrsVersion | 
     >>> location = ga4gh.vrs.models.SequenceLocation(
     ...     start=44908821,
     ...     end=44908822,
-    ...     sequenceReference=ga4gh.vrs.models.SequenceReference(refgetAccession="SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"),
+    ...     sequenceReference=ga4gh.vrs.models.SequenceReference(
+    ...         refgetAccession="SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+    ...     ),
     ... )
     >>> ga4gh_identify(location)
     'ga4gh:SL.4t6JnYWqHwYw9WzBT_lmWBb3tLQNalkT'
@@ -162,7 +168,9 @@ def ga4gh_identify(vro, in_place: str = "default", as_version: PrevVrsVersion | 
     return None
 
 
-def ga4gh_digest(vro: BaseModel, overwrite: bool = False, as_version: PrevVrsVersion | None = None) -> str | None:
+def ga4gh_digest(
+    vro: BaseModel, overwrite: bool = False, as_version: PrevVrsVersion | None = None
+) -> str | None:
     """Return the GA4GH digest for the object.
 
     Only GA4GH identifiable objects are GA4GH digestible.
@@ -176,7 +184,9 @@ def ga4gh_digest(vro: BaseModel, overwrite: bool = False, as_version: PrevVrsVer
     >>> location = ga4gh.vrs.models.SequenceLocation(
     ...     start=44908821,
     ...     end=44908822,
-    ...     sequenceReference=ga4gh.vrs.models.SequenceReference(refgetAccession="SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"),
+    ...     sequenceReference=ga4gh.vrs.models.SequenceReference(
+    ...         refgetAccession="SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"
+    ...     ),
     ... )
     >>> ga4gh_digest(location)
     '4t6JnYWqHwYw9WzBT_lmWBb3tLQNalkT'
@@ -190,7 +200,9 @@ def ga4gh_digest(vro: BaseModel, overwrite: bool = False, as_version: PrevVrsVer
     return None
 
 
-def ga4gh_serialize(obj: BaseModel, as_version: PrevVrsVersion | None = None) -> bytes | None:
+def ga4gh_serialize(
+    obj: BaseModel, as_version: PrevVrsVersion | None = None
+) -> bytes | None:
     """Serialize an object for use in computed digest computation.
 
     If ``as_version`` is provided, the returned serialization follows

--- a/src/ga4gh/core/identifiers.py
+++ b/src/ga4gh/core/identifiers.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel
 
 from ga4gh.core.pydantic import get_pydantic_root
 
-__all__= ["ga4gh_digest", "ga4gh_identify", "ga4gh_serialize", "is_ga4gh_identifier"]
+__all__ = ["ga4gh_digest", "ga4gh_identify", "ga4gh_serialize", "is_ga4gh_identifier"]
 
 CURIE_NAMESPACE = "ga4gh"
 CURIE_SEP = ":"

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -95,12 +95,8 @@ class Entity(BaseModel, ABC):
         description="The name of the class that is instantiated by a data object representing the Entity.",
     )
     label: Optional[str] = Field(None, description="A primary name for the entity.")
-    description: Optional[str] = Field(
-        None, description="A free-text description of the Entity."
-    )
-    alternativeLabels: Optional[List[str]] = Field(
-        None, description="Alternative name(s) for the Entity."
-    )
+    description: Optional[str] = Field(None, description="A free-text description of the Entity.")
+    alternativeLabels: Optional[List[str]] = Field(None, description="Alternative name(s) for the Entity.")
     extensions: Optional[List[Extension]] = Field(
         None,
         description="A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
@@ -212,7 +208,7 @@ class MappableConcept(Element):
 
     def ga4gh_serialize(self) -> Optional[str]:
         if self.primaryCode:
-          return self.primaryCode.root
+            return self.primaryCode.root
         return None
 
 

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -15,7 +15,7 @@ from pydantic import (
     model_validator,
 )
 
-from ga4gh.core import GA4GH_IR_REGEXP
+from ga4gh.core.identifiers import GA4GH_IR_REGEXP
 
 
 class Relation(str, Enum):

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from abc import ABC
 from enum import Enum
-from typing import Annotated, Any, Dict, List, Optional, Union
+from typing import Annotated, Any, Optional, Union
 
-from ga4gh.core import GA4GH_IR_REGEXP
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -15,6 +14,8 @@ from pydantic import (
     StringConstraints,
     model_validator,
 )
+
+from ga4gh.core import GA4GH_IR_REGEXP
 
 
 class Relation(str, Enum):
@@ -34,7 +35,7 @@ class Relation(str, Enum):
 #########################################
 
 
-class code(RootModel):
+class code(RootModel):  # noqa: N801
     """Indicates that the value is taken from a set of controlled strings defined
     elsewhere. Technically, a code is restricted to a string which has at least one
     character and no leading or trailing whitespace, and where there is no whitespace
@@ -50,7 +51,7 @@ class code(RootModel):
     )
 
 
-class iriReference(RootModel):
+class iriReference(RootModel):  # noqa: N801
     """An IRI Reference (either an IRI or a relative-reference), according to `RFC3986
     section 4.1 <https://datatracker.ietf.org/doc/html/rfc3986#section-4.1>`_ and
     `RFC3987 section 2.1 <https://datatracker.ietf.org/doc/html/rfc3987#section-2.1>`_.
@@ -58,10 +59,10 @@ class iriReference(RootModel):
     <https://datatracker.ietf.org/doc/html/rfc6901#section-6>`_.
     """
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> int:  # noqa: D105
         return self.root.__hash__()
 
-    def ga4gh_serialize(self) -> str:
+    def ga4gh_serialize(self) -> str:  # noqa: D102
         m = GA4GH_IR_REGEXP.match(self.root)
         if m is not None:
             return m["digest"]
@@ -96,8 +97,8 @@ class Entity(BaseModel, ABC):
     )
     label: Optional[str] = Field(None, description="A primary name for the entity.")
     description: Optional[str] = Field(None, description="A free-text description of the Entity.")
-    alternativeLabels: Optional[List[str]] = Field(None, description="Alternative name(s) for the Entity.")
-    extensions: Optional[List[Extension]] = Field(
+    alternativeLabels: Optional[list[str]] = Field(None, description="Alternative name(s) for the Entity.")  # noqa: N815
+    extensions: Optional[list[Extension]] = Field(
         None,
         description="A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
     )
@@ -113,7 +114,7 @@ class Element(BaseModel, ABC):
         None,
         description="The 'logical' identifier of the data element in the system of record, e.g. a UUID.  This 'id' is unique within a given system, but may or may not be globally unique outside the system. It is used within a system to reference an object from another.",
     )
-    extensions: Optional[List[Extension]] = Field(
+    extensions: Optional[list[Extension]] = Field(
         None,
         description="A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
     )
@@ -137,11 +138,11 @@ class Coding(Element):
         ...,
         description="The terminology/code system that defined the code. May be reported as a free-text name (e.g. 'Sequence Ontology'), but it is preferable to provide a uri/url for the system. When the 'code' is reported as a CURIE, the 'system' should be reported as the uri that the CURIE's prefix expands to (e.g. 'http://purl.obofoundry.org/so.owl/' for the Sequence Ontology).",
     )
-    systemVersion: Optional[str] = Field(
+    systemVersion: Optional[str] = Field(  # noqa: N815
         None,
         description="Version of the terminology or code system that provided the code.",
     )
-    code: "code"  # Cannot use Field due to PydanticUserError: field name and type annotation must not clash.
+    code: code  # Cannot use Field due to PydanticUserError: field name and type annotation must not clash.
 
 
 class ConceptMapping(Element):
@@ -171,7 +172,7 @@ class Extension(Element):
         ...,
         description="A name for the Extension. Should be indicative of its meaning and/or the type of information it value represents.",
     )
-    value: Optional[Union[float, str, bool, Dict[str, Any], List[Any]]] = Field(
+    value: Optional[Union[float, str, bool, dict[str, Any], list[Any]]] = Field(
         ...,
         description="The value of the Extension - can be any primitive or structured object",
     )
@@ -184,29 +185,29 @@ class Extension(Element):
 class MappableConcept(Element):
     """A concept label that may be mapped to one or more `Codings`."""
 
-    conceptType: Optional[str] = Field(
+    conceptType: Optional[str] = Field(  # noqa: N815
         None,
         description="A term indicating the type of concept being represented by the MappableConcept.",
     )
     label: Optional[str] = Field(None, description="A primary name for the concept.")
-    primaryCode: Optional[code] = Field(
+    primaryCode: Optional[code] = Field(  # noqa: N815
         None,
         description="A primary code for the concept that is used to identify the concept in a terminology or code system. If there is a public code system for the primaryCode then it should also be specified in the mappings array with a relation of 'exactMatch'. This attribute is provided to both allow a more technical code to be used when a public Coding with a system is not available as well as when it is available but should be identified as the primary code.",
     )
-    mappings: Optional[List[ConceptMapping]] = Field(
+    mappings: Optional[list[ConceptMapping]] = Field(
         None,
         description="A list of mappings to concepts in terminologies or code systems. Each mapping should include a coding and a relation.",
     )
 
     @model_validator(mode="after")
-    def require_label_or_primary_code(cls, v):
+    def require_label_or_primary_code(cls, v):  # noqa: ANN001 N805 ANN201
         """Ensure that ``label`` or ``primaryCode`` is provided"""
         if v.primaryCode is None and v.label is None:
             err_msg = "`One of label` or `primaryCode` must be provided."
             raise ValueError(err_msg)
         return v
 
-    def ga4gh_serialize(self) -> Optional[str]:
+    def ga4gh_serialize(self) -> Optional[str]:  # noqa: D102
         if self.primaryCode:
             return self.primaryCode.root
         return None

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -96,8 +96,12 @@ class Entity(BaseModel, ABC):
         description="The name of the class that is instantiated by a data object representing the Entity.",
     )
     label: Optional[str] = Field(None, description="A primary name for the entity.")
-    description: Optional[str] = Field(None, description="A free-text description of the Entity.")
-    alternativeLabels: Optional[list[str]] = Field(None, description="Alternative name(s) for the Entity.")  # noqa: N815
+    description: Optional[str] = Field(
+        None, description="A free-text description of the Entity."
+    )
+    alternativeLabels: Optional[list[str]] = Field(  # noqa: N815
+        None, description="Alternative name(s) for the Entity."
+    )
     extensions: Optional[list[Extension]] = Field(
         None,
         description="A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",

--- a/src/ga4gh/core/pydantic.py
+++ b/src/ga4gh/core/pydantic.py
@@ -1,13 +1,15 @@
+"""Provide helpful methods related to pydantic objects."""
 import re
-from typing import Any, Union
+from typing import Any
+
 from pydantic import BaseModel, RootModel
 
 
-def getattr_in(obj, names) -> Any:
-    """
-    Calls getattr on obj and the successive returns from getattr
+def getattr_in(obj, names) -> Any:  # noqa: ANN001
+    """Call getattr on obj and the successive returns from getattr
     using names as attribute names in order. If any return is None,
     terminate early, and return None.
+
     Like clojure (get-in obj names) or (some-> obj .name1 .name2 ...)
     """
     names_i = 0
@@ -22,8 +24,8 @@ def getattr_in(obj, names) -> Any:
 
 
 def is_curie_type(o: Any) -> bool:
-    """
-    Returns true if the object is a str-like matching the CURIE pattern.
+    """Return true if the object is a str-like matching the CURIE pattern.
+
     If object is a Pydantic custom root type, extracts the value first,
     which enables (for example) a GA4GH iriReference pydantic model object to be passed.
     """
@@ -34,26 +36,24 @@ def is_curie_type(o: Any) -> bool:
     return False
 
 
-def is_pydantic_instance(o: Any) -> bool:
+def is_pydantic_instance(o: Any) -> bool:  # noqa: D103
     return isinstance(o, BaseModel)
 
 
-def get_pydantic_root(obj: Union[Any, RootModel]) -> Any:
-    """
-    If o is a Pydantic custom root type, return the root object, else return the input obj
-    """
+def get_pydantic_root(obj: Any | RootModel) -> Any:
+    """If o is a Pydantic custom root type, return the root object, else return the input obj"""
     if isinstance(obj, RootModel):
         return obj.root
     return obj
 
 
-def pydantic_copy(obj: BaseModel) -> BaseModel:
+def pydantic_copy(obj: BaseModel) -> BaseModel:  # noqa: D103
     pydantic_class = type(obj)
     if not issubclass(pydantic_class, BaseModel):
-        raise RuntimeError("Argument was not a pydantic model: " + str(pydantic_class))
+        msg = f"Argument was not a pydantic model: {pydantic_class!r}"
+        raise RuntimeError(msg)  # noqa: TRY004
 
     # Treat RootModel differently, it's a thin wrapper of another object, has no fields
     if issubclass(pydantic_class, RootModel):
         return pydantic_class(obj.model_dump())
-    else:
-        return pydantic_class(**obj.model_dump())
+    return pydantic_class(**obj.model_dump())

--- a/src/ga4gh/core/pydantic.py
+++ b/src/ga4gh/core/pydantic.py
@@ -1,4 +1,5 @@
 """Provide helpful methods related to pydantic objects."""
+
 import re
 from typing import Any
 

--- a/src/ga4gh/core/pydantic.py
+++ b/src/ga4gh/core/pydantic.py
@@ -30,7 +30,7 @@ def is_curie_type(o: Any) -> bool:
     if isinstance(o, RootModel):
         o = o.root
     if isinstance(o, str):
-        return re.match(r'[a-zA-Z0-9.]+:\S+', o)
+        return re.match(r"[a-zA-Z0-9.]+:\S+", o)
     return False
 
 

--- a/src/ga4gh/vrs/__init__.py
+++ b/src/ga4gh/vrs/__init__.py
@@ -1,16 +1,15 @@
-# flake8: noqa
 """Public interface to the GA4GH Variation Representation reference
 implementation
 """
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
-from .normalize import normalize
-from .enderef import vrs_deref, vrs_enref
-from .models import VrsType
-from . import models
+from ga4gh.vrs import models
+from ga4gh.vrs.enderef import vrs_deref, vrs_enref
+from ga4gh.vrs.models import VrsType
+from ga4gh.vrs.normalize import normalize
 
-__all__ = ["normalize", "vrs_deref", "vrs_enref", "VrsType", "models"]
+__all__ = ["VrsType", "models", "normalize", "vrs_deref", "vrs_enref"]
 
 try:
     __version__ = version(__name__)

--- a/src/ga4gh/vrs/__init__.py
+++ b/src/ga4gh/vrs/__init__.py
@@ -2,6 +2,7 @@
 """Public interface to the GA4GH Variation Representation reference
 implementation
 """
+
 from importlib.metadata import version, PackageNotFoundError
 
 from .normalize import normalize
@@ -9,17 +10,11 @@ from .enderef import vrs_deref, vrs_enref
 from .models import VrsType
 from . import models
 
-__all__ = [
-    "normalize",
-    "vrs_deref",
-    "vrs_enref",
-    "VrsType",
-    "models"
-]
+__all__ = ["normalize", "vrs_deref", "vrs_enref", "VrsType", "models"]
 
 try:
     __version__ = version(__name__)
-except PackageNotFoundError:    # pragma: nocover
+except PackageNotFoundError:  # pragma: nocover
     __version__ = "unknown"
 finally:
     del version, PackageNotFoundError

--- a/src/ga4gh/vrs/dataproxy.py
+++ b/src/ga4gh/vrs/dataproxy.py
@@ -18,7 +18,6 @@ from bioutils.accessions import coerce_namespace
 import requests
 
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -151,8 +150,7 @@ class _DataProxy(ABC):
         return refget_accession
 
     def validate_ref_seq(
-        self, sequence_id: str, start_pos: int, end_pos: int, ref: str,
-        require_validation: bool = True
+        self, sequence_id: str, start_pos: int, end_pos: int, ref: str, require_validation: bool = True
     ) -> None:
         """Determine whether or not the expected reference sequence matches the actual
         reference sequence. Returns ``None``, but invalid results are logged at level
@@ -181,6 +179,7 @@ class _DataProxy(ABC):
 
             if require_validation:
                 raise DataProxyValidationError(err_msg)
+
 
 class _SeqRepoDataProxyBase(_DataProxy):
     # wraps seqreqpo classes in order to provide translation to/from
@@ -229,7 +228,7 @@ class SeqRepoDataProxy(_SeqRepoDataProxyBase):
             "alphabet": seqinfo["alpha"],
             "added": _isoformat(seqinfo["added"]),
             "aliases": [f"{a['namespace']}:{a['alias']}" for a in aliases],
-            }
+        }
         return md
 
 
@@ -285,17 +284,14 @@ class SequenceProxy(Sequence):
         raise NotImplementedError("Reversed iteration of a SequenceProxy is not implemented")
 
     def __getitem__(self, key):
-        """return sequence for key (slice), fetching if necessary
-
-        """
+        """return sequence for key (slice), fetching if necessary"""
 
         if isinstance(key, int):
-            key = slice(key, key+1)
+            key = slice(key, key + 1)
         if key.step is not None:
             raise ValueError("Only contiguous sequence slices are supported")
 
         return self.dp.get_sequence(self.alias, key.start, key.stop)
-
 
 
 def _isoformat(o):
@@ -316,12 +312,14 @@ def _isoformat(o):
     # eg: '2015-09-25T23:14:42.588601Z'
     return o.isoformat("T") + "Z"
 
+
 # Future implementations
 # * The RefGetDataProxy is waiting on support for sequence lookup by alias
 # class RefGetDataProxy(_DataProxy):
 #     def __init__(self, base_url):
 #         super().__init__()
 #         self.base_url = base_url
+
 
 def create_dataproxy(uri: str = None) -> _DataProxy:
     """Create a dataproxy from uri or GA4GH_VRS_DATAPROXY_URI
@@ -335,8 +333,7 @@ def create_dataproxy(uri: str = None) -> _DataProxy:
 
     """
 
-    uri = (uri
-           or os.environ.get("GA4GH_VRS_DATAPROXY_URI", None))
+    uri = uri or os.environ.get("GA4GH_VRS_DATAPROXY_URI", None)
 
     if uri is None:
         raise ValueError("No data proxy URI provided or found in GA4GH_VRS_DATAPROXY_URI")
@@ -353,10 +350,11 @@ def create_dataproxy(uri: str = None) -> _DataProxy:
         if proto in ("", "file"):
             # pylint: disable=import-error, import-outside-toplevel
             from biocommons.seqrepo import SeqRepo
+
             sr = SeqRepo(root_dir=parsed_uri.path)
             dp = SeqRepoDataProxy(sr)
         elif proto in ("http", "https"):
-            dp = SeqRepoRESTDataProxy(uri[len(provider)+1:])
+            dp = SeqRepoRESTDataProxy(uri[len(provider) + 1 :])
         else:
             raise ValueError(f"SeqRepo URI scheme {parsed_uri.scheme} not implemented")
 

--- a/src/ga4gh/vrs/dataproxy.py
+++ b/src/ga4gh/vrs/dataproxy.py
@@ -352,7 +352,6 @@ def create_dataproxy(uri: str | None = None) -> _DataProxy:
 
     if provider == "seqrepo":
         if proto in ("", "file"):
-            # pylint: disable=import-error, import-outside-toplevel
             from biocommons.seqrepo import SeqRepo
 
             sr = SeqRepo(root_dir=parsed_uri.path)

--- a/src/ga4gh/vrs/dataproxy.py
+++ b/src/ga4gh/vrs/dataproxy.py
@@ -35,7 +35,9 @@ class _DataProxy(ABC):
     """
 
     @abstractmethod
-    def get_sequence(self, identifier: str, start: int | None = None, end: int | None = None) -> str:
+    def get_sequence(
+        self, identifier: str, start: int | None = None, end: int | None = None
+    ) -> str:
         """Return the specified sequence or subsequence
 
         start and end are optional
@@ -99,7 +101,9 @@ class _DataProxy(ABC):
         return None
 
     @functools.lru_cache
-    def translate_sequence_identifier(self, identifier: str, namespace: str | None = None) -> list[str]:
+    def translate_sequence_identifier(
+        self, identifier: str, namespace: str | None = None
+    ) -> list[str]:
         """Translate given identifier to a list of identifiers in the
         specified namespace.
 
@@ -145,7 +149,12 @@ class _DataProxy(ABC):
         return refget_accession
 
     def validate_ref_seq(
-        self, sequence_id: str, start_pos: int, end_pos: int, ref: str, require_validation: bool = True
+        self,
+        sequence_id: str,
+        start_pos: int,
+        end_pos: int,
+        ref: str,
+        require_validation: bool = True,
     ) -> None:
         """Determine whether or not the expected reference sequence matches the actual
         reference sequence. Returns ``None``, but invalid results are logged at level
@@ -187,7 +196,9 @@ class _SeqRepoDataProxyBase(_DataProxy):
         return md
 
     @functools.lru_cache
-    def get_sequence(self, identifier: str, start: int | None = None, end: int | None = None) -> str:
+    def get_sequence(
+        self, identifier: str, start: int | None = None, end: int | None = None
+    ) -> str:
         return self._get_sequence(identifier, start=start, end=end)
 
     @abstractmethod
@@ -212,7 +223,9 @@ class SeqRepoDataProxy(_SeqRepoDataProxyBase):
         super().__init__()
         self.sr = sr
 
-    def _get_sequence(self, identifier: str, start: int | None = None, end: int | None = None) -> str:
+    def _get_sequence(
+        self, identifier: str, start: int | None = None, end: int | None = None
+    ) -> str:
         # fetch raises KeyError if not found
         return self.sr.fetch_uri(coerce_namespace(identifier), start, end)
 
@@ -245,7 +258,9 @@ class SeqRepoRESTDataProxy(_SeqRepoDataProxyBase):
         super().__init__()
         self.base_url = f"{base_url}/{self.rest_version}/"
 
-    def _get_sequence(self, identifier: str, start: int | None = None, end: int | None = None) -> str:
+    def _get_sequence(
+        self, identifier: str, start: int | None = None, end: int | None = None
+    ) -> str:
         url = self.base_url + f"sequence/{identifier}"
         _logger.info("Fetching %s", url)
         params = {"start": start, "end": end}

--- a/src/ga4gh/vrs/dataproxy.py
+++ b/src/ga4gh/vrs/dataproxy.py
@@ -5,18 +5,16 @@ See https://vr-spec.readthedocs.io/en/1.1/impl-guide/required_data.html
 
 """
 
-from abc import ABC, abstractmethod
-from typing import Tuple
-from collections.abc import Sequence
 import datetime
 import functools
 import logging
 import os
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from urllib.parse import urlparse
 
-from bioutils.accessions import coerce_namespace
 import requests
-
+from bioutils.accessions import coerce_namespace
 
 _logger = logging.getLogger(__name__)
 
@@ -37,8 +35,8 @@ class _DataProxy(ABC):
     """
 
     @abstractmethod
-    def get_sequence(self, identifier, start=None, end=None):
-        """return the specified sequence or subsequence
+    def get_sequence(self, identifier: str, start: int | None = None, end: int | None = None) -> str:
+        """Return the specified sequence or subsequence
 
         start and end are optional
 
@@ -50,8 +48,8 @@ class _DataProxy(ABC):
         """
 
     @abstractmethod
-    def get_metadata(self, identifier):
-        """for a given identifier, return a structure (dict) containing
+    def get_metadata(self, identifier: str) -> dict:
+        """For a given identifier, return a structure (dict) containing
         sequence length, aliases, and other optional info
 
         If the given sequence does not exist, KeyError is raised.
@@ -70,17 +68,16 @@ class _DataProxy(ABC):
         """
 
     @staticmethod
-    def extract_sequence_type(alias: str) -> str:
-        """
-        The purpose of this function is to provide a convenient way to extract the sequence type from an accession by matching its prefix to a known set of prefixes.
+    def extract_sequence_type(alias: str) -> str | None:
+        """Provide a convenient way to extract the sequence type from an accession by matching its prefix to a known set of prefixes.
 
         Args:
         alias (str): The accession string.
 
         Returns:
         str or None: The sequence type associated with the accession string, or None if no matching prefix is found.
-        """
 
+        """
         prefix_dict = {
             "refseq:NM_": "c",
             "refseq:NC_012920": "m",
@@ -101,8 +98,8 @@ class _DataProxy(ABC):
                 return seq_type
         return None
 
-    @functools.lru_cache()
-    def translate_sequence_identifier(self, identifier, namespace=None):
+    @functools.lru_cache
+    def translate_sequence_identifier(self, identifier: str, namespace: str | None = None) -> list[str]:
         """Translate given identifier to a list of identifiers in the
         specified namespace.
 
@@ -113,7 +110,6 @@ class _DataProxy(ABC):
         identifier isn't found.
 
         """
-
         try:
             md = self.get_metadata(identifier)
         except (ValueError, KeyError, IndexError) as e:
@@ -124,13 +120,12 @@ class _DataProxy(ABC):
             aliases = [a for a in aliases if a.startswith(nsd)]
         return aliases
 
-    def derive_refget_accession(self, ac: str):
+    def derive_refget_accession(self, ac: str) -> str | None:
         """Derive the refget accession from a public accession identifier
 
         :param ac: public accession in simple or curie form from which to derive the refget accession
         :return: Refget Accession if found
         """
-
         if ac is None:
             return None
 
@@ -142,7 +137,7 @@ class _DataProxy(ABC):
         try:
             aliases = self.translate_sequence_identifier(ac, namespace="ga4gh")
         except KeyError:
-            _logger.error("KeyError when getting refget accession: %s", ac)
+            _logger.exception("KeyError when getting refget accession: %s", ac)
         else:
             if aliases:
                 refget_accession = aliases[0].split("ga4gh:")[-1]
@@ -185,37 +180,43 @@ class _SeqRepoDataProxyBase(_DataProxy):
     # wraps seqreqpo classes in order to provide translation to/from
     # `ga4gh` identifiers.
 
-    @functools.lru_cache()
-    def get_metadata(self, identifier):
+    @functools.lru_cache
+    def get_metadata(self, identifier: str) -> dict:
         md = self._get_metadata(identifier)
-        md["aliases"] = list(a for a in md["aliases"])
+        md["aliases"] = list(a for a in md["aliases"])  # noqa: C400
         return md
 
-    @functools.lru_cache()
-    def get_sequence(self, identifier, start=None, end=None):
+    @functools.lru_cache
+    def get_sequence(self, identifier: str, start: int | None = None, end: int | None = None) -> str:
         return self._get_sequence(identifier, start=start, end=end)
 
     @abstractmethod
-    def _get_metadata(self, identifier):  # pragma: no cover
+    def _get_metadata(self, identifier: str) -> dict:  # pragma: no cover
         pass
 
     @abstractmethod
-    def _get_sequence(self, identifier, start=None, end=None):  # pragma: no cover
+    def _get_sequence(
+        self, identifier: str, start: int | None = None, end: int | None = None
+    ) -> str:  # pragma: no cover
         pass
 
 
 class SeqRepoDataProxy(_SeqRepoDataProxyBase):
     """DataProxy based on a local instance of SeqRepo"""
 
-    def __init__(self, sr):
+    def __init__(self, sr) -> None:  # noqa: ANN001
+        """Initialize DataProxy instance.
+
+        :param sr: SeqRepo instance
+        """
         super().__init__()
         self.sr = sr
 
-    def _get_sequence(self, identifier, start=None, end=None):
+    def _get_sequence(self, identifier: str, start: int | None = None, end: int | None = None) -> str:
         # fetch raises KeyError if not found
         return self.sr.fetch_uri(coerce_namespace(identifier), start, end)
 
-    def _get_metadata(self, identifier):
+    def _get_metadata(self, identifier: str) -> dict:
         ns, a = coerce_namespace(identifier).split(":", 2)
         r = list(self.sr.aliases.find_aliases(namespace=ns, alias=a))
         if len(r) == 0:
@@ -223,13 +224,12 @@ class SeqRepoDataProxy(_SeqRepoDataProxyBase):
         seq_id = r[0]["seq_id"]
         seqinfo = self.sr.sequences.fetch_seqinfo(seq_id)
         aliases = self.sr.aliases.find_aliases(seq_id=seq_id)
-        md = {
+        return {
             "length": seqinfo["len"],
             "alphabet": seqinfo["alpha"],
             "added": _isoformat(seqinfo["added"]),
             "aliases": [f"{a['namespace']}:{a['alias']}" for a in aliases],
         }
-        return md
 
 
 class SeqRepoRESTDataProxy(_SeqRepoDataProxyBase):
@@ -237,29 +237,32 @@ class SeqRepoRESTDataProxy(_SeqRepoDataProxyBase):
 
     rest_version = "1"
 
-    def __init__(self, base_url):
+    def __init__(self, base_url: str):
+        """Initialize REST-based dataproxy instance.
+
+        :param base_url: root URL to server
+        """
         super().__init__()
         self.base_url = f"{base_url}/{self.rest_version}/"
 
-    def _get_sequence(self, identifier, start=None, end=None):
+    def _get_sequence(self, identifier: str, start: int | None = None, end: int | None = None) -> str:
         url = self.base_url + f"sequence/{identifier}"
         _logger.info("Fetching %s", url)
         params = {"start": start, "end": end}
-        resp = requests.get(url, params=params)
+        resp = requests.get(url, params=params)  # noqa: S113
         if resp.status_code == 404:
             raise KeyError(identifier)
         resp.raise_for_status()
         return resp.text
 
-    def _get_metadata(self, identifier):
+    def _get_metadata(self, identifier: str) -> dict:
         url = self.base_url + f"metadata/{identifier}"
         _logger.info("Fetching %s", url)
-        resp = requests.get(url)
+        resp = requests.get(url)  # noqa: S113
         if resp.status_code == 404:
             raise KeyError(identifier)
         resp.raise_for_status()
-        data = resp.json()
-        return data
+        return resp.json()
 
 
 class SequenceProxy(Sequence):
@@ -269,42 +272,42 @@ class SequenceProxy(Sequence):
 
     """
 
-    def __init__(self, dp, alias):
+    def __init__(self, dp: _DataProxy, alias: str):  # noqa: D107
         self.dp = dp
         self.alias = alias
         self._md = self.dp.get_metadata(self.alias)
 
-    def __str__(self):
+    def __str__(self):  # noqa: D105 ANN204
         return self.dp.get_sequence(self.alias)
 
-    def __len__(self):
+    def __len__(self):  # noqa: D105 ANN204
         return self._md["length"]
 
-    def __reversed__(self):
-        raise NotImplementedError("Reversed iteration of a SequenceProxy is not implemented")
+    def __reversed__(self):  # noqa: D105 ANN204
+        msg = "Reversed iteration of a SequenceProxy is not implemented"
+        raise NotImplementedError(msg)
 
-    def __getitem__(self, key):
-        """return sequence for key (slice), fetching if necessary"""
-
+    def __getitem__(self, key):  # noqa: ANN001 ANN204
+        """Return sequence for key (slice), fetching if necessary"""
         if isinstance(key, int):
             key = slice(key, key + 1)
         if key.step is not None:
-            raise ValueError("Only contiguous sequence slices are supported")
+            msg = "Only contiguous sequence slices are supported"
+            raise ValueError(msg)
 
         return self.dp.get_sequence(self.alias, key.start, key.stop)
 
 
-def _isoformat(o):
-    """convert datetime.datetime to iso formatted timestamp
+def _isoformat(o: datetime.datetime) -> str:
+    """Convert datetime.datetime to iso formatted timestamp
 
     >>> dt = datetime.datetime(2019, 10, 15, 10, 23, 41, 115927)
     >>> _isoformat(dt)
     '2019-10-15T10:23:41.115927Z'
 
     """
-
     # stolen from connexion flask_app.py
-    assert isinstance(o, datetime.datetime)
+    assert isinstance(o, datetime.datetime)  # noqa: S101
     if o.tzinfo:
         # eg: '2015-09-25T23:14:42.588601+00:00'
         return o.isoformat("T")
@@ -321,7 +324,7 @@ def _isoformat(o):
 #         self.base_url = base_url
 
 
-def create_dataproxy(uri: str = None) -> _DataProxy:
+def create_dataproxy(uri: str | None = None) -> _DataProxy:
     """Create a dataproxy from uri or GA4GH_VRS_DATAPROXY_URI
 
     Currently accepted URI schemes:
@@ -332,17 +335,18 @@ def create_dataproxy(uri: str = None) -> _DataProxy:
     * seqrepo+https://somewhere:5000/seqrepo
 
     """
-
     uri = uri or os.environ.get("GA4GH_VRS_DATAPROXY_URI", None)
 
     if uri is None:
-        raise ValueError("No data proxy URI provided or found in GA4GH_VRS_DATAPROXY_URI")
+        msg = "No data proxy URI provided or found in GA4GH_VRS_DATAPROXY_URI"
+        raise ValueError(msg)
 
     parsed_uri = urlparse(uri)
     scheme = parsed_uri.scheme
 
     if "+" not in scheme:
-        raise ValueError("create_dataproxy scheme must include provider (e.g., `seqrepo+http:...`)")
+        msg = "create_dataproxy scheme must include provider (e.g., `seqrepo+http:...`)"
+        raise ValueError(msg)
 
     provider, proto = scheme.split("+")
 
@@ -356,9 +360,11 @@ def create_dataproxy(uri: str = None) -> _DataProxy:
         elif proto in ("http", "https"):
             dp = SeqRepoRESTDataProxy(uri[len(provider) + 1 :])
         else:
-            raise ValueError(f"SeqRepo URI scheme {parsed_uri.scheme} not implemented")
+            msg = f"SeqRepo URI scheme {parsed_uri.scheme} not implemented"
+            raise ValueError(msg)
 
     else:
-        raise ValueError(f"DataProxy provider {provider} not implemented")
+        msg = f"DataProxy provider {provider} not implemented"
+        raise ValueError(msg)
 
     return dp

--- a/src/ga4gh/vrs/enderef.py
+++ b/src/ga4gh/vrs/enderef.py
@@ -4,7 +4,12 @@ from .models import class_refatt_map
 
 
 def vrs_enref(o, object_store=None, return_id_obj_tuple=False):
-    return ga4gh_enref(o, cra_map=class_refatt_map, object_store=object_store, return_id_obj_tuple=return_id_obj_tuple)
+    return ga4gh_enref(
+        o,
+        cra_map=class_refatt_map,
+        object_store=object_store,
+        return_id_obj_tuple=return_id_obj_tuple,
+    )
 
 
 def vrs_deref(o, object_store):

--- a/src/ga4gh/vrs/extras/__init__.py
+++ b/src/ga4gh/vrs/extras/__init__.py
@@ -1,0 +1,1 @@
+"""Extra utilities and operations for working with VRS variations."""

--- a/src/ga4gh/vrs/extras/decorators.py
+++ b/src/ga4gh/vrs/extras/decorators.py
@@ -6,11 +6,12 @@ def lazy_property(fn):
 
     [mv]
     """
-    attr_name = '_lazy_' + fn.__name__
+    attr_name = "_lazy_" + fn.__name__
 
     @property
     def _lazy_property(self):
         if not hasattr(self, attr_name):
             setattr(self, attr_name, fn(self))
         return getattr(self, attr_name)
+
     return _lazy_property

--- a/src/ga4gh/vrs/extras/decorators.py
+++ b/src/ga4gh/vrs/extras/decorators.py
@@ -1,15 +1,18 @@
 """decorators for vrs-python"""
 
 
-def lazy_property(fn):
-    """Decorator that makes a property lazy-evaluated.
+from collections.abc import Callable
+
+
+def lazy_property(fn: Callable):  # noqa: ANN201
+    """Provide a decorator that makes a property lazy-evaluated.
 
     [mv]
     """
     attr_name = "_lazy_" + fn.__name__
 
     @property
-    def _lazy_property(self):
+    def _lazy_property(self):  # noqa: ANN001 ANN202
         if not hasattr(self, attr_name):
             setattr(self, attr_name, fn(self))
         return getattr(self, attr_name)

--- a/src/ga4gh/vrs/extras/decorators.py
+++ b/src/ga4gh/vrs/extras/decorators.py
@@ -1,6 +1,5 @@
 """decorators for vrs-python"""
 
-
 from collections.abc import Callable
 
 

--- a/src/ga4gh/vrs/extras/object_store.py
+++ b/src/ga4gh/vrs/extras/object_store.py
@@ -13,7 +13,7 @@ class Sqlite3MutableMapping(MutableMapping):
     If not used as a contextmanager, user must call commit and/or close.
     """
 
-    def __init__(self, sqlite3_db: str | sqlite3.Connection, autocommit: bool =True):
+    def __init__(self, sqlite3_db: str | sqlite3.Connection, autocommit: bool = True):
         """Connect to the sqlite3 database specified by an existing sqlite3.Connection
         or a connection string.
 

--- a/src/ga4gh/vrs/extras/object_store.py
+++ b/src/ga4gh/vrs/extras/object_store.py
@@ -14,11 +14,7 @@ class Sqlite3MutableMapping(MutableMapping):
     If not used as a contextmanager, user must call commit and/or close.
     """
 
-    def __init__(
-            self,
-            sqlite3_db: Union[str, sqlite3.Connection],
-            autocommit=True
-    ):
+    def __init__(self, sqlite3_db: Union[str, sqlite3.Connection], autocommit=True):
         """
         Connect to the sqlite3 database specified by an existing sqlite3.Connection
         or a connection string.
@@ -27,9 +23,7 @@ class Sqlite3MutableMapping(MutableMapping):
                 Significant performance implication (>10X speedup)
         """
         if isinstance(sqlite3_db, str):
-            sqlite3_db = sqlite3.connect(
-                sqlite3_db,
-                check_same_thread=True)
+            sqlite3_db = sqlite3.connect(sqlite3_db, check_same_thread=True)
         self.db = sqlite3_db
         self.autocommit = autocommit
         self._closed_lock = Lock()
@@ -39,12 +33,8 @@ class Sqlite3MutableMapping(MutableMapping):
     def _create_schema(self):
         cur = self.db.cursor()
         try:
-            cur.execute(
-                "create table if not exists mapping "
-                "(key text, value blob)")
-            cur.execute(
-                "create unique index if not exists mapping_key_idx "
-                "on mapping (key)")
+            cur.execute("create table if not exists mapping (key text, value blob)")
+            cur.execute("create unique index if not exists mapping_key_idx on mapping (key)")
             self.commit()
         finally:
             cur.close()
@@ -58,9 +48,7 @@ class Sqlite3MutableMapping(MutableMapping):
         # Delete if found
         cur = self.db.cursor()
         try:
-            cur.execute(
-                "delete from mapping where key = ?",
-                (key,))
+            cur.execute("delete from mapping where key = ?", (key,))
             if self.autocommit:
                 self.commit()
         finally:
@@ -70,10 +58,7 @@ class Sqlite3MutableMapping(MutableMapping):
         cur = self.db.cursor()
         try:
             ser = dill.dumps(value)
-            cur.execute(
-                "insert or replace into mapping(key, value) "
-                "values (?, ?)",
-                (key, sqlite3.Binary(ser)))
+            cur.execute("insert or replace into mapping(key, value) values (?, ?)", (key, sqlite3.Binary(ser)))
             if self.autocommit:
                 self.commit()
         finally:
@@ -82,9 +67,7 @@ class Sqlite3MutableMapping(MutableMapping):
     def __getitem__(self, key: Any) -> Any:
         cur = self.db.cursor()
         try:
-            rows = cur.execute(
-                "select value from mapping where key = ?",
-                (key,))
+            rows = cur.execute("select value from mapping where key = ?", (key,))
             row0 = next(rows)
             if row0:
                 des = dill.loads(row0[0])

--- a/src/ga4gh/vrs/extras/object_store.py
+++ b/src/ga4gh/vrs/extras/object_store.py
@@ -32,7 +32,9 @@ class Sqlite3MutableMapping(MutableMapping):
         cur = self.db.cursor()
         try:
             cur.execute("create table if not exists mapping (key text, value blob)")
-            cur.execute("create unique index if not exists mapping_key_idx on mapping (key)")
+            cur.execute(
+                "create unique index if not exists mapping_key_idx on mapping (key)"
+            )
             self.commit()
         finally:
             cur.close()
@@ -56,7 +58,10 @@ class Sqlite3MutableMapping(MutableMapping):
         cur = self.db.cursor()
         try:
             ser = dill.dumps(value)
-            cur.execute("insert or replace into mapping(key, value) values (?, ?)", (key, sqlite3.Binary(ser)))
+            cur.execute(
+                "insert or replace into mapping(key, value) values (?, ?)",
+                (key, sqlite3.Binary(ser)),
+            )
             if self.autocommit:
                 self.commit()
         finally:

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -32,14 +32,23 @@ class _Translator(ABC):  # noqa: B024
 
     """
 
-    beacon_re = re.compile(r"(?P<chr>[^-]+)\s*:\s*(?P<pos>\d+)\s*(?P<ref>\w+)\s*>\s*(?P<alt>\w+)")
-    gnomad_re = re.compile(
-        r"(?P<chr>[^-]+)-(?P<pos>\d+)-(?P<ref>[ACGTURYKMSWBDHVN]+)-(?P<alt>[ACGTURYKMSWBDHVN]+)", re.IGNORECASE
+    beacon_re = re.compile(
+        r"(?P<chr>[^-]+)\s*:\s*(?P<pos>\d+)\s*(?P<ref>\w+)\s*>\s*(?P<alt>\w+)"
     )
-    spdi_re = re.compile(r"(?P<ac>[^:]+):(?P<pos>\d+):(?P<del_len_or_seq>\w*):(?P<ins_seq>\w*)")
+    gnomad_re = re.compile(
+        r"(?P<chr>[^-]+)-(?P<pos>\d+)-(?P<ref>[ACGTURYKMSWBDHVN]+)-(?P<alt>[ACGTURYKMSWBDHVN]+)",
+        re.IGNORECASE,
+    )
+    spdi_re = re.compile(
+        r"(?P<ac>[^:]+):(?P<pos>\d+):(?P<del_len_or_seq>\w*):(?P<ins_seq>\w*)"
+    )
 
     def __init__(
-        self, data_proxy: _DataProxy, default_assembly_name="GRCh38", identify=True, rle_seq_limit: int | None = 50
+        self,
+        data_proxy: _DataProxy,
+        default_assembly_name="GRCh38",
+        identify=True,
+        rle_seq_limit: int | None = 50,
     ):
         self.default_assembly_name = default_assembly_name
         self.data_proxy = data_proxy
@@ -162,7 +171,9 @@ class AlleleTranslator(_Translator):
 
         """
         seq_ref = models.SequenceReference(refgetAccession=values["refget_accession"])
-        location = models.SequenceLocation(sequenceReference=seq_ref, start=values["start"], end=values["end"])
+        location = models.SequenceLocation(
+            sequenceReference=seq_ref, start=values["start"], end=values["end"]
+        )
         state = models.LiteralSequenceExpression(sequence=values["literal_sequence"])
         allele = models.Allele(location=location, state=state)
         return self._post_process_imported_allele(allele, **kwargs)
@@ -220,7 +231,12 @@ class AlleleTranslator(_Translator):
         end = start + len(ref)
         ins_seq = alt
 
-        values = {"refget_accession": refget_accession, "start": start, "end": end, "literal_sequence": ins_seq}
+        values = {
+            "refget_accession": refget_accession,
+            "start": start,
+            "end": end,
+            "literal_sequence": ins_seq,
+        }
         return self._create_allele(values, **kwargs)
 
     def _from_gnomad(self, gnomad_expr, **kwargs):
@@ -281,10 +297,19 @@ class AlleleTranslator(_Translator):
 
         # validation checks
         self.data_proxy.validate_ref_seq(
-            sequence, start, end, ref, require_validation=kwargs.get("require_validation", True)
+            sequence,
+            start,
+            end,
+            ref,
+            require_validation=kwargs.get("require_validation", True),
         )
 
-        values = {"refget_accession": refget_accession, "start": start, "end": end, "literal_sequence": ins_seq}
+        values = {
+            "refget_accession": refget_accession,
+            "start": start,
+            "end": end,
+            "literal_sequence": ins_seq,
+        }
         return self._create_allele(values, **kwargs)
 
     def _from_hgvs(self, hgvs_expr: str, **kwargs):
@@ -344,7 +369,12 @@ class AlleleTranslator(_Translator):
         end = start + del_len
         ins_seq = g["ins_seq"]
 
-        values = {"refget_accession": refget_accession, "start": start, "end": end, "literal_sequence": ins_seq}
+        values = {
+            "refget_accession": refget_accession,
+            "start": start,
+            "end": end,
+            "literal_sequence": ins_seq,
+        }
 
         return self._create_allele(values, **kwargs)
 
@@ -389,7 +419,11 @@ class AlleleTranslator(_Translator):
                 performed. `False` otherwise. Defaults to `True`
         """
         if kwargs.get("do_normalize", True):
-            allele = normalize(allele, self.data_proxy, rle_seq_limit=kwargs.get("rle_seq_limit", self.rle_seq_limit))
+            allele = normalize(
+                allele,
+                self.data_proxy,
+                rle_seq_limit=kwargs.get("rle_seq_limit", self.rle_seq_limit),
+            )
 
         if self.identify:
             allele.id = ga4gh_identify(allele)
@@ -436,7 +470,9 @@ class CnvTranslator(_Translator):
             return None
 
         location = models.SequenceLocation(
-            sequenceReference=models.SequenceReference(refgetAccession=refget_accession),
+            sequenceReference=models.SequenceReference(
+                refgetAccession=refget_accession
+            ),
             start=sv.posedit.pos.start.base - 1,
             end=sv.posedit.pos.end.base,
         )
@@ -447,9 +483,14 @@ class CnvTranslator(_Translator):
         else:
             copy_change = kwargs.get("copy_change")
             if not copy_change:
-                copy_change = models.CopyChange.EFO_0030067 if sv_type == "del" else models.CopyChange.EFO_0030070
+                copy_change = (
+                    models.CopyChange.EFO_0030067
+                    if sv_type == "del"
+                    else models.CopyChange.EFO_0030070
+                )
             cnv = models.CopyNumberChange(
-                location=location, copyChange=core_models.MappableConcept(primaryCode=copy_change)
+                location=location,
+                copyChange=core_models.MappableConcept(primaryCode=copy_change),
             )
 
         return self._post_process_imported_cnv(cnv)

--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -19,6 +19,7 @@ from ga4gh.vrs.utils.hgvs_tools import HgvsTools
 
 _logger = logging.getLogger(__name__)
 
+
 class _Translator(ABC):
     """abstract class / interface for VRS to/from translation needs
 
@@ -34,17 +35,12 @@ class _Translator(ABC):
 
     beacon_re = re.compile(r"(?P<chr>[^-]+)\s*:\s*(?P<pos>\d+)\s*(?P<ref>\w+)\s*>\s*(?P<alt>\w+)")
     gnomad_re = re.compile(
-        r"(?P<chr>[^-]+)-(?P<pos>\d+)-(?P<ref>[ACGTURYKMSWBDHVN]+)-(?P<alt>[ACGTURYKMSWBDHVN]+)",
-        re.IGNORECASE
+        r"(?P<chr>[^-]+)-(?P<pos>\d+)-(?P<ref>[ACGTURYKMSWBDHVN]+)-(?P<alt>[ACGTURYKMSWBDHVN]+)", re.IGNORECASE
     )
     spdi_re = re.compile(r"(?P<ac>[^:]+):(?P<pos>\d+):(?P<del_len_or_seq>\w*):(?P<ins_seq>\w*)")
 
     def __init__(
-        self,
-        data_proxy: _DataProxy,
-        default_assembly_name="GRCh38",
-        identify=True,
-        rle_seq_limit: Optional[int] = 50
+        self, data_proxy: _DataProxy, default_assembly_name="GRCh38", identify=True, rle_seq_limit: Optional[int] = 50
     ):
         self.default_assembly_name = default_assembly_name
         self.data_proxy = data_proxy
@@ -127,12 +123,11 @@ class _Translator(ABC):
             return None
         return model(**var)
 
+
 class AlleleTranslator(_Translator):
     """Class for translating formats to and from VRS Alleles"""
 
-    def __init__(
-        self, data_proxy, default_assembly_name="GRCh38", identify=True
-    ):
+    def __init__(self, data_proxy, default_assembly_name="GRCh38", identify=True):
         """Initialize AlleleTranslator class"""
         super().__init__(data_proxy, default_assembly_name, identify)
 
@@ -289,11 +284,7 @@ class AlleleTranslator(_Translator):
 
         # validation checks
         self.data_proxy.validate_ref_seq(
-            sequence,
-            start,
-            end,
-            ref,
-            require_validation=kwargs.get("require_validation", True)
+            sequence, start, end, ref, require_validation=kwargs.get("require_validation", True)
         )
 
         values = {"refget_accession": refget_accession, "start": start, "end": end, "literal_sequence": ins_seq}
@@ -389,7 +380,7 @@ class AlleleTranslator(_Translator):
         aliases = self.data_proxy.translate_sequence_identifier(sequence, namespace)
         aliases = [a.split(":")[1] for a in aliases]
         start, end = vo.location.start, vo.location.end
-        spdi_tail = f":{start}:{end-start}:{vo.state.sequence.root}"
+        spdi_tail = f":{start}:{end - start}:{vo.state.sequence.root}"
         spdis = [a + spdi_tail for a in aliases]
         return spdis
 
@@ -407,11 +398,7 @@ class AlleleTranslator(_Translator):
                 performed. `False` otherwise. Defaults to `True`
         """
         if kwargs.get("do_normalize", True):
-            allele = normalize(
-                allele,
-                self.data_proxy,
-                rle_seq_limit=kwargs.get("rle_seq_limit", self.rle_seq_limit)
-            )
+            allele = normalize(allele, self.data_proxy, rle_seq_limit=kwargs.get("rle_seq_limit", self.rle_seq_limit))
 
         if self.identify:
             allele.id = ga4gh_identify(allele)
@@ -423,9 +410,7 @@ class AlleleTranslator(_Translator):
 class CnvTranslator(_Translator):
     """Class for translating formats from format to VRS Copy Number"""
 
-    def __init__(
-        self, data_proxy, default_assembly_name="GRCh38", identify=True
-    ):
+    def __init__(self, data_proxy, default_assembly_name="GRCh38", identify=True):
         """Initialize CnvTranslator class"""
         super().__init__(data_proxy, default_assembly_name, identify)
         self.from_translators = {
@@ -460,7 +445,7 @@ class CnvTranslator(_Translator):
         location = models.SequenceLocation(
             sequenceReference=models.SequenceReference(refgetAccession=refget_accession),
             start=sv.posedit.pos.start.base - 1,
-            end=sv.posedit.pos.end.base
+            end=sv.posedit.pos.end.base,
         )
 
         copies = kwargs.get("copies")
@@ -470,9 +455,11 @@ class CnvTranslator(_Translator):
             copy_change = kwargs.get("copy_change")
             if not copy_change:
                 copy_change = models.CopyChange.EFO_0030067 if sv_type == "del" else models.CopyChange.EFO_0030070
-            cnv = models.CopyNumberChange(location=location, copyChange=core_models.MappableConcept(primaryCode=copy_change))
+            cnv = models.CopyNumberChange(
+                location=location, copyChange=core_models.MappableConcept(primaryCode=copy_change)
+            )
 
-        cnv =self._post_process_imported_cnv(cnv)
+        cnv = self._post_process_imported_cnv(cnv)
         return cnv
 
     def _post_process_imported_cnv(self, copy_number):

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -145,7 +145,7 @@ def _log_level_option(func: Callable) -> Callable:
     help="Require validation checks to pass to construct a VRS object.",
 )
 @click.option("--silent", "-s", is_flag=True, default=False, help="Suppress messages printed to stdout")
-def _annotate_vcf_cli(  # pylint: disable=too-many-arguments
+def _annotate_vcf_cli(
     vcf_in: pathlib.Path,
     vcf_out: pathlib.Path | None,
     vrs_pickle_out: pathlib.Path | None,
@@ -188,7 +188,7 @@ def _annotate_vcf_cli(  # pylint: disable=too-many-arguments
         click.echo(msg)
 
 
-class VCFAnnotator:  # pylint: disable=too-few-public-methods
+class VCFAnnotator:
     """Annotate VCFs with VRS allele IDs.
 
     Uses pysam to read, store, and (optionally) output VCFs. Alleles are translated
@@ -231,7 +231,7 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
         self.tlr = AlleleTranslator(self.dp)
 
     @use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.MISSING)
-    def annotate(  # pylint: disable=too-many-arguments,too-many-locals
+    def annotate(
         self,
         vcf_in: str,
         vcf_out: str | None = None,
@@ -266,7 +266,7 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
         info_field_desc = "REF and ALT" if compute_for_ref else "ALT"
 
         vrs_data = {}
-        vcf_in = pysam.VariantFile(filename=vcf_in)  # pylint: disable=no-member
+        vcf_in = pysam.VariantFile(filename=vcf_in)
         vcf_in.header.info.add(
             self.VRS_ALLELE_IDS_FIELD,
             info_field_num,
@@ -310,7 +310,7 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
             )
 
         if vcf_out:
-            vcf_out = pysam.VariantFile(vcf_out, "w", header=vcf_in.header)  # pylint: disable=no-member
+            vcf_out = pysam.VariantFile(vcf_out, "w", header=vcf_in.header)
 
         output_vcf = bool(vcf_out)
         output_pickle = bool(vrs_pickle_out)
@@ -355,7 +355,7 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
             with open(vrs_pickle_out, "wb") as wf:
                 pickle.dump(vrs_data, wf)
 
-    def _get_vrs_object(  # pylint: disable=too-many-arguments,too-many-locals
+    def _get_vrs_object(
         self,
         vcf_coords: str,
         vrs_data: dict,
@@ -400,7 +400,7 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
             vrs_obj = None
             _logger.exception("AssertionError when translating %s from gnomad", vcf_coords)
             raise
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             vrs_obj = None
             _logger.exception("Unhandled Exception when translating %s from gnomad", vcf_coords)
             raise
@@ -430,11 +430,11 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
                 vrs_field_data[self.VRS_ENDS_FIELD].append(end)
                 vrs_field_data[self.VRS_STATES_FIELD].append(alt)
 
-    def _get_vrs_data(  # pylint: disable=too-many-arguments,too-many-locals
+    def _get_vrs_data(
         self,
         record: pysam.VariantRecord,
         vrs_data: dict,
-        assembly: str,  # pylint: disable=no-member
+        assembly: str,
         additional_info_fields: list[str],
         vrs_attributes: bool = False,
         output_pickle: bool = True,

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -1,8 +1,9 @@
 """Annotate VCFs with VRS
 
-    $ vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+$ vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
 
 """
+
 from collections.abc import Callable
 import pathlib
 import logging
@@ -34,18 +35,18 @@ class SeqRepoProxyType(str, Enum):
     LOCAL = "local"
     REST = "rest"
 
+
 @click.group()
 def _cli() -> None:
     """Annotate input files with VRS variation objects."""
     logging.basicConfig(
-        filename="vrs-annotate.log",
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        filename="vrs-annotate.log", level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
 
 class _LogLevel(str, Enum):
     """Define legal values for `--log_level` option."""
+
     DEBUG = "debug"
     INFO = "info"
     WARNING = "warning"
@@ -62,6 +63,7 @@ def _log_level_option(func: Callable) -> Callable:
     :param func: incoming click command
     :return: same command, wrapped with log level option
     """
+
     def _set_log_level(ctx: dict, param: str, value: _LogLevel) -> None:  # pylint: disable=unused-argument
         level_map = {
             _LogLevel.DEBUG: logging.DEBUG,
@@ -79,31 +81,25 @@ def _log_level_option(func: Callable) -> Callable:
         help="Set the logging level.",
         callback=_set_log_level,
         expose_value=False,
-        is_eager=True
+        is_eager=True,
     )(func)
     return wrapped_func
 
 
 @_cli.command(name="vcf")
 @_log_level_option
-@click.argument(
-    "vcf_in",
-    nargs=1,
-    type=click.Path(exists=True, readable=True, dir_okay=False, path_type=pathlib.Path)
-)
+@click.argument("vcf_in", nargs=1, type=click.Path(exists=True, readable=True, dir_okay=False, path_type=pathlib.Path))
 @click.option(
     "--vcf_out",
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=pathlib.Path),
-    help=("Declare save location for output annotated VCF. If not provided, must provide "
-          "--vrs_pickle_out.")
+    help=("Declare save location for output annotated VCF. If not provided, must provide --vrs_pickle_out."),
 )
 @click.option(
     "--vrs_pickle_out",
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=pathlib.Path),
-    help=("Declare save location for output VCF pickle. If not provided, must provide "
-          "--vcf_out.")
+    help=("Declare save location for output VCF pickle. If not provided, must provide --vcf_out."),
 )
 @click.option(
     "--vrs_attributes",
@@ -115,11 +111,10 @@ def _log_level_option(func: Callable) -> Callable:
     "--seqrepo_dp_type",
     required=False,
     default=SeqRepoProxyType.LOCAL,
-    type=click.Choice([v.value for v in SeqRepoProxyType.__members__.values()],
-                      case_sensitive=True),
+    type=click.Choice([v.value for v in SeqRepoProxyType.__members__.values()], case_sensitive=True),
     help="Specify type of SeqRepo dataproxy to use.",
     show_default=True,
-    show_choices=True
+    show_choices=True,
 )
 @click.option(
     "--seqrepo_root_dir",
@@ -127,14 +122,14 @@ def _log_level_option(func: Callable) -> Callable:
     default=pathlib.Path("/usr/local/share/seqrepo/latest"),
     type=click.Path(path_type=pathlib.Path),
     help="Define root directory for local SeqRepo instance, if --seqrepo_dp_type=local.",
-    show_default=True
+    show_default=True,
 )
 @click.option(
     "--seqrepo_base_url",
     required=False,
     default="http://localhost:5000/seqrepo",
     help="Specify base URL for SeqRepo REST API, if --seqrepo_dp_type=rest.",
-    show_default=True
+    show_default=True,
 )
 @click.option(
     "--assembly",
@@ -142,31 +137,27 @@ def _log_level_option(func: Callable) -> Callable:
     default="GRCh38",
     show_default=True,
     help="Specify assembly that was used to create input VCF.",
-    type=str
+    type=str,
 )
-@click.option(
-    "--skip_ref",
-    is_flag=True,
-    default=False,
-    help="Skip VRS computation for REF alleles."
-)
+@click.option("--skip_ref", is_flag=True, default=False, help="Skip VRS computation for REF alleles.")
 @click.option(
     "--require_validation",
     is_flag=True,
     default=False,
-    help="Require validation checks to pass to construct a VRS object."
+    help="Require validation checks to pass to construct a VRS object.",
 )
-@click.option(
-    "--silent",
-    "-s",
-    is_flag=True,
-    default=False,
-    help="Suppress messages printed to stdout"
-)
+@click.option("--silent", "-s", is_flag=True, default=False, help="Suppress messages printed to stdout")
 def _annotate_vcf_cli(  # pylint: disable=too-many-arguments
-    vcf_in: pathlib.Path, vcf_out: pathlib.Path | None, vrs_pickle_out: pathlib.Path | None,
-    vrs_attributes: bool, seqrepo_dp_type: SeqRepoProxyType, seqrepo_root_dir: pathlib.Path,
-    seqrepo_base_url: str, assembly: str, skip_ref: bool, require_validation: bool,
+    vcf_in: pathlib.Path,
+    vcf_out: pathlib.Path | None,
+    vrs_pickle_out: pathlib.Path | None,
+    vrs_attributes: bool,
+    seqrepo_dp_type: SeqRepoProxyType,
+    seqrepo_root_dir: pathlib.Path,
+    seqrepo_base_url: str,
+    assembly: str,
+    skip_ref: bool,
+    require_validation: bool,
     silent: bool,
 ) -> None:
     """Extract VRS objects from VCF located at VCF_IN.
@@ -184,9 +175,13 @@ def _annotate_vcf_cli(  # pylint: disable=too-many-arguments
     if not silent:
         click.echo(msg)
     annotator.annotate(
-        str(vcf_in.absolute()), vcf_out=vcf_out_str, vrs_pickle_out=vrs_pkl_out_str,
-        vrs_attributes=vrs_attributes, assembly=assembly,
-        compute_for_ref=(not skip_ref), require_validation=require_validation
+        str(vcf_in.absolute()),
+        vcf_out=vcf_out_str,
+        vrs_pickle_out=vrs_pkl_out_str,
+        vrs_attributes=vrs_attributes,
+        assembly=assembly,
+        compute_for_ref=(not skip_ref),
+        require_validation=require_validation,
     )
     end = timer()
     msg = f"VCF Annotator finished in {(end - start):.5f} seconds"
@@ -218,9 +213,12 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
         ("\t", "%09"),
     ]
 
-    def __init__(self, seqrepo_dp_type: SeqRepoProxyType = SeqRepoProxyType.LOCAL,
-                 seqrepo_base_url: str = "http://localhost:5000/seqrepo",
-                 seqrepo_root_dir: str = "/usr/local/share/seqrepo/latest") -> None:
+    def __init__(
+        self,
+        seqrepo_dp_type: SeqRepoProxyType = SeqRepoProxyType.LOCAL,
+        seqrepo_base_url: str = "http://localhost:5000/seqrepo",
+        seqrepo_root_dir: str = "/usr/local/share/seqrepo/latest",
+    ) -> None:
         """Initialize the VCFAnnotator class.
 
         :param seqrepo_dp_type: The type of SeqRepo Data Proxy to use
@@ -236,10 +234,14 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
 
     @use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.MISSING)
     def annotate(  # pylint: disable=too-many-arguments,too-many-locals
-        self, vcf_in: str, vcf_out: str | None = None,
-        vrs_pickle_out: str | None = None, vrs_attributes: bool = False,
-        assembly: str = "GRCh38", compute_for_ref: bool = True,
-        require_validation: bool = True
+        self,
+        vcf_in: str,
+        vcf_out: str | None = None,
+        vrs_pickle_out: str | None = None,
+        vrs_attributes: bool = False,
+        assembly: str = "GRCh38",
+        compute_for_ref: bool = True,
+        require_validation: bool = True,
     ) -> None:
         """Given a VCF, produce an output VCF annotated with VRS allele IDs, and/or
         a pickle file containing the full VRS objects.
@@ -259,8 +261,7 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
             logged as warnings regardless.
         """
         if not any((vcf_out, vrs_pickle_out)):
-            raise VCFAnnotatorException(
-                "Must provide one of: `vcf_out` or `vrs_pickle_out`")
+            raise VCFAnnotatorException("Must provide one of: `vcf_out` or `vrs_pickle_out`")
 
         info_field_num = "R" if compute_for_ref else "A"
         info_field_desc = "REF and ALT" if compute_for_ref else "ALT"
@@ -268,30 +269,45 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
         vrs_data = {}
         vcf_in = pysam.VariantFile(filename=vcf_in)  # pylint: disable=no-member
         vcf_in.header.info.add(
-            self.VRS_ALLELE_IDS_FIELD, info_field_num, "String",
-            ("The computed identifiers for the GA4GH VRS Alleles corresponding to the "
-             f"GT indexes of the {info_field_desc} alleles")
+            self.VRS_ALLELE_IDS_FIELD,
+            info_field_num,
+            "String",
+            (
+                "The computed identifiers for the GA4GH VRS Alleles corresponding to the "
+                f"GT indexes of the {info_field_desc} alleles"
+            ),
         )
         vcf_in.header.info.add(
-            self.VRS_ERROR_FIELD, ".", "String",
-            ("If an error occurred computing a VRS Identifier, the error message")
+            self.VRS_ERROR_FIELD, ".", "String", ("If an error occurred computing a VRS Identifier, the error message")
         )
 
         if vrs_attributes:
             vcf_in.header.info.add(
-                self.VRS_STARTS_FIELD, info_field_num, "String",
-                ("Interresidue coordinates used as the location starts for the GA4GH "
-                 f"VRS Alleles corresponding to the GT indexes of the {info_field_desc} alleles")
+                self.VRS_STARTS_FIELD,
+                info_field_num,
+                "String",
+                (
+                    "Interresidue coordinates used as the location starts for the GA4GH "
+                    f"VRS Alleles corresponding to the GT indexes of the {info_field_desc} alleles"
+                ),
             )
             vcf_in.header.info.add(
-                self.VRS_ENDS_FIELD, info_field_num, "String",
-                ("Interresidue coordinates used as the location ends for the GA4GH VRS "
-                 f"Alleles corresponding to the GT indexes of the {info_field_desc} alleles")
+                self.VRS_ENDS_FIELD,
+                info_field_num,
+                "String",
+                (
+                    "Interresidue coordinates used as the location ends for the GA4GH VRS "
+                    f"Alleles corresponding to the GT indexes of the {info_field_desc} alleles"
+                ),
             )
             vcf_in.header.info.add(
-                self.VRS_STATES_FIELD, info_field_num, "String",
-                ("The literal sequence states used for the GA4GH VRS Alleles "
-                 f"corresponding to the GT indexes of the {info_field_desc} alleles")
+                self.VRS_STATES_FIELD,
+                info_field_num,
+                "String",
+                (
+                    "The literal sequence states used for the GA4GH VRS Alleles "
+                    f"corresponding to the GT indexes of the {info_field_desc} alleles"
+                ),
             )
 
         if vcf_out:
@@ -306,10 +322,15 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
                 additional_info_fields += [self.VRS_STARTS_FIELD, self.VRS_ENDS_FIELD, self.VRS_STATES_FIELD]
             try:
                 vrs_field_data = self._get_vrs_data(
-                    record, vrs_data, assembly, additional_info_fields,
-                    vrs_attributes=vrs_attributes, output_pickle=output_pickle,
-                    output_vcf=output_vcf, compute_for_ref=compute_for_ref,
-                    require_validation=require_validation
+                    record,
+                    vrs_data,
+                    assembly,
+                    additional_info_fields,
+                    vrs_attributes=vrs_attributes,
+                    output_pickle=output_pickle,
+                    output_vcf=output_vcf,
+                    compute_for_ref=compute_for_ref,
+                    require_validation=require_validation,
                 )
             except Exception as ex:
                 _logger.exception("VRS error on %s-%s", record.chrom, record.pos)
@@ -336,10 +357,16 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
                 pickle.dump(vrs_data, wf)
 
     def _get_vrs_object(  # pylint: disable=too-many-arguments,too-many-locals
-        self, vcf_coords: str, vrs_data: dict, vrs_field_data: dict, assembly: str,
-        vrs_data_key: str | None = None, output_pickle: bool = True,
-        output_vcf: bool = False, vrs_attributes: bool = False,
-        require_validation: bool = True
+        self,
+        vcf_coords: str,
+        vrs_data: dict,
+        vrs_field_data: dict,
+        assembly: str,
+        vrs_data_key: str | None = None,
+        output_pickle: bool = True,
+        output_vcf: bool = False,
+        vrs_attributes: bool = False,
+        require_validation: bool = True,
     ) -> None:
         """Get VRS object given `vcf_coords`. `vrs_data` and `vrs_field_data` will
         be mutated.
@@ -361,11 +388,7 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
             validation checks fail. Defaults to `True`.
         """
         try:
-            vrs_obj = self.tlr._from_gnomad(
-                vcf_coords,
-                assembly_name=assembly,
-                require_validation=require_validation
-            )
+            vrs_obj = self.tlr._from_gnomad(vcf_coords, assembly_name=assembly, require_validation=require_validation)
         except (ValidationError, DataProxyValidationError) as e:
             vrs_obj = None
             _logger.error("ValidationError when translating %s from gnomad: %s", vcf_coords, str(e))
@@ -412,10 +435,16 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
                 vrs_field_data[self.VRS_STATES_FIELD].append(alt)
 
     def _get_vrs_data(  # pylint: disable=too-many-arguments,too-many-locals
-        self, record: pysam.VariantRecord, vrs_data: dict, assembly: str,  # pylint: disable=no-member
-        additional_info_fields: list[str], vrs_attributes: bool = False,
-        output_pickle: bool = True, output_vcf: bool = True,
-        compute_for_ref: bool = True, require_validation: bool = True
+        self,
+        record: pysam.VariantRecord,
+        vrs_data: dict,
+        assembly: str,  # pylint: disable=no-member
+        additional_info_fields: list[str],
+        vrs_attributes: bool = False,
+        output_pickle: bool = True,
+        output_vcf: bool = True,
+        compute_for_ref: bool = True,
+        require_validation: bool = True,
     ) -> dict:
         """Get VRS data for record's reference and alt alleles.
 
@@ -445,9 +474,14 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
         if compute_for_ref:
             reference_allele = f"{gnomad_loc}-{record.ref}-{record.ref}"
             self._get_vrs_object(
-                reference_allele, vrs_data, vrs_field_data, assembly,
-                output_pickle=output_pickle, output_vcf=output_vcf,
-                vrs_attributes=vrs_attributes, require_validation=require_validation
+                reference_allele,
+                vrs_data,
+                vrs_field_data,
+                assembly,
+                output_pickle=output_pickle,
+                output_vcf=output_vcf,
+                vrs_attributes=vrs_attributes,
+                require_validation=require_validation,
             )
 
         # Get VRS data for alts
@@ -462,9 +496,15 @@ class VCFAnnotator:  # pylint: disable=too-few-public-methods
                         vrs_field_data[field].append("")
             else:
                 self._get_vrs_object(
-                    allele, vrs_data, vrs_field_data, assembly, vrs_data_key=data,
-                    output_pickle=output_pickle, output_vcf=output_vcf,
-                    vrs_attributes=vrs_attributes, require_validation=require_validation
+                    allele,
+                    vrs_data,
+                    vrs_field_data,
+                    assembly,
+                    vrs_data_key=data,
+                    output_pickle=output_pickle,
+                    output_vcf=output_vcf,
+                    vrs_attributes=vrs_attributes,
+                    require_validation=require_validation,
                 )
 
         return vrs_field_data

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -24,7 +24,7 @@ _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.DEBUG)
 
 
-class VCFAnnotatorException(Exception):  # noqa: N818
+class VCFAnnotatorException(Exception):
     """Custom exceptions for VCF Annotator tool"""
 
 

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -17,7 +17,11 @@ from biocommons.seqrepo import SeqRepo
 from pydantic import ValidationError
 
 from ga4gh.core import VrsObjectIdentifierIs, use_ga4gh_compute_identifier_when
-from ga4gh.vrs.dataproxy import DataProxyValidationError, SeqRepoDataProxy, SeqRepoRESTDataProxy
+from ga4gh.vrs.dataproxy import (
+    DataProxyValidationError,
+    SeqRepoDataProxy,
+    SeqRepoRESTDataProxy,
+)
 from ga4gh.vrs.extras.translator import AlleleTranslator
 
 _logger = logging.getLogger(__name__)
@@ -39,7 +43,9 @@ class SeqRepoProxyType(str, Enum):
 def _cli() -> None:
     """Annotate input files with VRS variation objects."""
     logging.basicConfig(
-        filename="vrs-annotate.log", level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        filename="vrs-annotate.log",
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
 
@@ -86,18 +92,26 @@ def _log_level_option(func: Callable) -> Callable:
 
 @_cli.command(name="vcf")
 @_log_level_option
-@click.argument("vcf_in", nargs=1, type=click.Path(exists=True, readable=True, dir_okay=False, path_type=pathlib.Path))
+@click.argument(
+    "vcf_in",
+    nargs=1,
+    type=click.Path(exists=True, readable=True, dir_okay=False, path_type=pathlib.Path),
+)
 @click.option(
     "--vcf_out",
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=pathlib.Path),
-    help=("Declare save location for output annotated VCF. If not provided, must provide --vrs_pickle_out."),
+    help=(
+        "Declare save location for output annotated VCF. If not provided, must provide --vrs_pickle_out."
+    ),
 )
 @click.option(
     "--vrs_pickle_out",
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=pathlib.Path),
-    help=("Declare save location for output VCF pickle. If not provided, must provide --vcf_out."),
+    help=(
+        "Declare save location for output VCF pickle. If not provided, must provide --vcf_out."
+    ),
 )
 @click.option(
     "--vrs_attributes",
@@ -109,7 +123,9 @@ def _log_level_option(func: Callable) -> Callable:
     "--seqrepo_dp_type",
     required=False,
     default=SeqRepoProxyType.LOCAL,
-    type=click.Choice([v.value for v in SeqRepoProxyType.__members__.values()], case_sensitive=True),
+    type=click.Choice(
+        [v.value for v in SeqRepoProxyType.__members__.values()], case_sensitive=True
+    ),
     help="Specify type of SeqRepo dataproxy to use.",
     show_default=True,
     show_choices=True,
@@ -137,14 +153,25 @@ def _log_level_option(func: Callable) -> Callable:
     help="Specify assembly that was used to create input VCF.",
     type=str,
 )
-@click.option("--skip_ref", is_flag=True, default=False, help="Skip VRS computation for REF alleles.")
+@click.option(
+    "--skip_ref",
+    is_flag=True,
+    default=False,
+    help="Skip VRS computation for REF alleles.",
+)
 @click.option(
     "--require_validation",
     is_flag=True,
     default=False,
     help="Require validation checks to pass to construct a VRS object.",
 )
-@click.option("--silent", "-s", is_flag=True, default=False, help="Suppress messages printed to stdout")
+@click.option(
+    "--silent",
+    "-s",
+    is_flag=True,
+    default=False,
+    help="Suppress messages printed to stdout",
+)
 def _annotate_vcf_cli(
     vcf_in: pathlib.Path,
     vcf_out: pathlib.Path | None,
@@ -164,9 +191,13 @@ def _annotate_vcf_cli(
 
     Note that at least one of --vcf_out or --vrs_pickle_out must be selected and defined.
     """
-    annotator = VCFAnnotator(seqrepo_dp_type, seqrepo_base_url, str(seqrepo_root_dir.absolute()))
+    annotator = VCFAnnotator(
+        seqrepo_dp_type, seqrepo_base_url, str(seqrepo_root_dir.absolute())
+    )
     vcf_out_str = str(vcf_out.absolute()) if vcf_out is not None else vcf_out
-    vrs_pkl_out_str = str(vrs_pickle_out.absolute()) if vrs_pickle_out is not None else vrs_pickle_out
+    vrs_pkl_out_str = (
+        str(vrs_pickle_out.absolute()) if vrs_pickle_out is not None else vrs_pickle_out
+    )
     start = timer()
     msg = f"Annotating {vcf_in} with the VCF Annotator..."
     _logger.info(msg)
@@ -277,7 +308,10 @@ class VCFAnnotator:
             ),
         )
         vcf_in.header.info.add(
-            self.VRS_ERROR_FIELD, ".", "String", ("If an error occurred computing a VRS Identifier, the error message")
+            self.VRS_ERROR_FIELD,
+            ".",
+            "String",
+            ("If an error occurred computing a VRS Identifier, the error message"),
         )
 
         if vrs_attributes:
@@ -318,7 +352,11 @@ class VCFAnnotator:
         for record in vcf_in:
             additional_info_fields = [self.VRS_ALLELE_IDS_FIELD]
             if vrs_attributes:
-                additional_info_fields += [self.VRS_STARTS_FIELD, self.VRS_ENDS_FIELD, self.VRS_STATES_FIELD]
+                additional_info_fields += [
+                    self.VRS_STARTS_FIELD,
+                    self.VRS_ENDS_FIELD,
+                    self.VRS_STATES_FIELD,
+                ]
             try:
                 vrs_field_data = self._get_vrs_data(
                     record,
@@ -339,7 +377,12 @@ class VCFAnnotator:
                 additional_info_fields = [self.VRS_ERROR_FIELD]
                 vrs_field_data = {self.VRS_ERROR_FIELD: [err_msg]}
 
-            _logger.debug("VCF record %s-%s generated vrs_field_data %s", record.chrom, record.pos, vrs_field_data)
+            _logger.debug(
+                "VCF record %s-%s generated vrs_field_data %s",
+                record.chrom,
+                record.pos,
+                vrs_field_data,
+            )
 
             if output_vcf:
                 for k in additional_info_fields:
@@ -387,10 +430,16 @@ class VCFAnnotator:
             validation checks fail. Defaults to `True`.
         """
         try:
-            vrs_obj = self.tlr._from_gnomad(vcf_coords, assembly_name=assembly, require_validation=require_validation)  # noqa: SLF001
+            vrs_obj = self.tlr._from_gnomad(  # noqa: SLF001
+                vcf_coords,
+                assembly_name=assembly,
+                require_validation=require_validation,
+            )
         except (ValidationError, DataProxyValidationError):
             vrs_obj = None
-            _logger.exception("ValidationError when translating %s from gnomad", vcf_coords)
+            _logger.exception(
+                "ValidationError when translating %s from gnomad", vcf_coords
+            )
             raise
         except KeyError:
             vrs_obj = None
@@ -398,15 +447,21 @@ class VCFAnnotator:
             raise
         except AssertionError:
             vrs_obj = None
-            _logger.exception("AssertionError when translating %s from gnomad", vcf_coords)
+            _logger.exception(
+                "AssertionError when translating %s from gnomad", vcf_coords
+            )
             raise
         except Exception:
             vrs_obj = None
-            _logger.exception("Unhandled Exception when translating %s from gnomad", vcf_coords)
+            _logger.exception(
+                "Unhandled Exception when translating %s from gnomad", vcf_coords
+            )
             raise
         else:
             if not vrs_obj:
-                _logger.debug("None was returned when translating %s from gnomad", vcf_coords)
+                _logger.debug(
+                    "None was returned when translating %s from gnomad", vcf_coords
+                )
 
         if output_pickle and vrs_obj:
             key = vrs_data_key if vrs_data_key else vcf_coords
@@ -420,7 +475,11 @@ class VCFAnnotator:
                 if vrs_obj:
                     start = str(vrs_obj.location.start)
                     end = str(vrs_obj.location.end)
-                    alt = str(vrs_obj.state.sequence.root) if vrs_obj.state.sequence else ""
+                    alt = (
+                        str(vrs_obj.state.sequence.root)
+                        if vrs_obj.state.sequence
+                        else ""
+                    )
                 else:
                     start = ""
                     end = ""
@@ -463,7 +522,9 @@ class VCFAnnotator:
             of associated values. If `output_vcf = False`, an empty dictionary will be
             returned.
         """
-        vrs_field_data = {field: [] for field in additional_info_fields} if output_vcf else {}
+        vrs_field_data = (
+            {field: [] for field in additional_info_fields} if output_vcf else {}
+        )
 
         # Get VRS data for reference allele
         gnomad_loc = f"{record.chrom}-{record.pos}"

--- a/src/ga4gh/vrs/extras/vcf_annotation.py
+++ b/src/ga4gh/vrs/extras/vcf_annotation.py
@@ -24,7 +24,7 @@ _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.DEBUG)
 
 
-class VCFAnnotatorException(Exception):
+class VCFAnnotatorException(Exception):  # noqa: N818
     """Custom exceptions for VCF Annotator tool"""
 
 

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -307,7 +307,7 @@ class Ga4ghIdentifiableObject(_ValueObject, ABC):
         else:
             return self.compute_ga4gh_identifier(recompute)
 
-    def compute_ga4gh_identifier(self, recompute: bool =False, as_version=None):
+    def compute_ga4gh_identifier(self, recompute: bool = False, as_version=None):
         """Return a GA4GH Computed Identifier.
 
         If ``as_version`` is provided, other parameters are ignored and a computed

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -11,20 +11,19 @@ Instead, users should use one of the following:
     module name, e.g., `ga4gh.vrs.models.Allele`
 """
 
-from abc import ABC
-from typing import List, Literal, Optional, Union, Dict, Annotated
-from collections import OrderedDict
-from enum import Enum
 import inspect
 import sys
-from ga4gh.core import sha512t24u, GA4GH_PREFIX_SEP, CURIE_SEP, CURIE_NAMESPACE, GA4GH_IR_REGEXP, PrevVrsVersion
-from ga4gh.core.pydantic import get_pydantic_root
+from abc import ABC
+from collections import OrderedDict
+from enum import Enum
+from typing import Annotated, Dict, List, Literal, Optional, Union
 
 from canonicaljson import encode_canonical_json
-from pydantic import BaseModel, Field, RootModel, StringConstraints, ConfigDict, ValidationInfo, field_validator
+from pydantic import BaseModel, ConfigDict, Field, RootModel, StringConstraints, ValidationInfo, field_validator
 
-from ga4gh.core.pydantic import getattr_in
-from ga4gh.core.models import iriReference, Entity, MappableConcept, Element
+from ga4gh.core import CURIE_NAMESPACE, CURIE_SEP, GA4GH_IR_REGEXP, GA4GH_PREFIX_SEP, PrevVrsVersion, sha512t24u
+from ga4gh.core.models import Element, Entity, MappableConcept, iriReference
+from ga4gh.core.pydantic import get_pydantic_root, getattr_in
 
 
 def flatten(vals):

--- a/src/ga4gh/vrs/normalize.py
+++ b/src/ga4gh/vrs/normalize.py
@@ -223,7 +223,7 @@ def _is_valid_cycle(template_start, template, target):
 # TODO _normalize_genotype?
 
 
-def _normalize_cis_phased_block[T](o: T, data_proxy: _DataProxy | None =None) -> T:  # noqa: ARG001
+def _normalize_cis_phased_block[T](o: T, data_proxy: _DataProxy | None = None) -> T:  # noqa: ARG001
     o.members = sorted(o.members, key=ga4gh_digest)
     return o
 
@@ -234,7 +234,7 @@ handlers = {
 }
 
 
-def normalize(vo, data_proxy: _DataProxy | None =None, **kwargs):
+def normalize(vo, data_proxy: _DataProxy | None = None, **kwargs):
     """Normalize given vrs object, regardless of type
 
     kwargs:

--- a/src/ga4gh/vrs/normalize.py
+++ b/src/ga4gh/vrs/normalize.py
@@ -223,7 +223,7 @@ def _is_valid_cycle(template_start, template, target):
 # TODO _normalize_genotype?
 
 
-def _normalize_cis_phased_block[T](o: T, data_proxy: _DataProxy | None = None) -> T:  # noqa: ARG001
+def _normalize_cis_phased_block(o, data_proxy: _DataProxy | None = None):  # noqa: ARG001
     o.members = sorted(o.members, key=ga4gh_digest)
     return o
 

--- a/src/ga4gh/vrs/utils/__init__.py
+++ b/src/ga4gh/vrs/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Provide extra utilities."""

--- a/src/ga4gh/vrs/utils/hgvs_tools.py
+++ b/src/ga4gh/vrs/utils/hgvs_tools.py
@@ -109,7 +109,9 @@ class HgvsTools:
             end = sv.posedit.pos.end.base
             if sv.posedit.edit.type == "identity":
                 state = self.data_proxy.get_sequence(
-                    sv.ac, start=sv.posedit.pos.start.base - 1, end=sv.posedit.pos.end.base
+                    sv.ac,
+                    start=sv.posedit.pos.start.base - 1,
+                    end=sv.posedit.pos.end.base,
                 )
             else:
                 state = sv.posedit.edit.alt or ""
@@ -117,7 +119,9 @@ class HgvsTools:
         elif sv.posedit.edit.type == "dup":
             start = sv.posedit.pos.start.base - 1
             end = sv.posedit.pos.end.base
-            ref = self.data_proxy.get_sequence(sv.ac, start=sv.posedit.pos.start.base - 1, end=sv.posedit.pos.end.base)
+            ref = self.data_proxy.get_sequence(
+                sv.ac, start=sv.posedit.pos.start.base - 1, end=sv.posedit.pos.end.base
+            )
             state = ref + ref
 
         else:
@@ -176,7 +180,12 @@ class HgvsTools:
 
         (start, end, state) = self.get_position_and_state(sv)
 
-        return {"refget_accession": refget_accession, "start": start, "end": end, "literal_sequence": state}
+        return {
+            "refget_accession": refget_accession,
+            "start": start,
+            "end": end,
+            "literal_sequence": state,
+        }
 
     def from_allele(self, vo, namespace=None):
         """Generate a *list* of HGVS expressions for VRS Allele.
@@ -224,7 +233,21 @@ class HgvsTools:
                 continue
 
             if not (
-                any(accession.startswith(pfx) for pfx in ("NM", "NP", "NC", "NG", "NR", "NW", "NT", "XM", "XR", "XP"))
+                any(
+                    accession.startswith(pfx)
+                    for pfx in (
+                        "NM",
+                        "NP",
+                        "NC",
+                        "NG",
+                        "NR",
+                        "NW",
+                        "NT",
+                        "XM",
+                        "XR",
+                        "XP",
+                    )
+                )
             ):
                 continue
 
@@ -254,7 +277,10 @@ class HgvsTools:
             ref = self.data_proxy.get_sequence(sequence, start, end)
             start += 1
 
-        ival = hgvs.location.Interval(start=hgvs.location.SimplePosition(start), end=hgvs.location.SimplePosition(end))
+        ival = hgvs.location.Interval(
+            start=hgvs.location.SimplePosition(start),
+            end=hgvs.location.SimplePosition(end),
+        )
         alt = str(vo.state.sequence.root) or None  # "" => None
         edit = hgvs.edit.NARefAlt(ref=ref, alt=alt)
 
@@ -294,7 +320,9 @@ class HgvsTools:
 if __name__ == "__main__":
     import os
 
-    seqrepo_uri = os.environ.get("SEQREPO_URI", "seqrepo+file:///usr/local/share/seqrepo/latest")
+    seqrepo_uri = os.environ.get(
+        "SEQREPO_URI", "seqrepo+file:///usr/local/share/seqrepo/latest"
+    )
     if seqrepo_uri is None:
         msg = "SEQREPO_URI environment variable must be set to a valid seqrepo URI"
         raise ValueError(msg)

--- a/src/ga4gh/vrs/utils/hgvs_tools.py
+++ b/src/ga4gh/vrs/utils/hgvs_tools.py
@@ -244,7 +244,6 @@ class HgvsTools:
             raise ValueError(msg)
             # ival = hgvs.location.Interval(start=start, end=end)
             # edit = hgvs.edit.AARefAlt(ref=None, alt=vo.state.sequence)
-        # pylint: disable=no-else-raise
         start, end = vo.location.start, vo.location.end
         # ib: 0 1 2 3 4 5
         #  h:  1 2 3 4 5

--- a/src/ga4gh/vrs/utils/hgvs_tools.py
+++ b/src/ga4gh/vrs/utils/hgvs_tools.py
@@ -1,4 +1,5 @@
 """Provide extra tools for working with hgvs expressions."""
+
 import logging
 import re
 
@@ -254,9 +255,7 @@ class HgvsTools:
             ref = self.data_proxy.get_sequence(sequence, start, end)
             start += 1
 
-        ival = hgvs.location.Interval(
-            start=hgvs.location.SimplePosition(start), end=hgvs.location.SimplePosition(end)
-        )
+        ival = hgvs.location.Interval(start=hgvs.location.SimplePosition(start), end=hgvs.location.SimplePosition(end))
         alt = str(vo.state.sequence.root) or None  # "" => None
         edit = hgvs.edit.NARefAlt(ref=ref, alt=alt)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,17 @@ from ga4gh.vrs.dataproxy import SeqRepoDataProxy, SeqRepoRESTDataProxy
 
 @pytest.fixture(scope="session")
 def dataproxy():
-    sr = SeqRepo(root_dir=os.environ.get("SEQREPO_ROOT_DIR", "/usr/local/share/seqrepo/latest"))
+    sr = SeqRepo(
+        root_dir=os.environ.get("SEQREPO_ROOT_DIR", "/usr/local/share/seqrepo/latest")
+    )
     return SeqRepoDataProxy(sr)
 
 
 @pytest.fixture(scope="session")
 def rest_dataproxy():
-    return SeqRepoRESTDataProxy(base_url=os.environ.get("SEQREPO_REST_URL", "http://localhost:5000/seqrepo"))
+    return SeqRepoRESTDataProxy(
+        base_url=os.environ.get("SEQREPO_REST_URL", "http://localhost:5000/seqrepo")
+    )
 
 
 # See https://github.com/ga4gh/vrs-python/issues/24

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,7 @@ def dataproxy():
 
 @pytest.fixture(scope="session")
 def rest_dataproxy():
-    return SeqRepoRESTDataProxy(
-        base_url=os.environ.get(
-            "SEQREPO_REST_URL",
-            "http://localhost:5000/seqrepo"))
+    return SeqRepoRESTDataProxy(base_url=os.environ.get("SEQREPO_REST_URL", "http://localhost:5000/seqrepo"))
 
 
 # See https://github.com/ga4gh/vrs-python/issues/24

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
 
 import pytest
-
 from biocommons.seqrepo import SeqRepo
-from ga4gh.vrs.dataproxy import SeqRepoRESTDataProxy, SeqRepoDataProxy
+
+from ga4gh.vrs.dataproxy import SeqRepoDataProxy, SeqRepoRESTDataProxy
 
 
 @pytest.fixture(scope="session")

--- a/tests/extras/test_allele_translator.py
+++ b/tests/extras/test_allele_translator.py
@@ -26,7 +26,10 @@ snv_output = {
     "location": {
         "end": 44908822,
         "start": 44908821,
-        "sequenceReference": {"refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
@@ -45,7 +48,10 @@ mito_output = {
     "location": {
         "start": 10082,
         "end": 10083,
-        "sequenceReference": {"refgetAccession": "SQ.k3grVkjY-hoWcCUojHw6VU6GE3MZ8Sct", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ.k3grVkjY-hoWcCUojHw6VU6GE3MZ8Sct",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "G", "type": "LiteralSequenceExpression"},
@@ -63,7 +69,10 @@ deletion_output = {
     "location": {
         "end": 20003097,
         "start": 20003096,
-        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "", "type": "LiteralSequenceExpression"},
@@ -74,7 +83,10 @@ gnomad_deletion_output = {
     "location": {
         "end": 20003097,
         "start": 20003095,
-        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "A", "type": "LiteralSequenceExpression"},
@@ -85,10 +97,18 @@ deletion_output_normalized = {
     "location": {
         "end": 20003097,
         "start": 20003096,
-        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
-    "state": {"length": 0, "repeatSubunitLength": 1, "sequence": "", "type": "ReferenceLengthExpression"},
+    "state": {
+        "length": 0,
+        "repeatSubunitLength": 1,
+        "sequence": "",
+        "type": "ReferenceLengthExpression",
+    },
     "type": "Allele",
 }
 
@@ -103,7 +123,10 @@ insertion_output = {
     "location": {
         "end": 20003010,
         "start": 20003010,
-        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "G", "type": "LiteralSequenceExpression"},
@@ -114,7 +137,10 @@ gnomad_insertion_output = {
     "location": {
         "end": 20003010,
         "start": 20003009,
-        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "AG", "type": "LiteralSequenceExpression"},
@@ -132,7 +158,10 @@ duplication_output = {
     "location": {
         "end": 19993839,
         "start": 19993837,
-        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "GTGT", "type": "LiteralSequenceExpression"},
@@ -143,59 +172,108 @@ duplication_output_normalized = {
     "location": {
         "end": 19993839,
         "start": 19993837,
-        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "sequenceReference": {
+            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+            "type": "SequenceReference",
+        },
         "type": "SequenceLocation",
     },
-    "state": {"length": 4, "repeatSubunitLength": 2, "sequence": "GTGT", "type": "ReferenceLengthExpression"},
+    "state": {
+        "length": 4,
+        "repeatSubunitLength": 2,
+        "sequence": "GTGT",
+        "type": "ReferenceLengthExpression",
+    },
     "type": "Allele",
 }
 
 
 def test_from_invalid(tlr):
-    with pytest.raises(ValueError, match="Unable to parse data as beacon, gnomad, hgvs, spdi, vrs"):
+    with pytest.raises(
+        ValueError, match="Unable to parse data as beacon, gnomad, hgvs, spdi, vrs"
+    ):
         tlr.translate_from("BRAF amplication")
 
 
 @pytest.mark.vcr
 def test_from_beacon(tlr):
     do_normalize = False
-    assert tlr._from_beacon(snv_inputs["beacon"], do_normalize=do_normalize).model_dump(exclude_none=True) == snv_output
     assert (
-        tlr._from_beacon(mito_inputs["beacon"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
+        tlr._from_beacon(snv_inputs["beacon"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
+        == snv_output
+    )
+    assert (
+        tlr._from_beacon(mito_inputs["beacon"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
+        == mito_output
     )
 
 
 @pytest.mark.vcr
 def test_from_gnomad(tlr):
     do_normalize = False
-    assert tlr._from_gnomad(snv_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True) == snv_output
     assert (
-        tlr._from_gnomad(mito_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
+        tlr._from_gnomad(snv_inputs["gnomad"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
+        == snv_output
     )
     assert (
-        tlr._from_gnomad(deletion_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        tlr._from_gnomad(mito_inputs["gnomad"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
+        == mito_output
+    )
+    assert (
+        tlr._from_gnomad(
+            deletion_inputs["gnomad"], do_normalize=do_normalize
+        ).model_dump(exclude_none=True)
         == gnomad_deletion_output
     )
     assert (
-        tlr._from_gnomad(insertion_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        tlr._from_gnomad(
+            insertion_inputs["gnomad"], do_normalize=do_normalize
+        ).model_dump(exclude_none=True)
         == gnomad_insertion_output
     )
     assert (
-        tlr._from_gnomad(duplication_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        tlr._from_gnomad(
+            duplication_inputs["gnomad"], do_normalize=do_normalize
+        ).model_dump(exclude_none=True)
         == duplication_output
     )
 
     # do_normalize defaults to true
-    assert tlr._from_gnomad(snv_inputs["gnomad"]).model_dump(exclude_none=True) == snv_output
-    assert tlr._from_gnomad(mito_inputs["gnomad"]).model_dump(exclude_none=True) == mito_output
-    assert tlr._from_gnomad(deletion_inputs["gnomad"]).model_dump(exclude_none=True) == deletion_output_normalized
-    assert tlr._from_gnomad(insertion_inputs["gnomad"]).model_dump(exclude_none=True) == insertion_output
-    assert tlr._from_gnomad(duplication_inputs["gnomad"]).model_dump(exclude_none=True) == duplication_output_normalized
+    assert (
+        tlr._from_gnomad(snv_inputs["gnomad"]).model_dump(exclude_none=True)
+        == snv_output
+    )
+    assert (
+        tlr._from_gnomad(mito_inputs["gnomad"]).model_dump(exclude_none=True)
+        == mito_output
+    )
+    assert (
+        tlr._from_gnomad(deletion_inputs["gnomad"]).model_dump(exclude_none=True)
+        == deletion_output_normalized
+    )
+    assert (
+        tlr._from_gnomad(insertion_inputs["gnomad"]).model_dump(exclude_none=True)
+        == insertion_output
+    )
+    assert (
+        tlr._from_gnomad(duplication_inputs["gnomad"]).model_dump(exclude_none=True)
+        == duplication_output_normalized
+    )
 
     assert tlr._from_gnomad("17-83129587-GTTGWCACATGA-G")
 
     # Test valid characters
-    assert tlr._from_gnomad("7-2-ACGTURYKMSWBDHVN-ACGTURYKMSWBDHVN", require_validation=False)
+    assert tlr._from_gnomad(
+        "7-2-ACGTURYKMSWBDHVN-ACGTURYKMSWBDHVN", require_validation=False
+    )
 
     # Invalid input. Ref does not match regex
     assert not tlr._from_gnomad("13-32936732-helloworld-C")
@@ -219,18 +297,34 @@ def test_from_gnomad(tlr):
 @pytest.mark.vcr
 def test_from_hgvs(tlr):
     do_normalize = False
-    assert tlr._from_hgvs(snv_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True) == snv_output
-    assert tlr._from_hgvs(mito_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
     assert (
-        tlr._from_hgvs(deletion_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        tlr._from_hgvs(snv_inputs["hgvs"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
+        == snv_output
+    )
+    assert (
+        tlr._from_hgvs(mito_inputs["hgvs"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
+        == mito_output
+    )
+    assert (
+        tlr._from_hgvs(deletion_inputs["hgvs"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
         == deletion_output
     )
     assert (
-        tlr._from_hgvs(insertion_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        tlr._from_hgvs(insertion_inputs["hgvs"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
         == insertion_output
     )
     assert (
-        tlr._from_hgvs(duplication_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        tlr._from_hgvs(
+            duplication_inputs["hgvs"], do_normalize=do_normalize
+        ).model_dump(exclude_none=True)
         == duplication_output
     )
 
@@ -238,18 +332,36 @@ def test_from_hgvs(tlr):
 @pytest.mark.vcr
 def test_from_spdi(tlr):
     do_normalize = False
-    assert tlr._from_spdi(snv_inputs["spdi"], do_normalize=do_normalize).model_dump(exclude_none=True) == snv_output
-    assert tlr._from_spdi(mito_inputs["spdi"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
+    assert (
+        tlr._from_spdi(snv_inputs["spdi"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
+        == snv_output
+    )
+    assert (
+        tlr._from_spdi(mito_inputs["spdi"], do_normalize=do_normalize).model_dump(
+            exclude_none=True
+        )
+        == mito_output
+    )
     for spdi_del_expr in deletion_inputs["spdi"]:
         assert (
-            tlr._from_spdi(spdi_del_expr, do_normalize=do_normalize).model_dump(exclude_none=True) == deletion_output
+            tlr._from_spdi(spdi_del_expr, do_normalize=do_normalize).model_dump(
+                exclude_none=True
+            )
+            == deletion_output
         ), spdi_del_expr
     for spdi_ins_expr in insertion_inputs["spdi"]:
         assert (
-            tlr._from_spdi(spdi_ins_expr, do_normalize=do_normalize).model_dump(exclude_none=True) == insertion_output
+            tlr._from_spdi(spdi_ins_expr, do_normalize=do_normalize).model_dump(
+                exclude_none=True
+            )
+            == insertion_output
         ), spdi_ins_expr
     assert (
-        tlr._from_spdi(duplication_inputs["spdi"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        tlr._from_spdi(
+            duplication_inputs["spdi"], do_normalize=do_normalize
+        ).model_dump(exclude_none=True)
         == duplication_output
     )
 
@@ -321,7 +433,12 @@ hgvs_tests = (
                 "start": 55181219,
                 "type": "SequenceLocation",
             },
-            "state": {"length": 0, "repeatSubunitLength": 1, "sequence": "", "type": "ReferenceLengthExpression"},
+            "state": {
+                "length": 0,
+                "repeatSubunitLength": 1,
+                "sequence": "",
+                "type": "ReferenceLengthExpression",
+            },
             "type": "Allele",
         },
     ),
@@ -386,7 +503,12 @@ hgvs_tests = (
                 "start": 32316466,
                 "type": "SequenceLocation",
             },
-            "state": {"length": 2, "repeatSubunitLength": 1, "sequence": "AA", "type": "ReferenceLengthExpression"},
+            "state": {
+                "length": 2,
+                "repeatSubunitLength": 1,
+                "sequence": "AA",
+                "type": "ReferenceLengthExpression",
+            },
             "type": "Allele",
         },
     ),
@@ -447,7 +569,12 @@ hgvs_tests = (
                 "start": 289464,
                 "type": "SequenceLocation",
             },
-            "state": {"length": 6, "repeatSubunitLength": 2, "sequence": "CACACA", "type": "ReferenceLengthExpression"},
+            "state": {
+                "length": 6,
+                "repeatSubunitLength": 2,
+                "sequence": "CACACA",
+                "type": "ReferenceLengthExpression",
+            },
         },
     ),
     (
@@ -467,7 +594,12 @@ hgvs_tests = (
                 "start": 289480,
                 "type": "SequenceLocation",
             },
-            "state": {"length": 5, "repeatSubunitLength": 16, "sequence": "CGAGG", "type": "ReferenceLengthExpression"},
+            "state": {
+                "length": 5,
+                "repeatSubunitLength": 16,
+                "sequence": "CGAGG",
+                "type": "ReferenceLengthExpression",
+            },
         },
     ),
 )
@@ -487,7 +619,9 @@ def test_hgvs(tlr, hgvsexpr, expected):
     assert allele.model_dump(exclude_none=True) == expected
 
     to_hgvs = tlr.translate_to(allele, "hgvs")
-    assert (hgvsexpr in to_hgvs) or (hgvs_tests_to_hgvs_map.get(hgvsexpr, hgvsexpr) in to_hgvs)
+    assert (hgvsexpr in to_hgvs) or (
+        hgvs_tests_to_hgvs_map.get(hgvsexpr, hgvsexpr) in to_hgvs
+    )
 
 
 @pytest.mark.vcr
@@ -509,7 +643,11 @@ def test_rle_seq_limit(tlr):
             "start": 32331042,
             "type": "SequenceLocation",
         },
-        "state": {"length": 104, "repeatSubunitLength": 52, "type": "ReferenceLengthExpression"},
+        "state": {
+            "length": 104,
+            "repeatSubunitLength": 52,
+            "type": "ReferenceLengthExpression",
+        },
         "type": "Allele",
     }
     input_hgvs_expr = "NC_000013.11:g.32331043_32331094dup"
@@ -518,11 +656,15 @@ def test_rle_seq_limit(tlr):
     allele_no_seq = tlr.translate_from(input_hgvs_expr, fmt="hgvs")
     assert allele_no_seq.model_dump(exclude_none=True) == a_dict
 
-    with pytest.raises(AttributeError, match="'NoneType' object has no attribute 'root'"):
+    with pytest.raises(
+        AttributeError, match="'NoneType' object has no attribute 'root'"
+    ):
         tlr.translate_to(allele_no_seq, "hgvs")
 
     # set rle_seq_limit to None
-    allele_with_seq = tlr.translate_from(input_hgvs_expr, fmt="hgvs", rle_seq_limit=None)
+    allele_with_seq = tlr.translate_from(
+        input_hgvs_expr, fmt="hgvs", rle_seq_limit=None
+    )
     a_dict_with_seq = a_dict.copy()
     a_dict_with_seq["state"]["sequence"] = (
         "TTTAGTTGAACTACAGGTTTTTTTGTTGTTGTTGTTTTGATTTTTTTTTTTTTTTAGTTGAACTACAGGTTTTTTTGTTGTTGTTGTTTTGATTTTTTTTTTTT"

--- a/tests/extras/test_allele_translator.py
+++ b/tests/extras/test_allele_translator.py
@@ -19,24 +19,18 @@ snv_inputs = {
     "hgvs": "NC_000019.10:g.44908822C>T",
     "beacon": "19 : 44908822 C > T",
     "spdi": "NC_000019.10:44908821:1:T",
-    "gnomad": "19-44908822-C-T"
+    "gnomad": "19-44908822-C-T",
 }
 
 snv_output = {
     "location": {
         "end": 44908822,
         "start": 44908821,
-        "sequenceReference": {
-            "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
-            "type": "SequenceReference"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "sequence": "T",
-        "type": "LiteralSequenceExpression"
-    },
-    "type": "Allele"
+    "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 # https://www.ncbi.nlm.nih.gov/clinvar/variation/693259/?new_evidence=true
@@ -44,169 +38,118 @@ mito_inputs = {
     "hgvs": "NC_012920.1:m.10083A>G",
     "beacon": "MT : 10083 A > G",
     "spdi": "NC_012920.1:10082:A:G",
-    "gnomad": "MT-10083-A-G"
+    "gnomad": "MT-10083-A-G",
 }
 
 mito_output = {
     "location": {
-      "start": 10082,
-      "end": 10083,
-      "sequenceReference": {
-        "refgetAccession": "SQ.k3grVkjY-hoWcCUojHw6VU6GE3MZ8Sct",
-        "type": "SequenceReference"
-      },
-      "type": "SequenceLocation"
+        "start": 10082,
+        "end": 10083,
+        "sequenceReference": {"refgetAccession": "SQ.k3grVkjY-hoWcCUojHw6VU6GE3MZ8Sct", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-      "sequence": "G",
-      "type": "LiteralSequenceExpression"
-    },
-    "type": "Allele"
+    "state": {"sequence": "G", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 # https://www.ncbi.nlm.nih.gov/clinvar/variation/1373966/?new_evidence=true
 deletion_inputs = {
     "hgvs": "NC_000013.11:g.20003097del",
     "spdi": ["NC_000013.11:20003096:C:", "NC_000013.11:20003096:1:"],
-    "gnomad": "13-20003096-AC-A"
+    "gnomad": "13-20003096-AC-A",
 }
 
 deletion_output = {
     "location": {
         "end": 20003097,
         "start": 20003096,
-        "sequenceReference": {
-            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
-            "type": "SequenceReference"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "sequence": "",
-        "type": "LiteralSequenceExpression"
-    },
-    "type": "Allele"
+    "state": {"sequence": "", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 gnomad_deletion_output = {
     "location": {
         "end": 20003097,
         "start": 20003095,
-        "sequenceReference": {
-            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
-            "type": "SequenceReference"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "sequence": "A",
-        "type": "LiteralSequenceExpression"
-    },
-    "type": "Allele"
+    "state": {"sequence": "A", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 deletion_output_normalized = {
     "location": {
         "end": 20003097,
         "start": 20003096,
-        "sequenceReference": {
-            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
-            "type": "SequenceReference"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "length": 0,
-        "repeatSubunitLength": 1,
-        "sequence": "",
-        "type": "ReferenceLengthExpression"
-    },
-    "type": "Allele"
+    "state": {"length": 0, "repeatSubunitLength": 1, "sequence": "", "type": "ReferenceLengthExpression"},
+    "type": "Allele",
 }
 
 # https://www.ncbi.nlm.nih.gov/clinvar/variation/1687427/?new_evidence=true
 insertion_inputs = {
     "hgvs": "NC_000013.11:g.20003010_20003011insG",
     "spdi": ["NC_000013.11:20003010::G", "NC_000013.11:20003010:0:G"],
-    "gnomad": "13-20003010-A-AG"
+    "gnomad": "13-20003010-A-AG",
 }
 
 insertion_output = {
     "location": {
         "end": 20003010,
         "start": 20003010,
-        "sequenceReference": {
-            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
-            "type": "SequenceReference"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "sequence": "G",
-        "type": "LiteralSequenceExpression"
-    },
-    "type": "Allele"
+    "state": {"sequence": "G", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 gnomad_insertion_output = {
     "location": {
         "end": 20003010,
         "start": 20003009,
-        "sequenceReference": {
-            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
-            "type": "SequenceReference"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "sequence": "AG",
-        "type": "LiteralSequenceExpression"
-    },
-    "type": "Allele"
+    "state": {"sequence": "AG", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 # https://www.ncbi.nlm.nih.gov/clinvar/variation/1264314/?new_evidence=true
 duplication_inputs = {
     "hgvs": "NC_000013.11:g.19993838_19993839dup",
     "spdi": "NC_000013.11:19993837:GT:GTGT",
-    "gnomad": "13-19993838-GT-GTGT"
+    "gnomad": "13-19993838-GT-GTGT",
 }
 
 duplication_output = {
     "location": {
         "end": 19993839,
         "start": 19993837,
-        "sequenceReference": {
-            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
-            "type": "SequenceReference"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "sequence": "GTGT",
-        "type": "LiteralSequenceExpression"
-    },
-    "type": "Allele"
+    "state": {"sequence": "GTGT", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 duplication_output_normalized = {
     "location": {
         "end": 19993839,
         "start": 19993837,
-        "sequenceReference": {
-            "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
-            "type": "SequenceReference"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT", "type": "SequenceReference"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "length": 4,
-        "repeatSubunitLength": 2,
-        "sequence": "GTGT",
-        "type": "ReferenceLengthExpression"
-    },
-    "type": "Allele"
+    "state": {"length": 4, "repeatSubunitLength": 2, "sequence": "GTGT", "type": "ReferenceLengthExpression"},
+    "type": "Allele",
 }
+
 
 def test_from_invalid(tlr):
     try:
@@ -215,21 +158,35 @@ def test_from_invalid(tlr):
     except ValueError as e:
         assert e.args[0] == "Unable to parse data as beacon, gnomad, hgvs, spdi, vrs"
 
+
 @pytest.mark.vcr
 def test_from_beacon(tlr):
     do_normalize = False
     assert tlr._from_beacon(snv_inputs["beacon"], do_normalize=do_normalize).model_dump(exclude_none=True) == snv_output
-    assert tlr._from_beacon(mito_inputs["beacon"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
+    assert (
+        tlr._from_beacon(mito_inputs["beacon"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
+    )
 
 
 @pytest.mark.vcr
 def test_from_gnomad(tlr):
     do_normalize = False
     assert tlr._from_gnomad(snv_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True) == snv_output
-    assert tlr._from_gnomad(mito_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
-    assert tlr._from_gnomad(deletion_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True) == gnomad_deletion_output
-    assert tlr._from_gnomad(insertion_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True) == gnomad_insertion_output
-    assert tlr._from_gnomad(duplication_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True) == duplication_output
+    assert (
+        tlr._from_gnomad(mito_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
+    )
+    assert (
+        tlr._from_gnomad(deletion_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        == gnomad_deletion_output
+    )
+    assert (
+        tlr._from_gnomad(insertion_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        == gnomad_insertion_output
+    )
+    assert (
+        tlr._from_gnomad(duplication_inputs["gnomad"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        == duplication_output
+    )
 
     # do_normalize defaults to true
     assert tlr._from_gnomad(snv_inputs["gnomad"]).model_dump(exclude_none=True) == snv_output
@@ -241,10 +198,7 @@ def test_from_gnomad(tlr):
     assert tlr._from_gnomad("17-83129587-GTTGWCACATGA-G")
 
     # Test valid characters
-    assert tlr._from_gnomad(
-        "7-2-ACGTURYKMSWBDHVN-ACGTURYKMSWBDHVN",
-        require_validation=False
-    )
+    assert tlr._from_gnomad("7-2-ACGTURYKMSWBDHVN-ACGTURYKMSWBDHVN", require_validation=False)
 
     # Invalid input. Ref does not match regex
     assert not tlr._from_gnomad("13-32936732-helloworld-C")
@@ -270,9 +224,18 @@ def test_from_hgvs(tlr):
     do_normalize = False
     assert tlr._from_hgvs(snv_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True) == snv_output
     assert tlr._from_hgvs(mito_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
-    assert tlr._from_hgvs(deletion_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True) == deletion_output
-    assert tlr._from_hgvs(insertion_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True) == insertion_output
-    assert tlr._from_hgvs(duplication_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True) == duplication_output
+    assert (
+        tlr._from_hgvs(deletion_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        == deletion_output
+    )
+    assert (
+        tlr._from_hgvs(insertion_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        == insertion_output
+    )
+    assert (
+        tlr._from_hgvs(duplication_inputs["hgvs"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        == duplication_output
+    )
 
 
 @pytest.mark.vcr
@@ -281,10 +244,17 @@ def test_from_spdi(tlr):
     assert tlr._from_spdi(snv_inputs["spdi"], do_normalize=do_normalize).model_dump(exclude_none=True) == snv_output
     assert tlr._from_spdi(mito_inputs["spdi"], do_normalize=do_normalize).model_dump(exclude_none=True) == mito_output
     for spdi_del_expr in deletion_inputs["spdi"]:
-        assert tlr._from_spdi(spdi_del_expr, do_normalize=do_normalize).model_dump(exclude_none=True) == deletion_output, spdi_del_expr
+        assert (
+            tlr._from_spdi(spdi_del_expr, do_normalize=do_normalize).model_dump(exclude_none=True) == deletion_output
+        ), spdi_del_expr
     for spdi_ins_expr in insertion_inputs["spdi"]:
-        assert tlr._from_spdi(spdi_ins_expr, do_normalize=do_normalize).model_dump(exclude_none=True) == insertion_output, spdi_ins_expr
-    assert tlr._from_spdi(duplication_inputs["spdi"], do_normalize=do_normalize).model_dump(exclude_none=True) == duplication_output
+        assert (
+            tlr._from_spdi(spdi_ins_expr, do_normalize=do_normalize).model_dump(exclude_none=True) == insertion_output
+        ), spdi_ins_expr
+    assert (
+        tlr._from_spdi(duplication_inputs["spdi"], do_normalize=do_normalize).model_dump(exclude_none=True)
+        == duplication_output
+    )
 
 
 @pytest.mark.vcr
@@ -298,147 +268,216 @@ def test_to_spdi(tlr):
 
 
 hgvs_tests = (
-    ("NC_000013.11:g.32936732=",
-     {'digest': 'GJ2JySBMXePcV2yItyvCfbGBUoawOBON',
-      'id': 'ga4gh:VA.GJ2JySBMXePcV2yItyvCfbGBUoawOBON',
-      'location': {'digest': '28YsnRvD40gKu1x3nev0gRzRz-5OTlpS',
-                   'end': 32936732,
-                   'id': 'ga4gh:SL.28YsnRvD40gKu1x3nev0gRzRz-5OTlpS',
-                   'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                         'type': 'SequenceReference'},
-                   'start': 32936731,
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'C', 'type': 'LiteralSequenceExpression'},
-      'type': 'Allele'}),
-    ("NC_000007.14:g.55181320A>T",
-     {'digest': 'Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE',
-      'id': 'ga4gh:VA.Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE',
-      'location': {'digest': '_G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd',
-                   'end': 55181320,
-                   'id': 'ga4gh:SL._G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd',
-                   'sequenceReference': {'refgetAccession': 'SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                                         'type': 'SequenceReference'},
-                   'start': 55181319,
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'T', 'type': 'LiteralSequenceExpression'},
-      'type': 'Allele'}),
-    ("NC_000007.14:g.55181220del",
-     {'digest': 'klRMVChjvV73ZxS9Ajq1Rb8WU-p_HbLu',
-      'id': 'ga4gh:VA.klRMVChjvV73ZxS9Ajq1Rb8WU-p_HbLu',
-      'location': {'digest': 'ljan7F0ePe9uiD6f2u80ZG5gDtx9Mr0V',
-                   'end': 55181220,
-                   'id': 'ga4gh:SL.ljan7F0ePe9uiD6f2u80ZG5gDtx9Mr0V',
-                   'sequenceReference': {'refgetAccession': 'SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                                         'type': 'SequenceReference'},
-                   'start': 55181219,
-                   'type': 'SequenceLocation'},
-      'state': {'length': 0,
-                'repeatSubunitLength': 1,
-                'sequence': '',
-                'type': 'ReferenceLengthExpression'},
-      'type': 'Allele'}),
-    ("NC_000007.14:g.55181230_55181231insGGCT",
-     {'digest': 'CLOvnFRJXGNRB9aTuNbvsLqc7syRYb55',
-      'id': 'ga4gh:VA.CLOvnFRJXGNRB9aTuNbvsLqc7syRYb55',
-      'location': {'digest': 'lh4dRt_xWPi3wrubcfomi5DkD7fu6wd2',
-                   'end': 55181230,
-                   'id': 'ga4gh:SL.lh4dRt_xWPi3wrubcfomi5DkD7fu6wd2',
-                   'sequenceReference': {'refgetAccession': 'SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul',
-                                         'type': 'SequenceReference'},
-                   'start': 55181230,
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'GGCT', 'type': 'LiteralSequenceExpression'},
-      'type': 'Allele'}),
-    ("NC_000013.11:g.32331093_32331094dup",
-     {'digest': 'swY2caCgv1kP6YqKyPlcEzJqTvou15vC',
-      'id': 'ga4gh:VA.swY2caCgv1kP6YqKyPlcEzJqTvou15vC',
-      'location': {'digest': 'ikECYncPpE1xh6f_LiComrFGevocjDHQ',
-                   'end': 32331094,
-                   'id': 'ga4gh:SL.ikECYncPpE1xh6f_LiComrFGevocjDHQ',
-                   'sequenceReference': {
-                       'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                       'type': 'SequenceReference'},
-                   'start': 32331082,
-                   'type': 'SequenceLocation'},
-      'state': {'length': 14,
-                'repeatSubunitLength': 2,
-                'sequence': 'TTTTTTTTTTTTTT',
-                'type': 'ReferenceLengthExpression'},
-      'type': 'Allele'}),
-    ("NC_000013.11:g.32316467dup",
-     {'digest': '96ak7XdY3DNbp71aHEXw-NHSfeHGW-KT',
-      'id': 'ga4gh:VA.96ak7XdY3DNbp71aHEXw-NHSfeHGW-KT',
-      'location': {'digest': 'fwfHu8VaD2-6Qvay9MJSINXPS767RYSw',
-                   'end': 32316467,
-                   'id': 'ga4gh:SL.fwfHu8VaD2-6Qvay9MJSINXPS767RYSw',
-                   'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                         'type': 'SequenceReference'},
-                   'start': 32316466,
-                   'type': 'SequenceLocation'},
-      'state': {'length': 2,
-                'repeatSubunitLength': 1,
-                'sequence': 'AA',
-                'type': 'ReferenceLengthExpression'},
-      'type': 'Allele'}),
-    ("NM_001331029.1:c.722A>G",
-     {'digest': 'DPe4AO-S0Yu4wzSCmys7eGn4p4sO0zaC',
-      'id': 'ga4gh:VA.DPe4AO-S0Yu4wzSCmys7eGn4p4sO0zaC',
-      'location': {'digest': '7hcVmPnIspQNDfZKBzRJFc8K9GaJuAlY',
-                   'end': 872,
-                   'id': 'ga4gh:SL.7hcVmPnIspQNDfZKBzRJFc8K9GaJuAlY',
-                   'sequenceReference': {'refgetAccession': 'SQ.MBIgVnoHFw34aFqNUVGM0zgjC3d-v8dK',
-                                         'type': 'SequenceReference'},
-                   'start': 871,
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'G', 'type': 'LiteralSequenceExpression'},
-      'type': 'Allele'}),
-    ("NM_181798.1:c.1007G>T",
-     {'digest': 'vSL4aV7mPQKQLX7Jk-PmXN0APs0cBIr9',
-      'id': 'ga4gh:VA.vSL4aV7mPQKQLX7Jk-PmXN0APs0cBIr9',
-      'location': {'digest': 'EtvHvoj1Lsq-RruzIzWbKOIAW-bt193w',
-                   'end': 1263,
-                   'id': 'ga4gh:SL.EtvHvoj1Lsq-RruzIzWbKOIAW-bt193w',
-                   'sequenceReference': {'refgetAccession': 'SQ.KN07u-RFqd1dTyOWOG98HnOq87Nq-ZIg',
-                                         'type': 'SequenceReference'},
-                   'start': 1262,
-                   'type': 'SequenceLocation'},
-      'state': {'sequence': 'T', 'type': 'LiteralSequenceExpression'},
-      'type': 'Allele'}),
-    ("NC_000019.10:g.289464_289465insCACA",
-     {'digest': 'YFUR4oR_84b-rRFf0UzOjfI4eE5FTKAP',
-      'id': 'ga4gh:VA.YFUR4oR_84b-rRFf0UzOjfI4eE5FTKAP',
-      'type': 'Allele',
-      'location': {'digest': 'L145KFLJeJ334YnOVm59pPlbdqfHhgXZ',
-                   'end': 289466,
-                   'id': 'ga4gh:SL.L145KFLJeJ334YnOVm59pPlbdqfHhgXZ',
-                   'sequenceReference': {'refgetAccession': 'SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl',
-                                         'type': 'SequenceReference'},
-                   'start': 289464,
-                   'type': 'SequenceLocation'},
-        'state': {'length': 6,
-                  'repeatSubunitLength': 2,
-                  'sequence': 'CACACA',
-                  'type': 'ReferenceLengthExpression'}}),
-    ("NC_000019.10:g.289485_289500del",
-     {'digest': 'Djc_SwVDFunsArqwUM00PciVaF70VTcU',
-      'id': 'ga4gh:VA.Djc_SwVDFunsArqwUM00PciVaF70VTcU',
-      'type': 'Allele',
-      'location': {'digest': 'WTE7jyihK4qvRRzEqM7u5nSD4iS2k3xp',
-                   'end': 289501,
-                   'id': 'ga4gh:SL.WTE7jyihK4qvRRzEqM7u5nSD4iS2k3xp',
-                   'sequenceReference': {'refgetAccession': 'SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl',
-                                         'type': 'SequenceReference'},
-                   'start': 289480,
-                   'type': 'SequenceLocation'},
-        'state': {'length': 5,
-                  'repeatSubunitLength': 16,
-                  'sequence': 'CGAGG',
-                  'type': 'ReferenceLengthExpression'}}),
+    (
+        "NC_000013.11:g.32936732=",
+        {
+            "digest": "GJ2JySBMXePcV2yItyvCfbGBUoawOBON",
+            "id": "ga4gh:VA.GJ2JySBMXePcV2yItyvCfbGBUoawOBON",
+            "location": {
+                "digest": "28YsnRvD40gKu1x3nev0gRzRz-5OTlpS",
+                "end": 32936732,
+                "id": "ga4gh:SL.28YsnRvD40gKu1x3nev0gRzRz-5OTlpS",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 32936731,
+                "type": "SequenceLocation",
+            },
+            "state": {"sequence": "C", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
+        },
+    ),
+    (
+        "NC_000007.14:g.55181320A>T",
+        {
+            "digest": "Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE",
+            "id": "ga4gh:VA.Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE",
+            "location": {
+                "digest": "_G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd",
+                "end": 55181320,
+                "id": "ga4gh:SL._G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd",
+                "sequenceReference": {
+                    "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                    "type": "SequenceReference",
+                },
+                "start": 55181319,
+                "type": "SequenceLocation",
+            },
+            "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
+        },
+    ),
+    (
+        "NC_000007.14:g.55181220del",
+        {
+            "digest": "klRMVChjvV73ZxS9Ajq1Rb8WU-p_HbLu",
+            "id": "ga4gh:VA.klRMVChjvV73ZxS9Ajq1Rb8WU-p_HbLu",
+            "location": {
+                "digest": "ljan7F0ePe9uiD6f2u80ZG5gDtx9Mr0V",
+                "end": 55181220,
+                "id": "ga4gh:SL.ljan7F0ePe9uiD6f2u80ZG5gDtx9Mr0V",
+                "sequenceReference": {
+                    "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                    "type": "SequenceReference",
+                },
+                "start": 55181219,
+                "type": "SequenceLocation",
+            },
+            "state": {"length": 0, "repeatSubunitLength": 1, "sequence": "", "type": "ReferenceLengthExpression"},
+            "type": "Allele",
+        },
+    ),
+    (
+        "NC_000007.14:g.55181230_55181231insGGCT",
+        {
+            "digest": "CLOvnFRJXGNRB9aTuNbvsLqc7syRYb55",
+            "id": "ga4gh:VA.CLOvnFRJXGNRB9aTuNbvsLqc7syRYb55",
+            "location": {
+                "digest": "lh4dRt_xWPi3wrubcfomi5DkD7fu6wd2",
+                "end": 55181230,
+                "id": "ga4gh:SL.lh4dRt_xWPi3wrubcfomi5DkD7fu6wd2",
+                "sequenceReference": {
+                    "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+                    "type": "SequenceReference",
+                },
+                "start": 55181230,
+                "type": "SequenceLocation",
+            },
+            "state": {"sequence": "GGCT", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
+        },
+    ),
+    (
+        "NC_000013.11:g.32331093_32331094dup",
+        {
+            "digest": "swY2caCgv1kP6YqKyPlcEzJqTvou15vC",
+            "id": "ga4gh:VA.swY2caCgv1kP6YqKyPlcEzJqTvou15vC",
+            "location": {
+                "digest": "ikECYncPpE1xh6f_LiComrFGevocjDHQ",
+                "end": 32331094,
+                "id": "ga4gh:SL.ikECYncPpE1xh6f_LiComrFGevocjDHQ",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 32331082,
+                "type": "SequenceLocation",
+            },
+            "state": {
+                "length": 14,
+                "repeatSubunitLength": 2,
+                "sequence": "TTTTTTTTTTTTTT",
+                "type": "ReferenceLengthExpression",
+            },
+            "type": "Allele",
+        },
+    ),
+    (
+        "NC_000013.11:g.32316467dup",
+        {
+            "digest": "96ak7XdY3DNbp71aHEXw-NHSfeHGW-KT",
+            "id": "ga4gh:VA.96ak7XdY3DNbp71aHEXw-NHSfeHGW-KT",
+            "location": {
+                "digest": "fwfHu8VaD2-6Qvay9MJSINXPS767RYSw",
+                "end": 32316467,
+                "id": "ga4gh:SL.fwfHu8VaD2-6Qvay9MJSINXPS767RYSw",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 32316466,
+                "type": "SequenceLocation",
+            },
+            "state": {"length": 2, "repeatSubunitLength": 1, "sequence": "AA", "type": "ReferenceLengthExpression"},
+            "type": "Allele",
+        },
+    ),
+    (
+        "NM_001331029.1:c.722A>G",
+        {
+            "digest": "DPe4AO-S0Yu4wzSCmys7eGn4p4sO0zaC",
+            "id": "ga4gh:VA.DPe4AO-S0Yu4wzSCmys7eGn4p4sO0zaC",
+            "location": {
+                "digest": "7hcVmPnIspQNDfZKBzRJFc8K9GaJuAlY",
+                "end": 872,
+                "id": "ga4gh:SL.7hcVmPnIspQNDfZKBzRJFc8K9GaJuAlY",
+                "sequenceReference": {
+                    "refgetAccession": "SQ.MBIgVnoHFw34aFqNUVGM0zgjC3d-v8dK",
+                    "type": "SequenceReference",
+                },
+                "start": 871,
+                "type": "SequenceLocation",
+            },
+            "state": {"sequence": "G", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
+        },
+    ),
+    (
+        "NM_181798.1:c.1007G>T",
+        {
+            "digest": "vSL4aV7mPQKQLX7Jk-PmXN0APs0cBIr9",
+            "id": "ga4gh:VA.vSL4aV7mPQKQLX7Jk-PmXN0APs0cBIr9",
+            "location": {
+                "digest": "EtvHvoj1Lsq-RruzIzWbKOIAW-bt193w",
+                "end": 1263,
+                "id": "ga4gh:SL.EtvHvoj1Lsq-RruzIzWbKOIAW-bt193w",
+                "sequenceReference": {
+                    "refgetAccession": "SQ.KN07u-RFqd1dTyOWOG98HnOq87Nq-ZIg",
+                    "type": "SequenceReference",
+                },
+                "start": 1262,
+                "type": "SequenceLocation",
+            },
+            "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
+        },
+    ),
+    (
+        "NC_000019.10:g.289464_289465insCACA",
+        {
+            "digest": "YFUR4oR_84b-rRFf0UzOjfI4eE5FTKAP",
+            "id": "ga4gh:VA.YFUR4oR_84b-rRFf0UzOjfI4eE5FTKAP",
+            "type": "Allele",
+            "location": {
+                "digest": "L145KFLJeJ334YnOVm59pPlbdqfHhgXZ",
+                "end": 289466,
+                "id": "ga4gh:SL.L145KFLJeJ334YnOVm59pPlbdqfHhgXZ",
+                "sequenceReference": {
+                    "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+                    "type": "SequenceReference",
+                },
+                "start": 289464,
+                "type": "SequenceLocation",
+            },
+            "state": {"length": 6, "repeatSubunitLength": 2, "sequence": "CACACA", "type": "ReferenceLengthExpression"},
+        },
+    ),
+    (
+        "NC_000019.10:g.289485_289500del",
+        {
+            "digest": "Djc_SwVDFunsArqwUM00PciVaF70VTcU",
+            "id": "ga4gh:VA.Djc_SwVDFunsArqwUM00PciVaF70VTcU",
+            "type": "Allele",
+            "location": {
+                "digest": "WTE7jyihK4qvRRzEqM7u5nSD4iS2k3xp",
+                "end": 289501,
+                "id": "ga4gh:SL.WTE7jyihK4qvRRzEqM7u5nSD4iS2k3xp",
+                "sequenceReference": {
+                    "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+                    "type": "SequenceReference",
+                },
+                "start": 289480,
+                "type": "SequenceLocation",
+            },
+            "state": {"length": 5, "repeatSubunitLength": 16, "sequence": "CGAGG", "type": "ReferenceLengthExpression"},
+        },
+    ),
 )
 
 hgvs_tests_to_hgvs_map = {
     "NC_000019.10:g.289464_289465insCACA": "NC_000019.10:g.289466_289467insCACA",
-    "NC_000019.10:g.289485_289500del": "NC_000019.10:g.289486_289501del"
+    "NC_000019.10:g.289485_289500del": "NC_000019.10:g.289486_289501del",
 }
 
 
@@ -453,25 +492,29 @@ def test_hgvs(tlr, hgvsexpr, expected):
     to_hgvs = tlr.translate_to(allele, "hgvs")
     assert (hgvsexpr in to_hgvs) or (hgvs_tests_to_hgvs_map.get(hgvsexpr, hgvsexpr) in to_hgvs)
 
+
 @pytest.mark.vcr
 def test_rle_seq_limit(tlr):
     # do_normalize defaults to true
     tlr.identify = True
 
     a_dict = {
-        'digest': 'j7qUzb1uvmdxLAbtdCPiay4kIRQmyZNv',
-        'id': 'ga4gh:VA.j7qUzb1uvmdxLAbtdCPiay4kIRQmyZNv',
-        'location': {'digest': '88oOqkUgALP7fnN8P8lbvCosFhG8YpY0',
-                     'end': 32331094,
-                     'id': 'ga4gh:SL.88oOqkUgALP7fnN8P8lbvCosFhG8YpY0',
-                     'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                           'type': 'SequenceReference'},
-                     'start': 32331042,
-                     'type': 'SequenceLocation'},
-        'state': {'length': 104,
-                  'repeatSubunitLength': 52,
-                  'type': 'ReferenceLengthExpression'},
-        'type': 'Allele'}
+        "digest": "j7qUzb1uvmdxLAbtdCPiay4kIRQmyZNv",
+        "id": "ga4gh:VA.j7qUzb1uvmdxLAbtdCPiay4kIRQmyZNv",
+        "location": {
+            "digest": "88oOqkUgALP7fnN8P8lbvCosFhG8YpY0",
+            "end": 32331094,
+            "id": "ga4gh:SL.88oOqkUgALP7fnN8P8lbvCosFhG8YpY0",
+            "sequenceReference": {
+                "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                "type": "SequenceReference",
+            },
+            "start": 32331042,
+            "type": "SequenceLocation",
+        },
+        "state": {"length": 104, "repeatSubunitLength": 52, "type": "ReferenceLengthExpression"},
+        "type": "Allele",
+    }
     input_hgvs_expr = "NC_000013.11:g.32331043_32331094dup"
 
     # use default rle_seq_limit
@@ -484,12 +527,14 @@ def test_rle_seq_limit(tlr):
     # set rle_seq_limit to None
     allele_with_seq = tlr.translate_from(input_hgvs_expr, fmt="hgvs", rle_seq_limit=None)
     a_dict_with_seq = a_dict.copy()
-    a_dict_with_seq["state"][
-        "sequence"] = "TTTAGTTGAACTACAGGTTTTTTTGTTGTTGTTGTTTTGATTTTTTTTTTTTTTTAGTTGAACTACAGGTTTTTTTGTTGTTGTTGTTTTGATTTTTTTTTTTT"
+    a_dict_with_seq["state"]["sequence"] = (
+        "TTTAGTTGAACTACAGGTTTTTTTGTTGTTGTTGTTTTGATTTTTTTTTTTTTTTAGTTGAACTACAGGTTTTTTTGTTGTTGTTGTTTTGATTTTTTTTTTTT"
+    )
     assert allele_with_seq.model_dump(exclude_none=True) == a_dict_with_seq
 
     output_hgvs_expr = tlr.translate_to(allele_with_seq, "hgvs")
     assert output_hgvs_expr == [input_hgvs_expr]
+
 
 @pytest.mark.vcr
 def test_to_hgvs_iri_ref_keyerror(tlr):
@@ -500,13 +545,10 @@ def test_to_hgvs_iri_ref_keyerror(tlr):
                 "end": 1263,
                 "start": 1262,
                 "sequenceReference": "seqrefs.jsonc#/NM_181798.1",
-                "type": "SequenceLocation"
+                "type": "SequenceLocation",
             },
-            "state": {
-                "sequence": "T",
-                "type": "LiteralSequenceExpression"
-            },
-            "type": "Allele"
+            "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
+            "type": "Allele",
         }
     )
     with pytest.raises(KeyError) as e:
@@ -514,6 +556,7 @@ def test_to_hgvs_iri_ref_keyerror(tlr):
         # we have to add functionality to address the handling of iri-references in the future
         tlr.translate_to(iri_vo, "hgvs")
     assert str(e.value) == "'ga4gh:seqrefs.jsonc#/NM_181798.1'"
+
 
 # TODO: Readd these tests
 # @pytest.mark.vcr

--- a/tests/extras/test_allele_translator.py
+++ b/tests/extras/test_allele_translator.py
@@ -152,11 +152,8 @@ duplication_output_normalized = {
 
 
 def test_from_invalid(tlr):
-    try:
+    with pytest.raises(ValueError, match="Unable to parse data as beacon, gnomad, hgvs, spdi, vrs"):
         tlr.translate_from("BRAF amplication")
-        assert "Expected exception to be thrown" is None
-    except ValueError as e:
-        assert e.args[0] == "Unable to parse data as beacon, gnomad, hgvs, spdi, vrs"
 
 
 @pytest.mark.vcr
@@ -263,7 +260,7 @@ def test_to_spdi(tlr):
     spdiexpr = snv_inputs["spdi"]
     allele = tlr.translate_from(spdiexpr, "spdi")
     to_spdi = tlr.translate_to(allele, "spdi")
-    assert 1 == len(to_spdi)
+    assert len(to_spdi) == 1
     assert spdiexpr == to_spdi[0]
 
 
@@ -481,7 +478,7 @@ hgvs_tests_to_hgvs_map = {
 }
 
 
-@pytest.mark.parametrize("hgvsexpr,expected", hgvs_tests)
+@pytest.mark.parametrize(("hgvsexpr", "expected"), hgvs_tests)
 @pytest.mark.vcr
 def test_hgvs(tlr, hgvsexpr, expected):
     # do_normalize defaults to true
@@ -540,7 +537,7 @@ def test_rle_seq_limit(tlr):
 def test_to_hgvs_iri_ref_keyerror(tlr):
     # iriReference is passed
     iri_vo = models.Allele(
-        **{
+        **{  # noqa: PIE804
             "location": {
                 "end": 1263,
                 "start": 1262,

--- a/tests/extras/test_cnv_translator.py
+++ b/tests/extras/test_cnv_translator.py
@@ -101,7 +101,7 @@ from_hgvs_cx_tests = (
 )
 
 
-@pytest.mark.parametrize(("hgvsexpr" ,"copy_change", "expected"), from_hgvs_cx_tests)
+@pytest.mark.parametrize(("hgvsexpr", "copy_change", "expected"), from_hgvs_cx_tests)
 @pytest.mark.vcr
 def test_from_hgvs_cx(tlr, hgvsexpr, copy_change, expected):
     """Test that _from_hgvs works correctly for copy number change"""
@@ -155,7 +155,7 @@ from_hgvs_cn_tests = (
 )
 
 
-@pytest.mark.parametrize(("hgvsexpr", "copies" ,"expected"), from_hgvs_cn_tests)
+@pytest.mark.parametrize(("hgvsexpr", "copies", "expected"), from_hgvs_cn_tests)
 @pytest.mark.vcr
 def test_from_hgvs_cn(tlr, hgvsexpr, copies, expected):
     """Test that _from_hgvs works correctly for copy number count"""

--- a/tests/extras/test_cnv_translator.py
+++ b/tests/extras/test_cnv_translator.py
@@ -13,103 +13,151 @@ def tlr(rest_dataproxy):
     )
 
 
-
 from_hgvs_cx_tests = (
-    ("NC_000013.11:g.26440969_26443305del", models.CopyChange.EFO_0030069,
-     {'copyChange': {'primaryCode': 'EFO:0030069'},
-      'digest': 'bY_40M893gdWmNhU598V-T_dYtPJs-pp',
-      'id': 'ga4gh:CX.bY_40M893gdWmNhU598V-T_dYtPJs-pp',
-      'location': {'digest': '4akcjXlbAu4xBKnxjOL_b4DM_20HOCA3',
-                   'end': 26443305,
-                   'id': 'ga4gh:SL.4akcjXlbAu4xBKnxjOL_b4DM_20HOCA3',
-                   'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                         'type': 'SequenceReference'},
-                   'start': 26440968,
-                   'type': 'SequenceLocation'},
-      'type': 'CopyNumberChange'}),
-    ("NC_000013.11:g.32379315_32379819del", None,
-     {'copyChange': {'primaryCode': 'EFO:0030067'},
-      'digest': 'WKtHlbV6XCoKqvyeAJxdFj4ogw9ipDfQ',
-      'id': 'ga4gh:CX.WKtHlbV6XCoKqvyeAJxdFj4ogw9ipDfQ',
-      'location': {'digest': '_TUGA9kX6JKdXzUklgN2zWkOvNu5pNmV',
-                   'end': 32379819,
-                   'id': 'ga4gh:SL._TUGA9kX6JKdXzUklgN2zWkOvNu5pNmV',
-                   'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                         'type': 'SequenceReference'},
-                   'start': 32379314,
-                   'type': 'SequenceLocation'},
-      'type': 'CopyNumberChange'}
-     ),
-    ("NC_000013.11:g.32332787_32333388dup", models.CopyChange.EFO_0030071,
-     {'copyChange': {'primaryCode': 'EFO:0030071'},
-      'digest': 'EqI18-X9p8MUDr-Oz2J5GPQppEQKqWMU',
-      'id': 'ga4gh:CX.EqI18-X9p8MUDr-Oz2J5GPQppEQKqWMU',
-      'location': {'digest': 'UOA3zJOPfQxxRord_7pBkoMBpt46xcQq',
-                   'end': 32333388,
-                   'id': 'ga4gh:SL.UOA3zJOPfQxxRord_7pBkoMBpt46xcQq',
-                   'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                         'type': 'SequenceReference'},
-                   'start': 32332786,
-                   'type': 'SequenceLocation'},
-      'type': 'CopyNumberChange'}
-     ),
-    ("NC_000013.11:g.32344743_32352093dup", None,
-     {'copyChange': {'primaryCode': 'EFO:0030070'},
-      'digest': 'eZVvwCSineeWTGKG3vbJvqkSUMW2JTCH',
-      'id': 'ga4gh:CX.eZVvwCSineeWTGKG3vbJvqkSUMW2JTCH',
-      'location': {'digest': '17-a6p7m6QznwxZyVz2QdA9oPf5jTCyT',
-                   'end': 32352093,
-                   'id': 'ga4gh:SL.17-a6p7m6QznwxZyVz2QdA9oPf5jTCyT',
-                   'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                         'type': 'SequenceReference'},
-                   'start': 32344742,
-                   'type': 'SequenceLocation'},
-      'type': 'CopyNumberChange'}
-     )
+    (
+        "NC_000013.11:g.26440969_26443305del",
+        models.CopyChange.EFO_0030069,
+        {
+            "copyChange": {"primaryCode": "EFO:0030069"},
+            "digest": "bY_40M893gdWmNhU598V-T_dYtPJs-pp",
+            "id": "ga4gh:CX.bY_40M893gdWmNhU598V-T_dYtPJs-pp",
+            "location": {
+                "digest": "4akcjXlbAu4xBKnxjOL_b4DM_20HOCA3",
+                "end": 26443305,
+                "id": "ga4gh:SL.4akcjXlbAu4xBKnxjOL_b4DM_20HOCA3",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 26440968,
+                "type": "SequenceLocation",
+            },
+            "type": "CopyNumberChange",
+        },
+    ),
+    (
+        "NC_000013.11:g.32379315_32379819del",
+        None,
+        {
+            "copyChange": {"primaryCode": "EFO:0030067"},
+            "digest": "WKtHlbV6XCoKqvyeAJxdFj4ogw9ipDfQ",
+            "id": "ga4gh:CX.WKtHlbV6XCoKqvyeAJxdFj4ogw9ipDfQ",
+            "location": {
+                "digest": "_TUGA9kX6JKdXzUklgN2zWkOvNu5pNmV",
+                "end": 32379819,
+                "id": "ga4gh:SL._TUGA9kX6JKdXzUklgN2zWkOvNu5pNmV",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 32379314,
+                "type": "SequenceLocation",
+            },
+            "type": "CopyNumberChange",
+        },
+    ),
+    (
+        "NC_000013.11:g.32332787_32333388dup",
+        models.CopyChange.EFO_0030071,
+        {
+            "copyChange": {"primaryCode": "EFO:0030071"},
+            "digest": "EqI18-X9p8MUDr-Oz2J5GPQppEQKqWMU",
+            "id": "ga4gh:CX.EqI18-X9p8MUDr-Oz2J5GPQppEQKqWMU",
+            "location": {
+                "digest": "UOA3zJOPfQxxRord_7pBkoMBpt46xcQq",
+                "end": 32333388,
+                "id": "ga4gh:SL.UOA3zJOPfQxxRord_7pBkoMBpt46xcQq",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 32332786,
+                "type": "SequenceLocation",
+            },
+            "type": "CopyNumberChange",
+        },
+    ),
+    (
+        "NC_000013.11:g.32344743_32352093dup",
+        None,
+        {
+            "copyChange": {"primaryCode": "EFO:0030070"},
+            "digest": "eZVvwCSineeWTGKG3vbJvqkSUMW2JTCH",
+            "id": "ga4gh:CX.eZVvwCSineeWTGKG3vbJvqkSUMW2JTCH",
+            "location": {
+                "digest": "17-a6p7m6QznwxZyVz2QdA9oPf5jTCyT",
+                "end": 32352093,
+                "id": "ga4gh:SL.17-a6p7m6QznwxZyVz2QdA9oPf5jTCyT",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 32344742,
+                "type": "SequenceLocation",
+            },
+            "type": "CopyNumberChange",
+        },
+    ),
 )
 
 
 @pytest.mark.parametrize("hgvsexpr,copy_change,expected", from_hgvs_cx_tests)
 @pytest.mark.vcr
-def test_from_hgvs_cx(tlr, hgvsexpr ,copy_change, expected):
+def test_from_hgvs_cx(tlr, hgvsexpr, copy_change, expected):
     """test that _from_hgvs works correctly for copy number change"""
     cx = tlr._from_hgvs(hgvsexpr, copy_change=copy_change)
     assert cx.model_dump(exclude_none=True) == expected
 
 
 from_hgvs_cn_tests = (
-    ("NC_000013.11:g.26440969_26443305del", 1,
-     {'copies': 1,
-      'digest': 'QnU97C-cRW431O9qWia9UCVRBDvGDH7I',
-      'id': 'ga4gh:CN.QnU97C-cRW431O9qWia9UCVRBDvGDH7I',
-      'location': {'digest': '4akcjXlbAu4xBKnxjOL_b4DM_20HOCA3',
-                   'end': 26443305,
-                   'id': 'ga4gh:SL.4akcjXlbAu4xBKnxjOL_b4DM_20HOCA3',
-                   'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                         'type': 'SequenceReference'},
-                   'start': 26440968,
-                   'type': 'SequenceLocation'},
-      'type': 'CopyNumberCount'}
-     ),
-    ("NC_000013.11:g.32332787_32333388dup", 2,
-     {'copies': 2,
-      'digest': 'a3aEKSzI46jK7_HRSpGNDap6Z1j_7kMM',
-      'id': 'ga4gh:CN.a3aEKSzI46jK7_HRSpGNDap6Z1j_7kMM',
-      'location': {'digest': 'UOA3zJOPfQxxRord_7pBkoMBpt46xcQq',
-                   'end': 32333388,
-                   'id': 'ga4gh:SL.UOA3zJOPfQxxRord_7pBkoMBpt46xcQq',
-                   'sequenceReference': {'refgetAccession': 'SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT',
-                                         'type': 'SequenceReference'},
-                   'start': 32332786,
-                   'type': 'SequenceLocation'},
-      'type': 'CopyNumberCount'}
-     ),
+    (
+        "NC_000013.11:g.26440969_26443305del",
+        1,
+        {
+            "copies": 1,
+            "digest": "QnU97C-cRW431O9qWia9UCVRBDvGDH7I",
+            "id": "ga4gh:CN.QnU97C-cRW431O9qWia9UCVRBDvGDH7I",
+            "location": {
+                "digest": "4akcjXlbAu4xBKnxjOL_b4DM_20HOCA3",
+                "end": 26443305,
+                "id": "ga4gh:SL.4akcjXlbAu4xBKnxjOL_b4DM_20HOCA3",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 26440968,
+                "type": "SequenceLocation",
+            },
+            "type": "CopyNumberCount",
+        },
+    ),
+    (
+        "NC_000013.11:g.32332787_32333388dup",
+        2,
+        {
+            "copies": 2,
+            "digest": "a3aEKSzI46jK7_HRSpGNDap6Z1j_7kMM",
+            "id": "ga4gh:CN.a3aEKSzI46jK7_HRSpGNDap6Z1j_7kMM",
+            "location": {
+                "digest": "UOA3zJOPfQxxRord_7pBkoMBpt46xcQq",
+                "end": 32333388,
+                "id": "ga4gh:SL.UOA3zJOPfQxxRord_7pBkoMBpt46xcQq",
+                "sequenceReference": {
+                    "refgetAccession": "SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT",
+                    "type": "SequenceReference",
+                },
+                "start": 32332786,
+                "type": "SequenceLocation",
+            },
+            "type": "CopyNumberCount",
+        },
+    ),
 )
 
 
 @pytest.mark.parametrize("hgvsexpr,copies,expected", from_hgvs_cn_tests)
 @pytest.mark.vcr
-def test_from_hgvs_cn(tlr, hgvsexpr ,copies, expected):
+def test_from_hgvs_cn(tlr, hgvsexpr, copies, expected):
     """test that _from_hgvs works correctly for copy number count"""
     cn = tlr._from_hgvs(hgvsexpr, copies=copies)
     assert cn.model_dump(exclude_none=True) == expected

--- a/tests/extras/test_cnv_translator.py
+++ b/tests/extras/test_cnv_translator.py
@@ -101,10 +101,10 @@ from_hgvs_cx_tests = (
 )
 
 
-@pytest.mark.parametrize("hgvsexpr,copy_change,expected", from_hgvs_cx_tests)
+@pytest.mark.parametrize(("hgvsexpr" ,"copy_change", "expected"), from_hgvs_cx_tests)
 @pytest.mark.vcr
 def test_from_hgvs_cx(tlr, hgvsexpr, copy_change, expected):
-    """test that _from_hgvs works correctly for copy number change"""
+    """Test that _from_hgvs works correctly for copy number change"""
     cx = tlr._from_hgvs(hgvsexpr, copy_change=copy_change)
     assert cx.model_dump(exclude_none=True) == expected
 
@@ -155,9 +155,9 @@ from_hgvs_cn_tests = (
 )
 
 
-@pytest.mark.parametrize("hgvsexpr,copies,expected", from_hgvs_cn_tests)
+@pytest.mark.parametrize(("hgvsexpr", "copies" ,"expected"), from_hgvs_cn_tests)
 @pytest.mark.vcr
 def test_from_hgvs_cn(tlr, hgvsexpr, copies, expected):
-    """test that _from_hgvs works correctly for copy number count"""
+    """Test that _from_hgvs works correctly for copy number count"""
     cn = tlr._from_hgvs(hgvsexpr, copies=copies)
     assert cn.model_dump(exclude_none=True) == expected

--- a/tests/extras/test_dataproxy.py
+++ b/tests/extras/test_dataproxy.py
@@ -16,5 +16,7 @@ def test_data_proxies(dp, request):
     seq = dataproxy.get_sequence("ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_")
     assert seq.startswith("CCTCGCCTCCGTTACAACGGCCTACGGTGCTGGAGGATCCTTCTGCGCAC")
 
-    seq = dataproxy.get_sequence("ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_", start=0, end=50)
+    seq = dataproxy.get_sequence(
+        "ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_", start=0, end=50
+    )
     assert seq == "CCTCGCCTCCGTTACAACGGCCTACGGTGCTGGAGGATCCTTCTGCGCAC"

--- a/tests/extras/test_dataproxy.py
+++ b/tests/extras/test_dataproxy.py
@@ -1,16 +1,16 @@
 import pytest
 
 
-@pytest.mark.parametrize("dp", ("rest_dataproxy", "dataproxy"))
+@pytest.mark.parametrize("dp", ["rest_dataproxy", "dataproxy"])
 @pytest.mark.vcr
 def test_data_proxies(dp, request):
     dataproxy = request.getfixturevalue(dp)
     r = dataproxy.get_metadata("NM_000551.3")
-    assert 4560 == r["length"]
+    assert r["length"] == 4560
     assert "ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_" in r["aliases"]
 
     r = dataproxy.get_metadata("NC_000013.11")
-    assert 114364328 == r["length"]
+    assert r["length"] == 114364328
     assert "ga4gh:SQ._0wi-qoDrvram155UmcSC-zA5ZK4fpLT" in r["aliases"]
 
     seq = dataproxy.get_sequence("ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_")

--- a/tests/extras/test_dataproxy.py
+++ b/tests/extras/test_dataproxy.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.parametrize("dp", ("rest_dataproxy","dataproxy"))
+@pytest.mark.parametrize("dp", ("rest_dataproxy", "dataproxy"))
 @pytest.mark.vcr
 def test_data_proxies(dp, request):
     dataproxy = request.getfixturevalue(dp)

--- a/tests/extras/test_object_store.py
+++ b/tests/extras/test_object_store.py
@@ -12,10 +12,7 @@ def test_simple(tmp_path):
     db_path = str(tmp_path) + "/test_simple.sqlite3"
     object_store = Sqlite3MutableMapping(db_path)
 
-    kvp = {
-        chr(ord("A") + i): i
-        for i in range(10)
-    }
+    kvp = {chr(ord("A") + i): i for i in range(10)}
 
     assert len(object_store) == 0
     for k, v in kvp.items():
@@ -40,20 +37,7 @@ def test_simple(tmp_path):
 def test_complex(tmp_path):
     db_path = str(tmp_path) + "/test_complex.sqlite3"
 
-    kvp = {
-        "A": "A-value",
-        "B": {
-            "B-1": "B-1-value",
-            "B-2": {
-                "B-2-1": [
-                    "B-2-1-1",
-                    "B-2-1-2",
-                    "B-2-1-3"
-                ],
-                "B-3": 12345
-            }
-        }
-    }
+    kvp = {"A": "A-value", "B": {"B-1": "B-1-value", "B-2": {"B-2-1": ["B-2-1-1", "B-2-1-2", "B-2-1-3"], "B-3": 12345}}}
 
     object_store = Sqlite3MutableMapping(db_path)
     assert len(object_store) == 0
@@ -122,6 +106,7 @@ def test_classes(tmp_path):
 #     object_store = Sqlite3MutableMapping(db_path)
 #     for i in range(value_count):
 #         assert object_store[f"key{i}"] == f"value{i}"
+
 
 def test_commit(tmp_path):
     db_path = str(tmp_path) + "/test_commit.sqlite3"

--- a/tests/extras/test_object_store.py
+++ b/tests/extras/test_object_store.py
@@ -32,7 +32,13 @@ def test_simple(tmp_path):
 def test_complex(tmp_path):
     db_path = str(tmp_path) + "/test_complex.sqlite3"
 
-    kvp = {"A": "A-value", "B": {"B-1": "B-1-value", "B-2": {"B-2-1": ["B-2-1-1", "B-2-1-2", "B-2-1-3"], "B-3": 12345}}}
+    kvp = {
+        "A": "A-value",
+        "B": {
+            "B-1": "B-1-value",
+            "B-2": {"B-2-1": ["B-2-1-1", "B-2-1-2", "B-2-1-3"], "B-3": 12345},
+        },
+    }
 
     object_store = Sqlite3MutableMapping(db_path)
     assert len(object_store) == 0

--- a/tests/extras/test_object_store.py
+++ b/tests/extras/test_object_store.py
@@ -1,9 +1,4 @@
-import tempfile
-import ast
-import os
 import pytest
-import shutil
-import sys
 
 from ga4gh.vrs.extras.object_store import Sqlite3MutableMapping
 
@@ -19,7 +14,7 @@ def test_simple(tmp_path):
         object_store[k] = v
 
     assert len(kvp) == len(object_store)
-    assert set([k for k, v in kvp.items()]) == set(object_store.keys())
+    assert set(kvp.keys()) == set(object_store.keys())
 
     for k_act, v_act in object_store.items():
         assert kvp[k_act] == v_act
@@ -30,7 +25,7 @@ def test_simple(tmp_path):
     with pytest.raises(KeyError):
         del object_store["A"]
     while len(object_store) > 0:
-        del object_store[list(object_store.keys())[0]]
+        del object_store[next(iter(object_store.keys()))[0]]
     assert len(object_store) == 0
 
 
@@ -46,7 +41,7 @@ def test_complex(tmp_path):
         object_store[k] = v
 
     assert len(kvp) == len(object_store)
-    assert set([k for k, v in kvp.items()]) == set(object_store.keys())
+    assert set(kvp.keys()) == set(object_store.keys())
 
     for k_act, v_act in object_store.items():
         assert kvp[k_act] == v_act
@@ -57,9 +52,9 @@ def test_complex(tmp_path):
 def test_classes(tmp_path):
     db_path = str(tmp_path) + "/test_complex.sqlite3"
 
-    class TestClass(object):
-        def __init__(self, id):
-            self.id = id
+    class TestClass:
+        def __init__(self, id_value):
+            self.id = id_value
             self.A = "A"
             self.B = ["B1", "B2", 3]
             self.C = {"C1": "C1-value"}

--- a/tests/extras/test_vcf_annotation.py
+++ b/tests/extras/test_vcf_annotation.py
@@ -23,7 +23,9 @@ def test_annotate_vcf_grch38_noattrs(vcf_annotator, vcr_cassette):
     input_vcf = f"{TEST_DATA_DIR}/test_vcf_input.vcf"
     output_vcf = f"{TEST_DATA_DIR}/test_vcf_output_grch38_noattrs.vcf.gz"
     output_vrs_pkl = f"{TEST_DATA_DIR}/test_vcf_pkl_grch38_noattrs.pkl"
-    expected_vcf_no_vrs_attrs = f"{TEST_DATA_DIR}/test_vcf_expected_output_no_vrs_attrs.vcf.gz"
+    expected_vcf_no_vrs_attrs = (
+        f"{TEST_DATA_DIR}/test_vcf_expected_output_no_vrs_attrs.vcf.gz"
+    )
 
     # Test GRCh38 assembly, which was used for input_vcf and no vrs attributes
     vcf_annotator.annotate(input_vcf, output_vcf, output_vrs_pkl)
@@ -31,7 +33,9 @@ def test_annotate_vcf_grch38_noattrs(vcf_annotator, vcr_cassette):
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_vcf_no_vrs_attrs, "rt") as expected_output:
         expected_output_lines = expected_output.readlines()
-    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines, strict=False):
+    for actual_line, expected_line in zip(
+        out_vcf_lines, expected_output_lines, strict=False
+    ):
         assert actual_line == expected_line
     assert Path(output_vrs_pkl).exists()
     assert vcr_cassette.all_played
@@ -53,7 +57,9 @@ def test_annotate_vcf_grch38_attrs(vcf_annotator, vcr_cassette):
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_vcf, "rt") as expected_output:
         expected_output_lines = expected_output.readlines()
-    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines, strict=False):
+    for actual_line, expected_line in zip(
+        out_vcf_lines, expected_output_lines, strict=False
+    ):
         assert actual_line == expected_line
     assert Path(output_vrs_pkl).exists()
     assert vcr_cassette.all_played
@@ -70,12 +76,20 @@ def test_annotate_vcf_grch38_attrs_altsonly(vcf_annotator, vcr_cassette):
     expected_altsonly_vcf = f"{TEST_DATA_DIR}/test_vcf_expected_altsonly_output.vcf.gz"
 
     # Test GRCh38 assembly with VRS computed for ALTs only, which was used for input_vcf and vrs attributes
-    vcf_annotator.annotate(input_vcf, output_vcf, output_vrs_pkl, vrs_attributes=True, compute_for_ref=False)
+    vcf_annotator.annotate(
+        input_vcf,
+        output_vcf,
+        output_vrs_pkl,
+        vrs_attributes=True,
+        compute_for_ref=False,
+    )
     with gzip.open(output_vcf, "rt") as out_vcf:
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_altsonly_vcf, "rt") as expected_output:
         expected_output_lines = expected_output.readlines()
-    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines, strict=False):
+    for actual_line, expected_line in zip(
+        out_vcf_lines, expected_output_lines, strict=False
+    ):
         assert actual_line == expected_line
     assert Path(output_vrs_pkl).exists()
     assert vcr_cassette.all_played
@@ -92,7 +106,9 @@ def test_annotate_vcf_grch37_attrs(vcf_annotator, vcr_cassette):
     expected_vcf = f"{TEST_DATA_DIR}/test_vcf_expected_output.vcf.gz"
 
     # Test GRCh37 assembly, which was not used for input_vcf
-    vcf_annotator.annotate(input_vcf, output_vcf, output_vrs_pkl, vrs_attributes=True, assembly="GRCh37")
+    vcf_annotator.annotate(
+        input_vcf, output_vcf, output_vrs_pkl, vrs_attributes=True, assembly="GRCh37"
+    )
     with gzip.open(output_vcf, "rt") as out_vcf:
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_vcf, "rt") as expected_output:
@@ -112,7 +128,9 @@ def test_annotate_vcf_pickle_only(vcf_annotator, vcr_cassette):
     output_vrs_pkl = f"{TEST_DATA_DIR}/test_vcf_pkl_pickle_only.pkl"
 
     # Test only pickle output
-    vcf_annotator.annotate(input_vcf, vrs_pickle_out=output_vrs_pkl, vrs_attributes=True)
+    vcf_annotator.annotate(
+        input_vcf, vrs_pickle_out=output_vrs_pkl, vrs_attributes=True
+    )
     assert Path(output_vrs_pkl).exists()
     assert not Path(output_vcf).exists()
     assert vcr_cassette.all_played
@@ -160,18 +178,26 @@ def test_get_vrs_object_invalid_input(vcf_annotator, caplog):
 
     # No REF
     vcf_annotator._get_vrs_object("7-140753336-.-T", {}, [], "GRCh38")
-    assert "None was returned when translating 7-140753336-.-T from gnomad" in caplog.text
+    assert (
+        "None was returned when translating 7-140753336-.-T from gnomad" in caplog.text
+    )
 
     # No ALT
     vcf_annotator._get_vrs_object("7-140753336-A-.", {}, [], "GRCh38")
-    assert "None was returned when translating 7-140753336-A-. from gnomad" in caplog.text
+    assert (
+        "None was returned when translating 7-140753336-A-. from gnomad" in caplog.text
+    )
 
     # Invalid ref, but not requiring validation checks so no error is raised
-    vcf_annotator._get_vrs_object("7-140753336-G-T", {}, [], "GRCh38", require_validation=False)
+    vcf_annotator._get_vrs_object(
+        "7-140753336-G-T", {}, [], "GRCh38", require_validation=False
+    )
     assert "" in caplog.text
 
     # Invalid ref, but requiring validation checks so an error is raised
     invalid_ref_seq_msg = "Expected reference sequence C on GRCh38:7 at positions (140753335, 140753336) but found A"
     with pytest.raises(DataProxyValidationError, match=re.escape(invalid_ref_seq_msg)):
-        vcf_annotator._get_vrs_object("7-140753336-C-T", {}, [], "GRCh38", require_validation=True)
+        vcf_annotator._get_vrs_object(
+            "7-140753336-C-T", {}, [], "GRCh38", require_validation=True
+        )
     assert invalid_ref_seq_msg in caplog.text

--- a/tests/extras/test_vcf_annotation.py
+++ b/tests/extras/test_vcf_annotation.py
@@ -1,8 +1,8 @@
 """Ensure proper functionality of VCFAnnotator"""
 
 import gzip
-import os
 import re
+from pathlib import Path
 
 import pytest
 
@@ -31,12 +31,12 @@ def test_annotate_vcf_grch38_noattrs(vcf_annotator, vcr_cassette):
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_vcf_no_vrs_attrs, "rt") as expected_output:
         expected_output_lines = expected_output.readlines()
-    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines):
+    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines, strict=False):
         assert actual_line == expected_line
-    assert os.path.exists(output_vrs_pkl)
+    assert Path(output_vrs_pkl).exists()
     assert vcr_cassette.all_played
-    os.remove(output_vcf)
-    os.remove(output_vrs_pkl)
+    Path(output_vcf).unlink()
+    Path(output_vrs_pkl).unlink()
 
 
 @pytest.mark.vcr
@@ -53,12 +53,12 @@ def test_annotate_vcf_grch38_attrs(vcf_annotator, vcr_cassette):
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_vcf, "rt") as expected_output:
         expected_output_lines = expected_output.readlines()
-    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines):
+    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines, strict=False):
         assert actual_line == expected_line
-    assert os.path.exists(output_vrs_pkl)
+    assert Path(output_vrs_pkl).exists()
     assert vcr_cassette.all_played
-    os.remove(output_vcf)
-    os.remove(output_vrs_pkl)
+    Path(output_vcf).unlink()
+    Path(output_vrs_pkl).unlink()
 
 
 @pytest.mark.vcr
@@ -75,12 +75,12 @@ def test_annotate_vcf_grch38_attrs_altsonly(vcf_annotator, vcr_cassette):
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_altsonly_vcf, "rt") as expected_output:
         expected_output_lines = expected_output.readlines()
-    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines):
+    for actual_line, expected_line in zip(out_vcf_lines, expected_output_lines, strict=False):
         assert actual_line == expected_line
-    assert os.path.exists(output_vrs_pkl)
+    assert Path(output_vrs_pkl).exists()
     assert vcr_cassette.all_played
-    os.remove(output_vcf)
-    os.remove(output_vrs_pkl)
+    Path(output_vcf).unlink()
+    Path(output_vrs_pkl).unlink()
 
 
 @pytest.mark.vcr
@@ -98,10 +98,10 @@ def test_annotate_vcf_grch37_attrs(vcf_annotator, vcr_cassette):
     with gzip.open(expected_vcf, "rt") as expected_output:
         expected_output_lines = expected_output.readlines()
     assert out_vcf_lines != expected_output_lines
-    assert os.path.exists(output_vrs_pkl)
+    assert Path(output_vrs_pkl).exists()
     assert vcr_cassette.all_played
-    os.remove(output_vcf)
-    os.remove(output_vrs_pkl)
+    Path(output_vcf).unlink()
+    Path(output_vrs_pkl).unlink()
 
 
 @pytest.mark.vcr
@@ -113,10 +113,10 @@ def test_annotate_vcf_pickle_only(vcf_annotator, vcr_cassette):
 
     # Test only pickle output
     vcf_annotator.annotate(input_vcf, vrs_pickle_out=output_vrs_pkl, vrs_attributes=True)
-    assert os.path.exists(output_vrs_pkl)
-    assert not os.path.exists(output_vcf)
+    assert Path(output_vrs_pkl).exists()
+    assert not Path(output_vcf).exists()
     assert vcr_cassette.all_played
-    os.remove(output_vrs_pkl)
+    Path(output_vrs_pkl).unlink()
 
 
 @pytest.mark.vcr
@@ -135,8 +135,8 @@ def test_annotate_vcf_vcf_only(vcf_annotator, vcr_cassette):
         expected_output_lines = expected_output.readlines()
     assert out_vcf_lines == expected_output_lines
     assert vcr_cassette.all_played
-    assert not os.path.exists(output_vrs_pkl)
-    os.remove(output_vcf)
+    assert not Path(output_vrs_pkl).exists()
+    Path(output_vcf).unlink()
 
 
 def test_annotate_vcf_input_validation(vcf_annotator):

--- a/tests/extras/test_vcf_annotation.py
+++ b/tests/extras/test_vcf_annotation.py
@@ -1,4 +1,5 @@
 """Ensure proper functionality of VCFAnnotator"""
+
 import gzip
 import os
 import re
@@ -113,7 +114,7 @@ def test_annotate_vcf_pickle_only(vcf_annotator, vcr_cassette):
     # Test only pickle output
     vcf_annotator.annotate(input_vcf, vrs_pickle_out=output_vrs_pkl, vrs_attributes=True)
     assert os.path.exists(output_vrs_pkl)
-    assert (not os.path.exists(output_vcf))
+    assert not os.path.exists(output_vcf)
     assert vcr_cassette.all_played
     os.remove(output_vrs_pkl)
 
@@ -166,15 +167,11 @@ def test_get_vrs_object_invalid_input(vcf_annotator, caplog):
     assert "None was returned when translating 7-140753336-A-. from gnomad" in caplog.text
 
     # Invalid ref, but not requiring validation checks so no error is raised
-    vcf_annotator._get_vrs_object(
-        "7-140753336-G-T", {}, [], "GRCh38", require_validation=False
-    )
+    vcf_annotator._get_vrs_object("7-140753336-G-T", {}, [], "GRCh38", require_validation=False)
     assert "" in caplog.text
 
     # Invalid ref, but requiring validation checks so an error is raised
     invalid_ref_seq_msg = "Expected reference sequence C on GRCh38:7 at positions (140753335, 140753336) but found A"
     with pytest.raises(DataProxyValidationError, match=re.escape(invalid_ref_seq_msg)):
-        vcf_annotator._get_vrs_object(
-            "7-140753336-C-T", {}, [], "GRCh38", require_validation=True
-        )
+        vcf_annotator._get_vrs_object("7-140753336-C-T", {}, [], "GRCh38", require_validation=True)
     assert invalid_ref_seq_msg in caplog.text

--- a/tests/test_vrs.py
+++ b/tests/test_vrs.py
@@ -10,25 +10,19 @@ from ga4gh.core import (
     is_curie_type,
     pydantic_copy,
     use_ga4gh_compute_identifier_when,
-    VrsObjectIdentifierIs
+    VrsObjectIdentifierIs,
 )
 from ga4gh.vrs import models, vrs_enref, vrs_deref
 
 allele_dict = {
-    'location': {
-        'end': 55181320,
-        'start': 55181319,
-        'sequenceReference': {
-            'type': 'SequenceReference',
-            'refgetAccession': 'SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul'
-        },
-        'type': 'SequenceLocation'
+    "location": {
+        "end": 55181320,
+        "start": 55181319,
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"},
+        "type": "SequenceLocation",
     },
-    'state': {
-        'sequence': 'T',
-        'type': 'LiteralSequenceExpression'
-    },
-    'type': 'Allele'
+    "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 a = models.Allele(**allele_dict)
@@ -41,58 +35,37 @@ allele_383650_dict = {
         "id": "ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
         "digest": "TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
         "type": "SequenceLocation",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
-        },
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"},
         "start": 128325834,
-        "end": 128325835
+        "end": 128325835,
     },
-    "state": {
-        "type": "LiteralSequenceExpression",
-        "sequence": "T"
-    }
+    "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
 }
 allele_417816_dict = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
-        },
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"},
         "start": 128325809,
-        "end": 128325810
+        "end": 128325810,
     },
-    "state": {
-        "type": "LiteralSequenceExpression",
-        "sequence": "T"
-    }
+    "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
 }
 allele_280320_dict = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
-        },
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"},
         "start": 128322879,
-        "end": 128322891
+        "end": 128322891,
     },
-    "state": {
-        "type": "LiteralSequenceExpression",
-        "sequence": "G"
-    }
+    "state": {"type": "LiteralSequenceExpression", "sequence": "G"},
 }
 allele_383650 = models.Allele(**allele_383650_dict)
 allele_417816 = models.Allele(**allele_417816_dict)
 allele_280320 = models.Allele(**allele_280320_dict)
 
-cpb_431012_dict = {
-    "type": "CisPhasedBlock",
-    "members": [allele_383650_dict, allele_417816_dict]
-}
+cpb_431012_dict = {"type": "CisPhasedBlock", "members": [allele_383650_dict, allele_417816_dict]}
 cpb_431012 = models.CisPhasedBlock(**cpb_431012_dict)
 
 
@@ -101,9 +74,15 @@ cpb_431012 = models.CisPhasedBlock(**cpb_431012_dict)
     [
         (lambda: models.Range(root=[None, None]), "Must provide at least one integer."),
         (lambda: models.Range(root=[2, 1]), "The first integer must be less than or equal to the second integer."),
-        (lambda: models.SequenceLocation(sequenceReference=allele_280320.location.sequenceReference, start=-1), "The minimum value of `start` is 0."),
-        (lambda: models.SequenceLocation(sequenceReference=allele_280320.location.sequenceReference, end=[-1, 0]), "The minimum value of `end` is 0."),
-    ]
+        (
+            lambda: models.SequenceLocation(sequenceReference=allele_280320.location.sequenceReference, start=-1),
+            "The minimum value of `start` is 0.",
+        ),
+        (
+            lambda: models.SequenceLocation(sequenceReference=allele_280320.location.sequenceReference, end=[-1, 0]),
+            "The minimum value of `end` is 0.",
+        ),
+    ],
 )
 def test_model_validation_errors(vrs_model, expected_err_msg):
     """Test that invalid VRS models raise errors"""
@@ -128,65 +107,72 @@ def test_vr():
     # Location
     loc = a.location
     loc_serialized = ga4gh_serialize(loc)
-    assert loc_serialized == b'{"end":55181320,"sequenceReference":{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul","type":"SequenceReference"},"start":55181319,"type":"SequenceLocation"}'
-    assert sha512t24u(loc_serialized) == '_G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd'
-    assert ga4gh_digest(loc) == '_G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd'
-    assert ga4gh_identify(loc) == 'ga4gh:SL._G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd'
+    assert (
+        loc_serialized
+        == b'{"end":55181320,"sequenceReference":{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul","type":"SequenceReference"},"start":55181319,"type":"SequenceLocation"}'
+    )
+    assert sha512t24u(loc_serialized) == "_G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd"
+    assert ga4gh_digest(loc) == "_G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd"
+    assert ga4gh_identify(loc) == "ga4gh:SL._G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd"
 
     # Allele
     allele_serialized = ga4gh_serialize(a)
-    assert allele_serialized == b'{"location":"_G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd","state":{"sequence":"T","type":"LiteralSequenceExpression"},"type":"Allele"}'
-    assert sha512t24u(allele_serialized) == 'Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE'
-    assert ga4gh_digest(a) == 'Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE'
-    assert ga4gh_identify(a) == 'ga4gh:VA.Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE'
+    assert (
+        allele_serialized
+        == b'{"location":"_G2K0qSioM74l_u3OaKR0mgLYdeTL7Xd","state":{"sequence":"T","type":"LiteralSequenceExpression"},"type":"Allele"}'
+    )
+    assert sha512t24u(allele_serialized) == "Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE"
+    assert ga4gh_digest(a) == "Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE"
+    assert ga4gh_identify(a) == "ga4gh:VA.Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE"
 
     with pytest.raises(ValidationError):
-        models.Allele(**{
-            "type": "Allele",
-            "location": {
-                "type": "SequenceLocation",
-                "sequenceReference": {
-                    "type": "SequenceReference",
-                    # refgetAccession can't include a namespace prefix
-                    "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
+        models.Allele(
+            **{
+                "type": "Allele",
+                "location": {
+                    "type": "SequenceLocation",
+                    "sequenceReference": {
+                        "type": "SequenceReference",
+                        # refgetAccession can't include a namespace prefix
+                        "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+                    },
+                    "start": 128325834,
+                    "end": 128325835,
                 },
-                "start": 128325834,
-                "end": 128325835
-            },
-            "state": {
-                "type": "LiteralSequenceExpression",
-                "sequence": "T"
+                "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
             }
-        })
+        )
     with pytest.raises(ValidationError):
-        models.Allele(**{
-            "type": "Allele",
-            "location": {
-                "type": "SequenceLocation",
-                "sequenceReference": {
-                    "type": "SequenceReference",
-                    "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"
+        models.Allele(
+            **{
+                "type": "Allele",
+                "location": {
+                    "type": "SequenceLocation",
+                    "sequenceReference": {
+                        "type": "SequenceReference",
+                        "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+                    },
+                    "start": 128325834,
+                    "end": 128325835,
                 },
-                "start": 128325834,
-                "end": 128325835
-            },
-            "state": {
-                "type": "LiteralSequenceExpression",
-                "sequence": "T"
-            },
-            # digest can't include a namespace prefix
-            "digest": "ga4gh:734G5mtNwe40do8F6GKuqQP4QxyjBqVp"
-        })
+                "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
+                # digest can't include a namespace prefix
+                "digest": "ga4gh:734G5mtNwe40do8F6GKuqQP4QxyjBqVp",
+            }
+        )
 
 
 def test_cpb():
     assert cpb_431012.model_dump(exclude_none=True) == cpb_431012_dict
     assert is_pydantic_instance(cpb_431012)
     cpb_serialized = ga4gh_serialize(cpb_431012)
-    assert cpb_serialized == b'{"members":["SZIS2ua7AL-0YgUTAqyBsFPYK3vE8h_d","TKhpDsfclpSXpn6BjTLViB_ceqRerOd2"],"type":"CisPhasedBlock"}'
-    assert sha512t24u(cpb_serialized) == 'x8GH5G73cPMs37jy1-9mJjWynu324rxI'
-    assert ga4gh_digest(cpb_431012) == 'x8GH5G73cPMs37jy1-9mJjWynu324rxI'
-    assert ga4gh_identify(cpb_431012) == 'ga4gh:CPB.x8GH5G73cPMs37jy1-9mJjWynu324rxI'
+    assert (
+        cpb_serialized
+        == b'{"members":["SZIS2ua7AL-0YgUTAqyBsFPYK3vE8h_d","TKhpDsfclpSXpn6BjTLViB_ceqRerOd2"],"type":"CisPhasedBlock"}'
+    )
+    assert sha512t24u(cpb_serialized) == "x8GH5G73cPMs37jy1-9mJjWynu324rxI"
+    assert ga4gh_digest(cpb_431012) == "x8GH5G73cPMs37jy1-9mJjWynu324rxI"
+    assert ga4gh_identify(cpb_431012) == "ga4gh:CPB.x8GH5G73cPMs37jy1-9mJjWynu324rxI"
 
 
 def test_ga4gh_iri():
@@ -205,28 +191,24 @@ def test_enref():
     actual_no_loc = allele_383650_enreffed.model_dump().copy()
     actual_no_loc.pop("location")
     assert actual_no_loc == orig_no_loc, "Original and enreffed match except for enreffed field"
-    assert allele_383650_enreffed.location == 'ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe'
-    assert (allele_383650_enreffed.model_dump(exclude_none=True) == {
-        'digest': 'SZIS2ua7AL-0YgUTAqyBsFPYK3vE8h_d',
-        'id': 'ga4gh:VA.SZIS2ua7AL-0YgUTAqyBsFPYK3vE8h_d',
-        'type': 'Allele',
-        'location': 'ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe',
-        'state': {
-            'type': 'LiteralSequenceExpression',
-            'sequence': 'T'}})
-
+    assert allele_383650_enreffed.location == "ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe"
+    assert allele_383650_enreffed.model_dump(exclude_none=True) == {
+        "digest": "SZIS2ua7AL-0YgUTAqyBsFPYK3vE8h_d",
+        "id": "ga4gh:VA.SZIS2ua7AL-0YgUTAqyBsFPYK3vE8h_d",
+        "type": "Allele",
+        "location": "ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
+        "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
+    }
 
     dereffed = vrs_deref(allele_383650_enreffed, object_store=object_store)
-    assert (dereffed.location.model_dump(exclude_none=True) == {
-        'digest': 'TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe',
-        'id': 'ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe',
-        'type': 'SequenceLocation',
-        'sequenceReference': {
-            'type': 'SequenceReference',
-            'refgetAccession': 'SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI'
-        },
-        'start': 128325834,
-        'end': 128325835})
+    assert dereffed.location.model_dump(exclude_none=True) == {
+        "digest": "TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
+        "id": "ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
+        "type": "SequenceLocation",
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"},
+        "start": 128325834,
+        "end": 128325835,
+    }
     assert dereffed.location.model_dump(exclude_none=True) == allele_383650.location.model_dump(exclude_none=True)
     assert dereffed.model_dump() == allele_383650.model_dump()
 
@@ -243,15 +225,12 @@ def test_enref2():
             "type": "SequenceLocation",
             "sequenceReference": {
                 "type": "SequenceReference",
-                "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"
+                "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
             },
             "start": 44908821,
-            "end": 44908822
+            "end": 44908822,
         },
-        "state": {
-            "type": "LiteralSequenceExpression",
-            "sequence": "T"
-        }
+        "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
     }
     vo_a = models.Allele(**a)
     a_enreffed = vrs_enref(vo_a, object_store=object_store)
@@ -260,29 +239,26 @@ def test_enref2():
     actual_no_loc = a_enreffed.model_dump().copy()
     actual_no_loc.pop("location")
     assert orig_no_loc == actual_no_loc, "Original and enreffed match except for enreffed field"
-    assert a_enreffed.location == 'ga4gh:SL.wIlaGykfwHIpPY2Fcxtbx4TINbbODFVz'
+    assert a_enreffed.location == "ga4gh:SL.wIlaGykfwHIpPY2Fcxtbx4TINbbODFVz"
     assert a_enreffed.model_dump(exclude_none=True) == {
-        'id': 'ga4gh:VA.LDzK5JahEZG2Ua_5itDtVV8v3O1ptTgI',
-        'digest': 'LDzK5JahEZG2Ua_5itDtVV8v3O1ptTgI',
-        'type': 'Allele',
-        'location': 'ga4gh:SL.wIlaGykfwHIpPY2Fcxtbx4TINbbODFVz',
-        'state': {
-            'type': 'LiteralSequenceExpression',
-            'sequence': 'T'
-        }
+        "id": "ga4gh:VA.LDzK5JahEZG2Ua_5itDtVV8v3O1ptTgI",
+        "digest": "LDzK5JahEZG2Ua_5itDtVV8v3O1ptTgI",
+        "type": "Allele",
+        "location": "ga4gh:SL.wIlaGykfwHIpPY2Fcxtbx4TINbbODFVz",
+        "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
     }
 
 
 def test_class_refatt_map():
     class_refatt_map_expected = {
-        'Allele': ['location'],
-        'CisPhasedBlock': ['members'],
-        'CopyNumberCount': ['location'],
-        'CopyNumberChange': ['location'],
-        'DerivativeMolecule': ['components'],
-        'Adjacency': ['adjoinedSequences'],
-        'TraversalBlock': ['component'],
-        'Terminus': ['location']
+        "Allele": ["location"],
+        "CisPhasedBlock": ["members"],
+        "CopyNumberCount": ["location"],
+        "CopyNumberChange": ["location"],
+        "DerivativeMolecule": ["components"],
+        "Adjacency": ["adjoinedSequences"],
+        "TraversalBlock": ["component"],
+        "Terminus": ["location"],
     }
     assert class_refatt_map_expected == models.class_refatt_map
 
@@ -307,69 +283,69 @@ def test_compute_identifiers_when():
 
     # when id property is missing
     vo_a = models.Allele(**a)
-    assert ga4gh_identify(vo_a, in_place='never') == correct_id
+    assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.ANY):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.GA4GH_INVALID):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.MISSING):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
 
     # when id property is none
     a["id"] = None
     vo_a = models.Allele(**a)
-    assert ga4gh_identify(vo_a, in_place='never') == correct_id
+    assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.ANY):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.GA4GH_INVALID):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.MISSING):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
 
     # when id property is blank
     a["id"] = ""
     vo_a = models.Allele(**a)
-    assert ga4gh_identify(vo_a, in_place='never') == correct_id
+    assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.ANY):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.GA4GH_INVALID):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.MISSING):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
 
     # when id property is syntactically invalid
     a["id"] = syntax_invalid_id
     vo_a = models.Allele(**a)
-    assert ga4gh_identify(vo_a, in_place='never') == correct_id
+    assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.ANY):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.GA4GH_INVALID):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.MISSING):
-        assert ga4gh_identify(vo_a, in_place='never') == syntax_invalid_id
+        assert ga4gh_identify(vo_a, in_place="never") == syntax_invalid_id
 
     # when id property is syntactically valid
     a["id"] = syntax_valid_id
     vo_a = models.Allele(**a)
-    assert ga4gh_identify(vo_a, in_place='never') == correct_id
+    assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.ANY):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.GA4GH_INVALID):
-        assert ga4gh_identify(vo_a, in_place='never') == syntax_valid_id
+        assert ga4gh_identify(vo_a, in_place="never") == syntax_valid_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.MISSING):
-        assert ga4gh_identify(vo_a, in_place='never') == syntax_valid_id
+        assert ga4gh_identify(vo_a, in_place="never") == syntax_valid_id
 
     # when id property is correct
     a["id"] = correct_id
     vo_a = models.Allele(**a)
-    assert ga4gh_identify(vo_a, in_place='never') == correct_id
-    assert ga4gh_identify(vo_a, in_place='never') is not correct_id
+    assert ga4gh_identify(vo_a, in_place="never") == correct_id
+    assert ga4gh_identify(vo_a, in_place="never") is not correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.ANY):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
-        assert ga4gh_identify(vo_a, in_place='never') is not correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") is not correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.GA4GH_INVALID):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
-        assert ga4gh_identify(vo_a, in_place='never') is correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") is correct_id
     with use_ga4gh_compute_identifier_when(VrsObjectIdentifierIs.MISSING):
-        assert ga4gh_identify(vo_a, in_place='never') == correct_id
-        assert ga4gh_identify(vo_a, in_place='never') is correct_id
+        assert ga4gh_identify(vo_a, in_place="never") == correct_id
+        assert ga4gh_identify(vo_a, in_place="never") is correct_id

--- a/tests/test_vrs.py
+++ b/tests/test_vrs.py
@@ -18,7 +18,10 @@ allele_dict = {
     "location": {
         "end": 55181320,
         "start": 55181319,
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "T", "type": "LiteralSequenceExpression"},
@@ -35,7 +38,10 @@ allele_383650_dict = {
         "id": "ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
         "digest": "TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+        },
         "start": 128325834,
         "end": 128325835,
     },
@@ -45,7 +51,10 @@ allele_417816_dict = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+        },
         "start": 128325809,
         "end": 128325810,
     },
@@ -55,7 +64,10 @@ allele_280320_dict = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+        },
         "start": 128322879,
         "end": 128322891,
     },
@@ -65,7 +77,10 @@ allele_383650 = models.Allele(**allele_383650_dict)
 allele_417816 = models.Allele(**allele_417816_dict)
 allele_280320 = models.Allele(**allele_280320_dict)
 
-cpb_431012_dict = {"type": "CisPhasedBlock", "members": [allele_383650_dict, allele_417816_dict]}
+cpb_431012_dict = {
+    "type": "CisPhasedBlock",
+    "members": [allele_383650_dict, allele_417816_dict],
+}
 cpb_431012 = models.CisPhasedBlock(**cpb_431012_dict)
 
 
@@ -73,13 +88,20 @@ cpb_431012 = models.CisPhasedBlock(**cpb_431012_dict)
     ("vrs_model", "expected_err_msg"),
     [
         (lambda: models.Range(root=[None, None]), "Must provide at least one integer."),
-        (lambda: models.Range(root=[2, 1]), "The first integer must be less than or equal to the second integer."),
         (
-            lambda: models.SequenceLocation(sequenceReference=allele_280320.location.sequenceReference, start=-1),
+            lambda: models.Range(root=[2, 1]),
+            "The first integer must be less than or equal to the second integer.",
+        ),
+        (
+            lambda: models.SequenceLocation(
+                sequenceReference=allele_280320.location.sequenceReference, start=-1
+            ),
             "The minimum value of `start` is 0.",
         ),
         (
-            lambda: models.SequenceLocation(sequenceReference=allele_280320.location.sequenceReference, end=[-1, 0]),
+            lambda: models.SequenceLocation(
+                sequenceReference=allele_280320.location.sequenceReference, end=[-1, 0]
+            ),
             "The minimum value of `end` is 0.",
         ),
     ],
@@ -99,7 +121,10 @@ def test_vr():
     # Sequence Reference
     seqref = a.location.sequenceReference
     seqref_serialized = ga4gh_serialize(seqref)
-    assert seqref_serialized == b'{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul","type":"SequenceReference"}'
+    assert (
+        seqref_serialized
+        == b'{"refgetAccession":"SQ.F-LrLMe1SRpfUZHkQmvkVKFEGaoDeHul","type":"SequenceReference"}'
+    )
     assert ga4gh_digest(seqref) is None
     assert ga4gh_identify(seqref) is None
 
@@ -170,7 +195,9 @@ def test_cpb():
 
 
 def test_ga4gh_iri():
-    iri = models.iriReference.model_construct("ga4gh:VA.Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE")
+    iri = models.iriReference.model_construct(
+        "ga4gh:VA.Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE"
+    )
     assert is_curie_type(iri)
     assert iri.root == pydantic_copy(iri).root
     assert ga4gh_serialize(iri) == b'"Hy2XU_-rp4IMh6I_1NXNecBo8Qx8n0oE"'
@@ -184,8 +211,12 @@ def test_enref():
     orig_no_loc.pop("location")
     actual_no_loc = allele_383650_enreffed.model_dump().copy()
     actual_no_loc.pop("location")
-    assert actual_no_loc == orig_no_loc, "Original and enreffed match except for enreffed field"
-    assert allele_383650_enreffed.location == "ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe"
+    assert actual_no_loc == orig_no_loc, (
+        "Original and enreffed match except for enreffed field"
+    )
+    assert (
+        allele_383650_enreffed.location == "ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe"
+    )
     assert allele_383650_enreffed.model_dump(exclude_none=True) == {
         "digest": "SZIS2ua7AL-0YgUTAqyBsFPYK3vE8h_d",
         "id": "ga4gh:VA.SZIS2ua7AL-0YgUTAqyBsFPYK3vE8h_d",
@@ -199,11 +230,16 @@ def test_enref():
         "digest": "TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
         "id": "ga4gh:SL.TaoXEhpHvA6SdilBUO-AX00YDARv9Uoe",
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
+        },
         "start": 128325834,
         "end": 128325835,
     }
-    assert dereffed.location.model_dump(exclude_none=True) == allele_383650.location.model_dump(exclude_none=True)
+    assert dereffed.location.model_dump(
+        exclude_none=True
+    ) == allele_383650.location.model_dump(exclude_none=True)
     assert dereffed.model_dump() == allele_383650.model_dump()
 
 
@@ -232,7 +268,9 @@ def test_enref2():
     orig_no_loc.pop("location")
     actual_no_loc = a_enreffed.model_dump().copy()
     actual_no_loc.pop("location")
-    assert orig_no_loc == actual_no_loc, "Original and enreffed match except for enreffed field"
+    assert orig_no_loc == actual_no_loc, (
+        "Original and enreffed match except for enreffed field"
+    )
     assert a_enreffed.location == "ga4gh:SL.wIlaGykfwHIpPY2Fcxtbx4TINbbODFVz"
     assert a_enreffed.model_dump(exclude_none=True) == {
         "id": "ga4gh:VA.LDzK5JahEZG2Ua_5itDtVV8v3O1ptTgI",

--- a/tests/test_vrs.py
+++ b/tests/test_vrs.py
@@ -1,18 +1,18 @@
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 from ga4gh.core import (
-    sha512t24u,
-    ga4gh_digest,
-    ga4gh_serialize,
-    ga4gh_identify,
-    is_pydantic_instance,
-    is_curie_type,
-    pydantic_copy,
-    use_ga4gh_compute_identifier_when,
     VrsObjectIdentifierIs,
+    ga4gh_digest,
+    ga4gh_identify,
+    ga4gh_serialize,
+    is_curie_type,
+    is_pydantic_instance,
+    pydantic_copy,
+    sha512t24u,
+    use_ga4gh_compute_identifier_when,
 )
-from ga4gh.vrs import models, vrs_enref, vrs_deref
+from ga4gh.vrs import models, vrs_deref, vrs_enref
 
 allele_dict = {
     "location": {
@@ -70,7 +70,7 @@ cpb_431012 = models.CisPhasedBlock(**cpb_431012_dict)
 
 
 @pytest.mark.parametrize(
-    "vrs_model, expected_err_msg",
+    ("vrs_model", "expected_err_msg"),
     [
         (lambda: models.Range(root=[None, None]), "Must provide at least one integer."),
         (lambda: models.Range(root=[2, 1]), "The first integer must be less than or equal to the second integer."),
@@ -86,9 +86,8 @@ cpb_431012 = models.CisPhasedBlock(**cpb_431012_dict)
 )
 def test_model_validation_errors(vrs_model, expected_err_msg):
     """Test that invalid VRS models raise errors"""
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match=expected_err_msg):
         vrs_model()
-    assert str(e.value.errors()[0]["ctx"]["error"]) == expected_err_msg
 
 
 def test_vr():
@@ -127,38 +126,33 @@ def test_vr():
 
     with pytest.raises(ValidationError):
         models.Allele(
-            **{
-                "type": "Allele",
-                "location": {
-                    "type": "SequenceLocation",
-                    "sequenceReference": {
-                        "type": "SequenceReference",
-                        # refgetAccession can't include a namespace prefix
-                        "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
-                    },
-                    "start": 128325834,
-                    "end": 128325835,
+            type="Allele",
+            location={
+                "type": "SequenceLocation",
+                "sequenceReference": {
+                    "type": "SequenceReference",
+                    # refgetAccession can't include a namespace prefix
+                    "refgetAccession": "ga4gh:SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
                 },
-                "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
-            }
+                "start": 128325834,
+                "end": 128325835,
+            },
+            state={"type": "LiteralSequenceExpression", "sequence": "T"},
         )
     with pytest.raises(ValidationError):
         models.Allele(
-            **{
-                "type": "Allele",
-                "location": {
-                    "type": "SequenceLocation",
-                    "sequenceReference": {
-                        "type": "SequenceReference",
-                        "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
-                    },
-                    "start": 128325834,
-                    "end": 128325835,
+            type="Allele",
+            location={
+                "type": "SequenceLocation",
+                "sequenceReference": {
+                    "type": "SequenceReference",
+                    "refgetAccession": "SQ.KEO-4XBcm1cxeo_DIQ8_ofqGUkp4iZhI",
                 },
-                "state": {"type": "LiteralSequenceExpression", "sequence": "T"},
-                # digest can't include a namespace prefix
-                "digest": "ga4gh:734G5mtNwe40do8F6GKuqQP4QxyjBqVp",
-            }
+                "start": 128325834,
+                "end": 128325835,
+            },
+            state={"type": "LiteralSequenceExpression", "sequence": "T"},
+            digest="ga4gh:734G5mtNwe40do8F6GKuqQP4QxyjBqVp",
         )
 
 

--- a/tests/test_vrs_normalize.py
+++ b/tests/test_vrs_normalize.py
@@ -12,7 +12,10 @@ allele_dict = {
     "location": {
         "end": 26090951,
         "start": 26090950,
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "C", "type": "LiteralSequenceExpression"},
@@ -24,7 +27,10 @@ allele_dict2 = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+        },
         "start": [None, 155980375],
         "end": [155980377, None],
     },
@@ -36,11 +42,18 @@ allele_dict2_normalized = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+        },
         "start": [None, 155980375],
         "end": [155980377, None],
     },
-    "state": {"length": 0, "repeatSubunitLength": 2, "type": "ReferenceLengthExpression"},
+    "state": {
+        "length": 0,
+        "repeatSubunitLength": 2,
+        "type": "ReferenceLengthExpression",
+    },
 }
 
 
@@ -48,7 +61,10 @@ allele_dict3 = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+        },
         "start": [155980374, 155980375],
         "end": [155980377, 155980378],
     },
@@ -60,7 +76,10 @@ allele_dict4 = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+        },
         "start": 155980373,
         "end": 155980375,
     },
@@ -71,18 +90,29 @@ allele_dict4_normalized = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+        },
         "start": 155980373,
         "end": 155980375,
     },
-    "state": {"length": 4, "repeatSubunitLength": 2, "sequence": "GTGT", "type": "ReferenceLengthExpression"},
+    "state": {
+        "length": 4,
+        "repeatSubunitLength": 2,
+        "sequence": "GTGT",
+        "type": "ReferenceLengthExpression",
+    },
 }
 
 allele_dict5 = {
     "location": {
         "end": 289464,
         "start": 289464,
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+        },
         "type": "SequenceLocation",
     },
     "state": {"sequence": "CAGCAG", "type": "LiteralSequenceExpression"},
@@ -93,11 +123,19 @@ allele_dict5_normalized = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"},
+        "sequenceReference": {
+            "type": "SequenceReference",
+            "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl",
+        },
         "start": 289464,
         "end": 289469,
     },
-    "state": {"type": "ReferenceLengthExpression", "length": 11, "sequence": "CAGCAGCAGCA", "repeatSubunitLength": 3},
+    "state": {
+        "type": "ReferenceLengthExpression",
+        "length": 11,
+        "sequence": "CAGCAGCAGCA",
+        "repeatSubunitLength": 3,
+    },
 }
 
 

--- a/tests/test_vrs_normalize.py
+++ b/tests/test_vrs_normalize.py
@@ -11,17 +11,11 @@ allele_dict = {
     "location": {
         "end": 26090951,
         "start": 26090950,
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV"
-        },
-        "type": "SequenceLocation"
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV"},
+        "type": "SequenceLocation",
     },
-    "state": {
-        "sequence": "C",
-        "type": "LiteralSequenceExpression"
-      },
-    "type": "Allele"
+    "state": {"sequence": "C", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 
@@ -29,17 +23,11 @@ allele_dict2 = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"
-        },
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
         "start": [None, 155980375],
-        "end": [155980377, None]
+        "end": [155980377, None],
     },
-    "state": {
-        "sequence": "",
-        "type": "LiteralSequenceExpression"
-    }
+    "state": {"sequence": "", "type": "LiteralSequenceExpression"},
 }
 
 
@@ -47,18 +35,11 @@ allele_dict2_normalized = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"
-        },
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
         "start": [None, 155980375],
-        "end": [155980377, None]
+        "end": [155980377, None],
     },
-    "state": {
-        "length": 0,
-        "repeatSubunitLength": 2,
-        "type": "ReferenceLengthExpression"
-    }
+    "state": {"length": 0, "repeatSubunitLength": 2, "type": "ReferenceLengthExpression"},
 }
 
 
@@ -66,17 +47,11 @@ allele_dict3 = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"
-        },
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
         "start": [155980374, 155980375],
-        "end": [155980377, 155980378]
+        "end": [155980377, 155980378],
     },
-    "state": {
-        "sequence": "",
-        "type": "LiteralSequenceExpression"
-    }
+    "state": {"sequence": "", "type": "LiteralSequenceExpression"},
 }
 
 
@@ -84,67 +59,46 @@ allele_dict4 = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"
-        },
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
         "start": 155980373,
-        "end": 155980375
+        "end": 155980375,
     },
-    "state": {
-        "sequence": "GTGT",
-        "type": "LiteralSequenceExpression"
-    }
+    "state": {"sequence": "GTGT", "type": "LiteralSequenceExpression"},
 }
 
 allele_dict4_normalized = {
     "type": "Allele",
     "location": {
         "type": "SequenceLocation",
-        "sequenceReference": {
-            "type": "SequenceReference",
-            "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"
-        },
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"},
         "start": 155980373,
-        "end": 155980375
+        "end": 155980375,
     },
-    "state": {
-        "length": 4,
-        "repeatSubunitLength": 2,
-        "sequence": "GTGT",
-        "type": "ReferenceLengthExpression"
-    }
+    "state": {"length": 4, "repeatSubunitLength": 2, "sequence": "GTGT", "type": "ReferenceLengthExpression"},
 }
 
 allele_dict5 = {
-    'location': {
-        'end': 289464,
-        'start': 289464,
-        'sequenceReference': {
-            'type': 'SequenceReference',
-            'refgetAccession': 'SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl'
-        },
-        'type': 'SequenceLocation'
+    "location": {
+        "end": 289464,
+        "start": 289464,
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"},
+        "type": "SequenceLocation",
     },
-    'state': {
-        'sequence': 'CAGCAG',
-        'type': 'LiteralSequenceExpression'
-    },
-    'type': 'Allele'
+    "state": {"sequence": "CAGCAG", "type": "LiteralSequenceExpression"},
+    "type": "Allele",
 }
 
 allele_dict5_normalized = {
-    'type': 'Allele',
-    'location': {'type': 'SequenceLocation',
-                 'sequenceReference': {'type': 'SequenceReference',
-                                       'refgetAccession': 'SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl'},
-                 'start': 289464,
-                 'end': 289469},
-    'state': {'type': 'ReferenceLengthExpression',
-              'length': 11,
-              'sequence': 'CAGCAGCAGCA',
-              'repeatSubunitLength': 3}
+    "type": "Allele",
+    "location": {
+        "type": "SequenceLocation",
+        "sequenceReference": {"type": "SequenceReference", "refgetAccession": "SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"},
+        "start": 289464,
+        "end": 289469,
+    },
+    "state": {"type": "ReferenceLengthExpression", "length": 11, "sequence": "CAGCAGCAGCA", "repeatSubunitLength": 3},
 }
+
 
 @pytest.mark.vcr
 def test_normalize_allele(rest_dataproxy):

--- a/tests/test_vrs_normalize.py
+++ b/tests/test_vrs_normalize.py
@@ -1,4 +1,5 @@
 import pytest
+
 from ga4gh.vrs import models, normalize
 
 # >>> dp.get_sequence("refseq:NC_000019.10", 44908820, 44908830)

--- a/tests/validation/test_functions.py
+++ b/tests/validation/test_functions.py
@@ -1,13 +1,12 @@
-import os
+from pathlib import Path
 
 import pytest
-import vcr
 import yaml
 
 from ga4gh.core import sha512t24u
 
-validation_fn = os.path.join(os.path.dirname(__file__), "data", "functions.yaml")
-validation_tests = yaml.load(open(validation_fn), Loader=yaml.SafeLoader)
+validation_fn = Path(__file__).parent / "data" / "functions.yaml"
+validation_tests = yaml.load(Path(validation_fn).open(), Loader=yaml.SafeLoader)  # noqa: SIM115
 
 
 @pytest.mark.parametrize("test", validation_tests["sha512t24u"])

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -6,7 +6,13 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from ga4gh.core import PrevVrsVersion, core_models, ga4gh_digest, ga4gh_identify, ga4gh_serialize
+from ga4gh.core import (
+    PrevVrsVersion,
+    core_models,
+    ga4gh_digest,
+    ga4gh_identify,
+    ga4gh_serialize,
+)
 from ga4gh.vrs import VrsType, models
 
 
@@ -70,24 +76,33 @@ def test_prev_vrs_version():
     loc = models.SequenceLocation(
         start=44908821,
         end=44908822,
-        sequenceReference=models.SequenceReference(refgetAccession="SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"),
+        sequenceReference=models.SequenceReference(
+            refgetAccession="SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"
+        ),
     )
 
     # string representation should work as well
     ga4gh_identify(loc, as_version="1.3")
 
     invalid_vrs_version = "0.0"
-    invalid_vrs_version_msg = f"Expected `PrevVrsVersion`, but got {invalid_vrs_version}"
+    invalid_vrs_version_msg = (
+        f"Expected `PrevVrsVersion`, but got {invalid_vrs_version}"
+    )
 
     loc_no_seq_ref = models.SequenceLocation(start=44908821, end=44908822)
     loc_iri = models.SequenceLocation(
-        start=44908821, end=44908822, sequenceReference=core_models.iriReference("sequenceReferences.json#example1")
+        start=44908821,
+        end=44908822,
+        sequenceReference=core_models.iriReference("sequenceReferences.json#example1"),
     )
     allele_rle_no_seq = models.Allele(
-        location=loc, state=models.ReferenceLengthExpression(length=11, repeatSubunitLength=3)
+        location=loc,
+        state=models.ReferenceLengthExpression(length=11, repeatSubunitLength=3),
     )
     allele_le = models.Allele(location=loc, state=models.LengthExpression(length=2))
-    loc_seq_ref_msg = "Must provide `sequenceReference` and it must be a valid `SequenceReference`"
+    loc_seq_ref_msg = (
+        "Must provide `sequenceReference` and it must be a valid `SequenceReference`"
+    )
     for ga4gh_func in [ga4gh_identify, ga4gh_digest, ga4gh_serialize]:
         with pytest.raises(ValueError, match=invalid_vrs_version_msg):
             ga4gh_func(loc, as_version=invalid_vrs_version_msg)
@@ -98,7 +113,9 @@ def test_prev_vrs_version():
         with pytest.raises(ValueError, match=loc_seq_ref_msg):
             ga4gh_func(loc_iri, as_version=PrevVrsVersion.V1_3)
 
-        with pytest.raises(ValueError, match="State sequence attribute must be defined."):
+        with pytest.raises(
+            ValueError, match="State sequence attribute must be defined."
+        ):
             ga4gh_func(allele_rle_no_seq, as_version=PrevVrsVersion.V1_3)
 
         allele_rlse_seq = allele_rle_no_seq.model_copy(deep=True)
@@ -135,7 +152,9 @@ def test_valid_types():
 def test_mappable_concept():
     """Test the MappableConcept model validator"""
     # Does not provide required fields
-    with pytest.raises(ValueError, match="`One of label` or `primaryCode` must be provided."):
+    with pytest.raises(
+        ValueError, match="`One of label` or `primaryCode` must be provided."
+    ):
         core_models.MappableConcept(conceptType="test")
 
     # Valid models
@@ -149,18 +168,30 @@ def test_copy_number_change():
 
     # Primary code not provided
     with pytest.raises(ValueError, match="`primaryCode` is required."):
-        models.CopyNumberChange(location=location, copyChange=core_models.MappableConcept(label="test"))
+        models.CopyNumberChange(
+            location=location, copyChange=core_models.MappableConcept(label="test")
+        )
 
     # Primary code not valid EFO
     with pytest.raises(ValueError, match="`primaryCode` must be one of:"):
-        models.CopyNumberChange(location=location, copyChange=core_models.MappableConcept(primaryCode="test"))
+        models.CopyNumberChange(
+            location=location,
+            copyChange=core_models.MappableConcept(primaryCode="test"),
+        )
 
 
 def test_adjacency():
     """Test the Adjacency field validator"""
     # Both start and end provided
-    with pytest.raises(ValueError, match="Adjoined sequence must not have both `start` and `end`."):
-        models.Adjacency(adjoinedSequences=[models.SequenceLocation(start=1), models.SequenceLocation(start=1, end=2)])
+    with pytest.raises(
+        ValueError, match="Adjoined sequence must not have both `start` and `end`."
+    ):
+        models.Adjacency(
+            adjoinedSequences=[
+                models.SequenceLocation(start=1),
+                models.SequenceLocation(start=1, end=2),
+            ]
+        )
 
     assert models.Adjacency(
         adjoinedSequences=[

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -1,6 +1,4 @@
-"""execute models validation tests from the VRS repo
-
-"""
+"""execute models validation tests from the VRS repo"""
 
 import os
 
@@ -11,17 +9,21 @@ import yaml
 from ga4gh.core import ga4gh_serialize, ga4gh_digest, ga4gh_identify, PrevVrsVersion, core_models
 from ga4gh.vrs import models, VrsType
 
+
 def ga4gh_1_3_identify(*args, **kwargs):
-    kwargs['as_version'] = PrevVrsVersion.V1_3
+    kwargs["as_version"] = PrevVrsVersion.V1_3
     return ga4gh_identify(*args, **kwargs)
 
+
 def ga4gh_1_3_digest(*args, **kwargs):
-    kwargs['as_version'] = PrevVrsVersion.V1_3
+    kwargs["as_version"] = PrevVrsVersion.V1_3
     return ga4gh_digest(*args, **kwargs)
 
+
 def ga4gh_1_3_serialize(*args, **kwargs):
-    kwargs['as_version'] = PrevVrsVersion.V1_3
+    kwargs["as_version"] = PrevVrsVersion.V1_3
     return ga4gh_serialize(*args, **kwargs)
+
 
 fxs = {
     "ga4gh_serialize": ga4gh_serialize,
@@ -29,7 +31,7 @@ fxs = {
     "ga4gh_identify": ga4gh_identify,
     "ga4gh_1_3_digest": ga4gh_1_3_digest,
     "ga4gh_1_3_identify": ga4gh_1_3_identify,
-    "ga4gh_1_3_serialize": ga4gh_1_3_serialize
+    "ga4gh_1_3_serialize": ga4gh_1_3_serialize,
 }
 
 validation_fn = os.path.join(os.path.dirname(__file__), "data", "models.yaml")
@@ -52,8 +54,8 @@ def flatten_tests(vts):
                 yield pytest.param(cls, t["in"], fn, exp, id=test_name)
 
 
-#tests, ids = zip(*list(flatten_tests(validation_tests)))
-#import IPython; IPython.embed()	  ### TODO: Remove IPython.embed()
+# tests, ids = zip(*list(flatten_tests(validation_tests)))
+# import IPython; IPython.embed()	  ### TODO: Remove IPython.embed()
 
 
 @pytest.mark.parametrize("cls,data,fn,exp", flatten_tests(validation_tests))
@@ -67,7 +69,11 @@ def test_validation(cls, data, fn, exp):
 
 def test_prev_vrs_version():
     """Ensure that support to previous VRS digest/identifiers works correctly"""
-    loc = models.SequenceLocation(start=44908821, end=44908822, sequenceReference=models.SequenceReference(refgetAccession="SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"))
+    loc = models.SequenceLocation(
+        start=44908821,
+        end=44908822,
+        sequenceReference=models.SequenceReference(refgetAccession="SQ.IIB53T8CNeJJdUqzn9V_JnRtQadwWCbl"),
+    )
 
     # string representation should work as well
     ga4gh_identify(loc, as_version="1.3")
@@ -76,8 +82,12 @@ def test_prev_vrs_version():
     invalid_vrs_version_msg = f"Expected `PrevVrsVersion`, but got {invalid_vrs_version}"
 
     loc_no_seq_ref = models.SequenceLocation(start=44908821, end=44908822)
-    loc_iri = models.SequenceLocation(start=44908821, end=44908822, sequenceReference=core_models.iriReference("sequenceReferences.json#example1"))
-    allele_rle_no_seq = models.Allele(location=loc, state=models.ReferenceLengthExpression(length=11, repeatSubunitLength=3))
+    loc_iri = models.SequenceLocation(
+        start=44908821, end=44908822, sequenceReference=core_models.iriReference("sequenceReferences.json#example1")
+    )
+    allele_rle_no_seq = models.Allele(
+        location=loc, state=models.ReferenceLengthExpression(length=11, repeatSubunitLength=3)
+    )
     allele_le = models.Allele(location=loc, state=models.LengthExpression(length=2))
     loc_seq_ref_msg = "Must provide `sequenceReference` and it must be a valid `SequenceReference`"
     for ga4gh_func in [ga4gh_identify, ga4gh_digest, ga4gh_serialize]:
@@ -97,7 +107,10 @@ def test_prev_vrs_version():
         allele_rlse_seq.state.sequence = "C"
         assert ga4gh_func(allele_rlse_seq, as_version=PrevVrsVersion.V1_3)
 
-        with pytest.raises(ValueError, match="Only `LiteralSequenceExpression` and `ReferenceLengthExpression` are supported for previous versions of VRS"):
+        with pytest.raises(
+            ValueError,
+            match="Only `LiteralSequenceExpression` and `ReferenceLengthExpression` are supported for previous versions of VRS",
+        ):
             ga4gh_func(allele_le, as_version=PrevVrsVersion.V1_3)
 
 
@@ -114,7 +127,9 @@ def test_valid_types():
                 for error in e.errors():
                     if error["loc"] == ("type",):
                         found_type_mismatch = True
-                assert not found_type_mismatch, f"Found mismatch in type literal: {enum_val} vs {error['ctx']['expected']}"
+                assert not found_type_mismatch, (
+                    f"Found mismatch in type literal: {enum_val} vs {error['ctx']['expected']}"
+                )
         else:
             assert False, f"{str(models)} class not found: {enum_val}"
 
@@ -147,16 +162,11 @@ def test_adjacency():
     """Test the Adjacency field validator"""
     # Both start and end provided
     with pytest.raises(ValueError, match="Adjoined sequence must not have both `start` and `end`."):
-        models.Adjacency(
-            adjoinedSequences=[
-                models.SequenceLocation(start=1),
-                models.SequenceLocation(start=1, end=2)
-            ]
-        )
+        models.Adjacency(adjoinedSequences=[models.SequenceLocation(start=1), models.SequenceLocation(start=1, end=2)])
 
     assert models.Adjacency(
-            adjoinedSequences=[
-                models.SequenceLocation(start=1),
-                models.SequenceLocation(end=2),
-            ]
-        )
+        adjoinedSequences=[
+            models.SequenceLocation(start=1),
+            models.SequenceLocation(end=2),
+        ]
+    )

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -58,7 +58,7 @@ def flatten_tests(vts):
 # import IPython; IPython.embed()	  ### TODO: Remove IPython.embed()
 
 
-@pytest.mark.parametrize("cls,data,fn,exp", flatten_tests(validation_tests))
+@pytest.mark.parametrize(("cls","data","fn","exp"), flatten_tests(validation_tests))
 def test_validation(cls, data, fn, exp):
     o = getattr(models, cls)(**data)
     fx = fxs[fn]
@@ -131,7 +131,7 @@ def test_valid_types():
                     f"Found mismatch in type literal: {enum_val} vs {error['ctx']['expected']}"
                 )
         else:
-            assert False, f"{str(models)} class not found: {enum_val}"
+            pytest.fail(f"{models!r} class not found: {enum_val}")
 
 
 def test_mappable_concept():

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -56,7 +56,7 @@ def flatten_tests(vts):  # noqa: ARG001
 # import IPython; IPython.embed()	  ### TODO: Remove IPython.embed()
 
 
-@pytest.mark.parametrize(("cls","data","fn","exp"), flatten_tests(validation_tests))
+@pytest.mark.parametrize(("cls", "data", "fn", "exp"), flatten_tests(validation_tests))
 def test_validation(cls, data, fn, exp):
     o = getattr(models, cls)(**data)
     fx = fxs[fn]

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -1,13 +1,13 @@
 """execute models validation tests from the VRS repo"""
 
-import os
+from pathlib import Path
 
-from pydantic import ValidationError
 import pytest
 import yaml
+from pydantic import ValidationError
 
-from ga4gh.core import ga4gh_serialize, ga4gh_digest, ga4gh_identify, PrevVrsVersion, core_models
-from ga4gh.vrs import models, VrsType
+from ga4gh.core import PrevVrsVersion, core_models, ga4gh_digest, ga4gh_identify, ga4gh_serialize
+from ga4gh.vrs import VrsType, models
 
 
 def ga4gh_1_3_identify(*args, **kwargs):
@@ -34,17 +34,15 @@ fxs = {
     "ga4gh_1_3_serialize": ga4gh_1_3_serialize,
 }
 
-validation_fn = os.path.join(os.path.dirname(__file__), "data", "models.yaml")
-validation_tests = yaml.load(open(validation_fn), Loader=yaml.SafeLoader)
+validation_fn = Path(__file__).parent / "data" / "models.yaml"
+validation_tests = yaml.load(Path(validation_fn).open(), Loader=yaml.SafeLoader)  # noqa: SIM115
 
 
-def flatten_tests(vts):
-    """flatten tests to (class, data, function name, exp out) tuples
+def flatten_tests(vts):  # noqa: ARG001
+    """Flatten tests to (class, data, function name, exp out) tuples
 
     Each tuple is a test in which an object of the specified class is
-    created with data, evaluated with the named function, and compared
-    with the expected output.
-
+    created with data, evaluated with the named function, and compared with the expected output.
     """
     for cls, tests in validation_tests.items():
         for t in tests:

--- a/tests/validation/test_schemas.py
+++ b/tests/validation/test_schemas.py
@@ -27,7 +27,9 @@ class GKSSchemaMapping(BaseModel):
     schema: dict = {}
 
 
-def _update_gks_schema_mapping(f_path: Path, gks_schema_mapping: GKSSchemaMapping) -> None:
+def _update_gks_schema_mapping(
+    f_path: Path, gks_schema_mapping: GKSSchemaMapping
+) -> None:
     """Update ``gks_schema_mapping`` properties
 
     :param f_path: Path to JSON Schema file
@@ -58,7 +60,9 @@ for f in (SUBMODULES_DIR / "schema" / "vrs" / "json").glob("*"):
 
 # Get core classes
 core_mapping = GKS_SCHEMA_MAPPING[GKSSchema.CORE]
-for f in (SUBMODULES_DIR / "submodules" / "gks-core" / "schema" / "gks-core" / "json").glob("*"):
+for f in (
+    SUBMODULES_DIR / "submodules" / "gks-core" / "schema" / "gks-core" / "json"
+).glob("*"):
     _update_gks_schema_mapping(f, core_mapping)
 
 
@@ -72,8 +76,13 @@ for f in (SUBMODULES_DIR / "submodules" / "gks-core" / "schema" / "gks-core" / "
 def test_schema_models_in_pydantic(gks_schema, pydantic_models):
     """Ensure that each schema model has corresponding Pydantic model"""
     mapping = GKS_SCHEMA_MAPPING[gks_schema]
-    for schema_model in mapping.base_classes | mapping.concrete_classes | mapping.primitives:
-        if schema_model not in {"date", "datetime"}:  # since we leverage datetime module
+    for schema_model in (
+        mapping.base_classes | mapping.concrete_classes | mapping.primitives
+    ):
+        if schema_model not in {
+            "date",
+            "datetime",
+        }:  # since we leverage datetime module
             assert getattr(pydantic_models, schema_model, False), schema_model
 
 
@@ -110,9 +119,13 @@ def test_schema_class_fields(gks_schema, pydantic_models):
                 if prop != "code":  # special exception
                     assert property_def["description"].replace(
                         "'", '"'
-                    ) == pydantic_model_field_info.description.replace("'", '"'), f"{pydantic_model}.{prop}"
+                    ) == pydantic_model_field_info.description.replace("'", '"'), (
+                        f"{pydantic_model}.{prop}"
+                    )
             else:
-                assert pydantic_model_field_info.description is None, f"{pydantic_model}.{prop}"
+                assert pydantic_model_field_info.description is None, (
+                    f"{pydantic_model}.{prop}"
+                )
 
 
 def test_ga4gh_keys():
@@ -129,5 +142,9 @@ def test_ga4gh_keys():
         except AttributeError as e:
             raise AttributeError(vrs_class) from e
 
-        assert set(pydantic_model_digest_keys) == set(vrs_mapping.schema[vrs_class]["ga4gh"]["inherent"]), vrs_class
-        assert pydantic_model_digest_keys == sorted(pydantic_model.ga4gh.keys), vrs_class
+        assert set(pydantic_model_digest_keys) == set(
+            vrs_mapping.schema[vrs_class]["ga4gh"]["inherent"]
+        ), vrs_class
+        assert pydantic_model_digest_keys == sorted(pydantic_model.ga4gh.keys), (
+            vrs_class
+        )

--- a/tests/validation/test_schemas.py
+++ b/tests/validation/test_schemas.py
@@ -1,7 +1,7 @@
 """Test that VRS-Python Pydantic models match VRS and GKS-Common schemas"""
 
-from enum import Enum
 import json
+from enum import Enum
 from pathlib import Path
 
 import pytest

--- a/tests/validation/test_schemas.py
+++ b/tests/validation/test_schemas.py
@@ -27,9 +27,7 @@ class GKSSchemaMapping(BaseModel):
     schema: dict = {}
 
 
-def _update_gks_schema_mapping(
-    f_path: Path, gks_schema_mapping: GKSSchemaMapping
-) -> None:
+def _update_gks_schema_mapping(f_path: Path, gks_schema_mapping: GKSSchemaMapping) -> None:
     """Update ``gks_schema_mapping`` properties
 
     :param f_path: Path to JSON Schema file
@@ -74,9 +72,7 @@ for f in (SUBMODULES_DIR / "submodules" / "gks-core" / "schema" / "gks-core" / "
 def test_schema_models_in_pydantic(gks_schema, pydantic_models):
     """Ensure that each schema model has corresponding Pydantic model"""
     mapping = GKS_SCHEMA_MAPPING[gks_schema]
-    for schema_model in (
-        mapping.base_classes | mapping.concrete_classes | mapping.primitives
-    ):
+    for schema_model in mapping.base_classes | mapping.concrete_classes | mapping.primitives:
         if schema_model not in {"date", "datetime"}:  # since we leverage datetime module
             assert getattr(pydantic_models, schema_model, False), schema_model
 
@@ -112,7 +108,9 @@ def test_schema_class_fields(gks_schema, pydantic_models):
 
             if "description" in property_def:
                 if prop != "code":  # special exception
-                    assert property_def["description"].replace("'", "\"") == pydantic_model_field_info.description.replace("'", "\""), f"{pydantic_model}.{prop}"
+                    assert property_def["description"].replace(
+                        "'", '"'
+                    ) == pydantic_model_field_info.description.replace("'", '"'), f"{pydantic_model}.{prop}"
             else:
                 assert pydantic_model_field_info.description is None, f"{pydantic_model}.{prop}"
 
@@ -121,10 +119,7 @@ def test_ga4gh_keys():
     """Ensure ga4gh inherent defined in schema model exist in corresponding Pydantic model"""
     vrs_mapping = GKS_SCHEMA_MAPPING[GKSSchema.VRS]
     for vrs_class in vrs_mapping.concrete_classes:
-        if (
-            vrs_mapping.schema[vrs_class].get("ga4gh", {}).get("inherent", None)
-            is None
-        ):
+        if vrs_mapping.schema[vrs_class].get("ga4gh", {}).get("inherent", None) is None:
             continue
 
         pydantic_model = getattr(vrs_models, vrs_class)
@@ -134,9 +129,5 @@ def test_ga4gh_keys():
         except AttributeError as e:
             raise AttributeError(vrs_class) from e
 
-        assert set(pydantic_model_digest_keys) == set(
-            vrs_mapping.schema[vrs_class]["ga4gh"]["inherent"]
-        ), vrs_class
-        assert pydantic_model_digest_keys == sorted(
-            pydantic_model.ga4gh.keys
-        ), vrs_class
+        assert set(pydantic_model_digest_keys) == set(vrs_mapping.schema[vrs_class]["ga4gh"]["inherent"]), vrs_class
+        assert pydantic_model_digest_keys == sorted(pydantic_model.ga4gh.keys), vrs_class

--- a/tests/vcr_support.py
+++ b/tests/vcr_support.py
@@ -1,9 +1,10 @@
 import os
+from pathlib import Path
 
 import vcr as vcrpy
 
-test_dir = os.path.dirname(__file__)
-test_data_dir = os.path.join(test_dir, "data", "cassettes")
+test_dir = Path(__file__).parent
+test_data_dir = Path(test_dir) / "data" / "cassettes"
 
 vcr = vcrpy.VCR(
     cassette_library_dir=test_data_dir,


### PR DESCRIPTION
close #411 

- [x] lots left to do, some farmed out to new issues
    * I made some decent progress in `vrs/models.py` but it's just an utter minefield so I opted to exclude it from linting entirely. It'd be nice to return at a later point but it's gonna take some real attention, particularly given the way that equivalent type annotations seem to have some runtime effects here.
    * Some other lint groups are blanket ignored for a couple of different files, mostly related to docstrings and type annotations for modules that I'm not particularly familiar with. It'd be good to make progress on them in the future.
    * Made a few specific issues about particular things that will entail minor runtime changes to correctly fix. Otherwise, every change made here should be more or less irrelevant for anything other than style
- [x] add to CICD/precommit
- [x] sort out circular import issue

open questions:

- [x] should the test action only run if lint passes?