### PR TITLE
 feat!: move, reorganize field const variables 

### DIFF
--- a/src/ga4gh/vrs/extras/annotator/vcf.py
+++ b/src/ga4gh/vrs/extras/annotator/vcf.py
@@ -285,7 +285,7 @@ class VCFAnnotator:
 
         if output_vcf:
             allele_id = vrs_obj.id if vrs_obj else ""
-            vrs_field_data[self.VRS_ALLELE_IDS_FIELD].append(allele_id)
+            vrs_field_data[VRS_ALLELE_IDS_FIELD].append(allele_id)
 
             if vrs_attributes:
                 if vrs_obj:


### PR DESCRIPTION
Another easier one.

* `str.translate` is a more straightforward way to do a multi pass mapping on a string
* move consts outside of the class. It probably doesn't matter but it made more sense to me to put them there in case another module wants to refer to them.