### PR TITLE
chore: remove obselete version property

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   seqrepo:
     image: biocommons/seqrepo:2024-02-20


### PR DESCRIPTION
Docker now emits a warning when you try to use this property, and recommends its removal. See https://docs.docker.com/reference/compose-file/version-and-name/
