### PR TITLE
test: use recommended pytest-vcr settings

### DIFF
--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -52,7 +52,7 @@ jobs:
         pip install -e .[dev,extras]
     - name: Test with pytest
       run: |
-        python -m pytest
+        python -m pytest --vcr-record=none
 
   precommit_hooks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
from the docs: https://pytest-vcr.readthedocs.io/en/latest/

> When running your tests on CI it's recommended to use the --vcr-record=none option. This way you can make sure that you have committed all the cassettes.