### PR TITLE
test: decouple test cases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def dataproxy():
     return SeqRepoDataProxy(sr)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def rest_dataproxy():
     return SeqRepoRESTDataProxy(
         base_url=os.environ.get("SEQREPO_REST_URL", "http://localhost:5000/seqrepo")

--- a/tests/extras/test_allele_translator.py
+++ b/tests/extras/test_allele_translator.py
@@ -5,7 +5,7 @@ from ga4gh.vrs.dataproxy import DataProxyValidationError
 from ga4gh.vrs.extras.translator import AlleleTranslator
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def tlr(rest_dataproxy):
     return AlleleTranslator(
         data_proxy=rest_dataproxy,

--- a/tests/extras/test_cnv_translator.py
+++ b/tests/extras/test_cnv_translator.py
@@ -4,7 +4,7 @@ from ga4gh.vrs import models
 from ga4gh.vrs.extras.translator import CnvTranslator
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def tlr(rest_dataproxy):
     return CnvTranslator(
         data_proxy=rest_dataproxy,


### PR DESCRIPTION
close #479 

This issue relates to SeqRepo's LRU cache and pytest-VCR. 
* pytest-vcr mocks REST requests on a per-function basis. 
* however, several dataproxy requests recur in multiple test cases. 
* When all tests are run at once, I believe that SeqRepo's LRU cache decorator is caching the response after the first request, and doesn't issue it again in subsequent test cases (because it gets a cache hit). 
* This means that the cassettes for those test cases don't include responses for those requests. If you just run those tests in isolation, you'll be issuing requests that aren't in the cassette, and you'll fail.

One obvious solution is to reconstruct the fixture after every test case (i.e. every test function). However, that kind of sucks and makes running tests far slower (27 seconds on my machine, and that's with a bunch of fails, vs 5 seconds the old way) because there's a little bit of cost to re-create the fixture after every test case. We'll also need to generate new cassettes if we go this route.