### PR TITLE
docs: remove restview dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ dev = [
     # docs
     "sphinx",
     "sphinx_rtd_theme",
-    "restview",
 ]
 notebooks = [
     "jupyter",


### PR DESCRIPTION
"restview" can be a helpful tool, but a) there are better alternatives (sphinx-view) and b) this isn't used in any part of the docs toolchain for this repo so I don't think it should be a declared dependency
