### PR TITLE
feat!: refactor annotator as ABC, add NDJSON annotation + support optional side effects

### DIFF
--- a/src/ga4gh/vrs/extras/annotator/cli.py
+++ b/src/ga4gh/vrs/extras/annotator/cli.py
@@ -98,7 +98,7 @@ def _log_level_option(func: Callable) -> Callable:
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=Path),
     help=(
-        "Declare save location for output NDJSON file mapping VRS IDs to alleles. At least one form of output must be declared."
+        "Declare save location for output NDJSON file dump of VRS alleles. At least one form of output must be declared."
     ),
 )
 @click.option(

--- a/src/ga4gh/vrs/extras/annotator/cli.py
+++ b/src/ga4gh/vrs/extras/annotator/cli.py
@@ -82,15 +82,23 @@ def _log_level_option(func: Callable) -> Callable:
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=Path),
     help=(
-        "Declare save location for output annotated VCF. If not provided, must provide --vrs_pickle_out."
+        "Declare save location for output annotated VCF. At least one form of output must be declared."
     ),
 )
 @click.option(
-    "--vrs_pickle_out",
+    "--pkl_out",
     required=False,
     type=click.Path(writable=True, allow_dash=False, path_type=Path),
     help=(
-        "Declare save location for output VCF pickle. If not provided, must provide --vcf_out."
+        "Declare save location for output PKL file mapping VRS IDs to alleles. At least one form of output must be declared."
+    ),
+)
+@click.option(
+    "--ndjson_out",
+    required=False,
+    type=click.Path(writable=True, allow_dash=False, path_type=Path),
+    help=(
+        "Declare save location for output NDJSON file mapping VRS IDs to alleles. At least one form of output must be declared."
     ),
 )
 @click.option(
@@ -136,7 +144,8 @@ def _log_level_option(func: Callable) -> Callable:
 def _annotate_vcf_cli(
     vcf_in: Path,
     vcf_out: Path | None,
-    vrs_pickle_out: Path | None,
+    pkl_out: Path | None,
+    ndjson_out: Path | None,
     vrs_attributes: bool,
     dataproxy_uri: str,
     assembly: str,
@@ -146,9 +155,10 @@ def _annotate_vcf_cli(
 ) -> None:
     """Extract VRS objects from VCF located at VCF_IN.
 
-        $ vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --vrs_pickle_out vrs_objects.pkl
+        $ vrs-annotate vcf input.vcf.gz --vcf_out output.vcf.gz --pkl_out vrs_objects.pkl
 
-    Note that at least one of --vcf_out or --vrs_pickle_out must be selected and defined.
+    Note that at least one of --vcf_out, --pkl_out, or --ndjson_out must be selected and
+    defined; otherwise, this process will terminate immediately.
 
     Sequence data from a provider such as SeqRepo is required. Use the `--dataproxy_uri`
     option or the environment variable `GA4GH_VRS_DATAPROXY_URI` to define its location
@@ -180,11 +190,12 @@ def _annotate_vcf_cli(
     annotator.annotate(
         vcf_in.absolute(),
         output_vcf_path=vcf_out,
-        output_pkl_path=vrs_pickle_out,
         vrs_attributes=vrs_attributes,
         assembly=assembly,
         compute_for_ref=(not skip_ref),
         require_validation=require_validation,
+        output_pkl_path=pkl_out,
+        output_ndjson_path=ndjson_out,
     )
     end = timer()
     msg = f"VCF Annotator finished in {(end - start):.5f} seconds"

--- a/src/ga4gh/vrs/extras/annotator/cli.py
+++ b/src/ga4gh/vrs/extras/annotator/cli.py
@@ -12,7 +12,7 @@ from timeit import default_timer as timer
 
 import click
 
-from ga4gh.vrs.extras.annotator.vcf import SeqRepoProxyType, VCFAnnotator
+from ga4gh.vrs.extras.annotator.vcf import SeqRepoProxyType, VcfAnnotator
 
 _logger = logging.getLogger(__name__)
 
@@ -169,7 +169,7 @@ def _annotate_vcf_cli(
 
     Note that at least one of --vcf_out or --vrs_pickle_out must be selected and defined.
     """
-    annotator = VCFAnnotator(
+    annotator = VcfAnnotator(
         seqrepo_dp_type, seqrepo_base_url, str(seqrepo_root_dir.absolute())
     )
     start = timer()

--- a/src/ga4gh/vrs/extras/annotator/vcf.py
+++ b/src/ga4gh/vrs/extras/annotator/vcf.py
@@ -57,7 +57,6 @@ class AbstractVcfAnnotator(abc.ABC):
         self.data_proxy = data_proxy
         self.tlr = AlleleTranslator(self.data_proxy)
 
-
     @abc.abstractmethod
     def raise_for_output_args(self, output_vcf_path: Path | None, **kwargs) -> None:
         """Raise an exception if no output appears to be configured or declared.
@@ -175,7 +174,7 @@ class AbstractVcfAnnotator(abc.ABC):
                     vrs_attributes=vrs_attributes,
                     compute_for_ref=compute_for_ref,
                     require_validation=require_validation,
-                    **kwargs
+                    **kwargs,
                 )
             except Exception as ex:
                 _logger.exception("VRS error on %s-%s", record.chrom, record.pos)
@@ -239,7 +238,7 @@ class AbstractVcfAnnotator(abc.ABC):
         assembly: str,
         vrs_attributes: bool = False,
         require_validation: bool = True,
-        **kwargs
+        **kwargs,
     ) -> None:
         """Get VRS object given `vcf_coords`. `vrs_data` and `vrs_field_data` will
         be mutated.
@@ -310,7 +309,7 @@ class AbstractVcfAnnotator(abc.ABC):
         vrs_attributes: bool = False,
         compute_for_ref: bool = True,
         require_validation: bool = True,
-        **kwargs
+        **kwargs,
     ) -> dict:
         """Get VRS data for record's reference and alt alleles.
 
@@ -343,7 +342,7 @@ class AbstractVcfAnnotator(abc.ABC):
                 assembly,
                 vrs_attributes=vrs_attributes,
                 require_validation=require_validation,
-                **kwargs
+                **kwargs,
             )
 
         # Get VRS data for alts

--- a/src/ga4gh/vrs/extras/annotator/vcf.py
+++ b/src/ga4gh/vrs/extras/annotator/vcf.py
@@ -74,7 +74,7 @@ def dump_alleles_to_ndjson(
 class AbstractVcfAnnotator(abc.ABC):
     """Abstract class for VCF annotation with VRS.
 
-    Child classes should implement all abstract methods, though some may be less relevant
+    Child classes must implement all abstract methods, though some may be less relevant
     and can just be stubbed out (for example, if the desired side effect for each VRS
     object is something like a REST request, there may be no need for extra cleanup in
     ``on_vrs_object_collection``).

--- a/src/ga4gh/vrs/extras/annotator/vcf.py
+++ b/src/ga4gh/vrs/extras/annotator/vcf.py
@@ -279,7 +279,7 @@ class AbstractVcfAnnotator(abc.ABC):
         Reimplement in a child class to add custom logic. Otherwise, this method does
         nothing.
 
-        :param vrs_alleles: VRS alleles constructed from ingested VCF
+        :param vrs_alleles_collection: VRS alleles constructed from ingested VCF
         """
 
     def _get_vrs_object(
@@ -296,13 +296,11 @@ class AbstractVcfAnnotator(abc.ABC):
         be mutated.
 
         :param vcf_coords: Allele to get VRS object for. Format is chr-pos-ref-alt
-        :param vrs_data: All constructed VRS objects. Can be `None` if no data dumps
+        :param allele_collection: All constructed VRS objects. Can be `None` if no data dumps
             will be created.
         :param vrs_field_data: If `vrs_data`, keys are VRS Fields and values are list
             of VRS data. Empty dict otherwise.
         :param assembly: The assembly used in `vcf_coords`
-        :param vrs_data_key: The key to update in `vrs_data`. If not provided, will use
-            `vcf_coords` as the key.
         :param vrs_attributes: If `True` will include VRS_Start, VRS_End, VRS_State
             fields in the INFO field. If `False` will not include these fields. Only
             used if `output_vcf` set to `True`.
@@ -366,8 +364,8 @@ class AbstractVcfAnnotator(abc.ABC):
         """Get VRS data for record's reference and alt alleles.
 
         :param record: A row in the VCF file
-        :param vrs_data: Dictionary containing the VRS object information for the VCF.
-            Will be mutated if `output_pickle = True`
+        :param allele_collection: Dictionary containing the VRS object information for
+            the VCF. Will be mutated if `output_pickle = True`
         :param assembly: The assembly used in `record`
         :param additional_info_fields: Additional VRS fields to add in INFO field
         :param vrs_attributes: If `True` will include VRS_Start, VRS_End, VRS_State
@@ -512,7 +510,7 @@ class VcfAnnotator(AbstractVcfAnnotator):
         """Perform clean-up operations (eg file writing) on VRS objects collected
         during VCF ingestion.
 
-        :param vrs_alleles: VRS alleles constructed from ingested VCF
+        :param vrs_alleles_collection: VRS alleles constructed from ingested VCF
         """
         if vrs_alleles_collection is not None:
             output_pkl_path = kwargs.get(self.pkl_arg_name)

--- a/src/ga4gh/vrs/extras/annotator/vcf.py
+++ b/src/ga4gh/vrs/extras/annotator/vcf.py
@@ -364,8 +364,8 @@ class AbstractVcfAnnotator(abc.ABC):
         """Get VRS data for record's reference and alt alleles.
 
         :param record: A row in the VCF file
-        :param allele_collection: Dictionary containing the VRS object information for
-            the VCF. Will be mutated if `output_pickle = True`
+        :param allele_collection: List containing the VRS object information for
+            the VCF, if `self.collect_alleles` is `True`.
         :param assembly: The assembly used in `record`
         :param additional_info_fields: Additional VRS fields to add in INFO field
         :param vrs_attributes: If `True` will include VRS_Start, VRS_End, VRS_State

--- a/src/ga4gh/vrs/extras/annotator/vcf.py
+++ b/src/ga4gh/vrs/extras/annotator/vcf.py
@@ -66,8 +66,8 @@ class AbstractVcfAnnotator(abc.ABC):
         seqrepo_dp_type: SeqRepoProxyType = SeqRepoProxyType.LOCAL,
         seqrepo_base_url: str = "http://localhost:5000/seqrepo",
         seqrepo_root_dir: str = "/usr/local/share/seqrepo/latest",
-        **kwargs
-    ) -> None:  # noqa: ARG002
+        **kwargs,
+    ) -> None:
         """Initialize the VCFAnnotator class.
 
         :param seqrepo_dp_type: The type of SeqRepo Data Proxy to use

--- a/src/ga4gh/vrs/extras/annotator/vcf.py
+++ b/src/ga4gh/vrs/extras/annotator/vcf.py
@@ -86,7 +86,7 @@ class AbstractVcfAnnotator(abc.ABC):
 
     collect_alleles: bool = False
 
-    def __init__(self, data_proxy: _DataProxy) -> None:
+    def __init__(self, data_proxy: _DataProxy, **kwargs) -> None:  # noqa: ARG002
         """Initialize the VCFAnnotator class.
 
         :param data_proxy: GA4GH sequence dataproxy instance.
@@ -178,7 +178,6 @@ class AbstractVcfAnnotator(abc.ABC):
 
         :param input_vcf_path: Location of input VCF
         :param output_vcf_path: The path for the output VCF file
-        :param output_pkl_path: The path for the output VCF pickle file
         :param vrs_attributes: If `True`, include VRS_Start, VRS_End, VRS_State
             properties in the VCF INFO field. If `False` will not include these
             properties. Only used if `output_vcf_path` is defined.
@@ -449,7 +448,6 @@ class VcfAnnotator(AbstractVcfAnnotator):
 
         :param input_vcf_path: Location of input VCF
         :param output_vcf_path: The path for the output VCF file
-        :param output_pkl_path: The path for the output VCF pickle file
         :param vrs_attributes: If `True`, include VRS_Start, VRS_End, VRS_State
             properties in the VCF INFO field. If `False` will not include these
             properties. Only used if `output_vcf_path` is defined.

--- a/tests/extras/test_annotate_vcf.py
+++ b/tests/extras/test_annotate_vcf.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from ga4gh.vrs.dataproxy import DataProxyValidationError, SeqRepoRESTDataProxy
-from ga4gh.vrs.extras.annotator.vcf import VcfAnnotator, VCFAnnotatorError
+from ga4gh.vrs.extras.annotator.vcf import VcfAnnotator, VcfAnnotatorError
 
 TEST_DATA_DIR = Path("tests/extras/data")
 
@@ -45,7 +45,7 @@ def test_annotate_vcf_grch38_noattrs(
     )
 
     # Test GRCh38 assembly, which was used for input_vcf and no vrs attributes
-    vcf_annotator.annotate(input_vcf, output_vcf, output_vrs_pkl)
+    vcf_annotator.annotate(input_vcf, output_vcf, output_pkl_path=output_vrs_pkl)
     with gzip.open(output_vcf, "rt") as out_vcf:
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_vcf_no_vrs_attrs, "rt") as expected_output:
@@ -68,7 +68,9 @@ def test_annotate_vcf_grch38_attrs(
     expected_vcf = TEST_DATA_DIR / "test_vcf_expected_output.vcf.gz"
 
     # Test GRCh38 assembly, which was used for input_vcf and vrs attributes
-    vcf_annotator.annotate(input_vcf, output_vcf, output_vrs_pkl, vrs_attributes=True)
+    vcf_annotator.annotate(
+        input_vcf, output_vcf, vrs_attributes=True, output_pkl_path=output_vrs_pkl
+    )
     with gzip.open(output_vcf, "rt") as out_vcf:
         out_vcf_lines = out_vcf.readlines()
     with gzip.open(expected_vcf, "rt") as expected_output:
@@ -94,9 +96,9 @@ def test_annotate_vcf_grch38_attrs_altsonly(
     vcf_annotator.annotate(
         input_vcf,
         output_vcf,
-        output_vrs_pkl,
         vrs_attributes=True,
         compute_for_ref=False,
+        output_pkl_path=output_vrs_pkl,
     )
     with gzip.open(output_vcf, "rt") as out_vcf:
         out_vcf_lines = out_vcf.readlines()
@@ -121,7 +123,11 @@ def test_annotate_vcf_grch37_attrs(
 
     # Test GRCh37 assembly, which was not used for input_vcf
     vcf_annotator.annotate(
-        input_vcf, output_vcf, output_vrs_pkl, vrs_attributes=True, assembly="GRCh37"
+        input_vcf,
+        output_vcf,
+        vrs_attributes=True,
+        assembly="GRCh37",
+        output_pkl_path=output_vrs_pkl,
     )
     with gzip.open(output_vcf, "rt") as out_vcf:
         out_vcf_lines = out_vcf.readlines()
@@ -170,9 +176,11 @@ def test_annotate_vcf_vcf_only(
 
 
 def test_annotate_vcf_input_validation(vcf_annotator: VcfAnnotator, input_vcf: Path):
-    with pytest.raises(VCFAnnotatorError) as e:
+    with pytest.raises(
+        VcfAnnotatorError,
+        match="No VCF, PKL, or NDJSON output path provided -- must pass at least one of `output_vcf_path`, `output_pkl_path`, `output_ndjson_path` to annotate().",
+    ):
         vcf_annotator.annotate(input_vcf)
-    assert str(e.value) == "Must provide one of: `output_vcf_path` or `output_pkl_path`"
 
 
 @pytest.mark.vcr
@@ -182,28 +190,28 @@ def test_get_vrs_object_invalid_input(vcf_annotator: VcfAnnotator, caplog):
     caplog.set_level(logging.DEBUG)
 
     # No CHROM
-    vcf_annotator._get_vrs_object(".-140753336-A-T", {}, [], "GRCh38")
+    vcf_annotator._get_vrs_object(".-140753336-A-T", [], {}, "GRCh38")
     assert "KeyError when getting refget accession: GRCh38:." in caplog.text
 
     # No POS
-    vcf_annotator._get_vrs_object("7-.-A-T", {}, [], "GRCh38")
+    vcf_annotator._get_vrs_object("7-.-A-T", [], {}, "GRCh38")
     assert "None was returned when translating 7-.-A-T from gnomad" in caplog.text
 
     # No REF
-    vcf_annotator._get_vrs_object("7-140753336-.-T", {}, [], "GRCh38")
+    vcf_annotator._get_vrs_object("7-140753336-.-T", [], {}, "GRCh38")
     assert (
         "None was returned when translating 7-140753336-.-T from gnomad" in caplog.text
     )
 
     # No ALT
-    vcf_annotator._get_vrs_object("7-140753336-A-.", {}, [], "GRCh38")
+    vcf_annotator._get_vrs_object("7-140753336-A-.", [], {}, "GRCh38")
     assert (
         "None was returned when translating 7-140753336-A-. from gnomad" in caplog.text
     )
 
     # Invalid ref, but not requiring validation checks so no error is raised
     vcf_annotator._get_vrs_object(
-        "7-140753336-G-T", {}, [], "GRCh38", require_validation=False
+        "7-140753336-G-T", [], {}, "GRCh38", require_validation=False
     )
     assert "" in caplog.text
 
@@ -211,6 +219,6 @@ def test_get_vrs_object_invalid_input(vcf_annotator: VcfAnnotator, caplog):
     invalid_ref_seq_msg = "Expected reference sequence C on GRCh38:7 at positions (140753335, 140753336) but found A"
     with pytest.raises(DataProxyValidationError, match=re.escape(invalid_ref_seq_msg)):
         vcf_annotator._get_vrs_object(
-            "7-140753336-C-T", {}, [], "GRCh38", require_validation=True
+            "7-140753336-C-T", [], {}, "GRCh38", require_validation=True
         )
     assert invalid_ref_seq_msg in caplog.text

--- a/tests/extras/test_annotate_vcf.py
+++ b/tests/extras/test_annotate_vcf.py
@@ -8,14 +8,14 @@ from pathlib import Path
 import pytest
 
 from ga4gh.vrs.dataproxy import DataProxyValidationError
-from ga4gh.vrs.extras.annotator.vcf import VCFAnnotator, VCFAnnotatorError
+from ga4gh.vrs.extras.annotator.vcf import VcfAnnotator, VCFAnnotatorError
 
 TEST_DATA_DIR = Path("tests/extras/data")
 
 
 @pytest.fixture
 def vcf_annotator():
-    return VCFAnnotator("rest")
+    return VcfAnnotator("rest")
 
 
 @pytest.fixture(scope="session")
@@ -26,7 +26,7 @@ def input_vcf():
 
 @pytest.mark.vcr
 def test_annotate_vcf_grch38_noattrs(
-    vcf_annotator: VCFAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
+    vcf_annotator: VcfAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
 ):
     vcr_cassette.allow_playback_repeats = False
     output_vcf = tmp_path / "test_vcf_output_grch38_noattrs.vcf.gz"
@@ -51,7 +51,7 @@ def test_annotate_vcf_grch38_noattrs(
 
 @pytest.mark.vcr
 def test_annotate_vcf_grch38_attrs(
-    vcf_annotator: VCFAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
+    vcf_annotator: VcfAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
 ):
     vcr_cassette.allow_playback_repeats = False
     output_vcf = tmp_path / "test_vcf_output_grch38_attrs.vcf.gz"
@@ -74,7 +74,7 @@ def test_annotate_vcf_grch38_attrs(
 
 @pytest.mark.vcr
 def test_annotate_vcf_grch38_attrs_altsonly(
-    vcf_annotator: VCFAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
+    vcf_annotator: VcfAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
 ):
     vcr_cassette.allow_playback_repeats = False
     output_vcf = tmp_path / "test_vcf_output_grch38_attrs_altsonly.vcf.gz"
@@ -103,7 +103,7 @@ def test_annotate_vcf_grch38_attrs_altsonly(
 
 @pytest.mark.vcr
 def test_annotate_vcf_grch37_attrs(
-    vcf_annotator: VCFAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
+    vcf_annotator: VcfAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
 ):
     vcr_cassette.allow_playback_repeats = False
     output_vcf = tmp_path / "test_vcf_output_grch37_attrs.vcf.gz"
@@ -125,7 +125,7 @@ def test_annotate_vcf_grch37_attrs(
 
 @pytest.mark.vcr
 def test_annotate_vcf_pickle_only(
-    vcf_annotator: VCFAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
+    vcf_annotator: VcfAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
 ):
     vcr_cassette.allow_playback_repeats = False
     output_vcf = tmp_path / "test_vcf_output_pickle_only.vcf.gz"
@@ -142,7 +142,7 @@ def test_annotate_vcf_pickle_only(
 
 @pytest.mark.vcr
 def test_annotate_vcf_vcf_only(
-    vcf_annotator: VCFAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
+    vcf_annotator: VcfAnnotator, input_vcf: Path, tmp_path: Path, vcr_cassette
 ):
     vcr_cassette.allow_playback_repeats = False
     output_vcf = tmp_path / "test_vcf_output_vcf_only.vcf.gz"
@@ -160,14 +160,14 @@ def test_annotate_vcf_vcf_only(
     assert not Path(output_vrs_pkl).exists()
 
 
-def test_annotate_vcf_input_validation(vcf_annotator: VCFAnnotator, input_vcf: Path):
+def test_annotate_vcf_input_validation(vcf_annotator: VcfAnnotator, input_vcf: Path):
     with pytest.raises(VCFAnnotatorError) as e:
         vcf_annotator.annotate(input_vcf)
     assert str(e.value) == "Must provide one of: `vcf_out` or `vrs_pickle_out`"
 
 
 @pytest.mark.vcr
-def test_get_vrs_object_invalid_input(vcf_annotator: VCFAnnotator, caplog):
+def test_get_vrs_object_invalid_input(vcf_annotator: VcfAnnotator, caplog):
     """Test that _get_vrs_object method works as expected with invalid input"""
     # some tests below are checking for debug logging statements
     caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
close #474 

Refactor the Annotator class to better support configurable outputs and side effects beyond an annotated VCF. Specifically, the class is now an Abstract Base Class, `AbstractVcfAnnotator`, and implementations must define three methods:

* `on_vrs_object`: perform filtering/transformation/side effects on VRS objects that have been translated from VCF coords. For example, attach additional extensions or mappings, or upload to a DB. Called every time the translator produces a successful VRS allele.
  * Eugene had originally proposed this solely for producing side effects (like DB uploads). I thought it might be helpful to a) enable transformations/more annotations (maybe do something with the expression added by the translator, or don't pass along for VCF annotation if it meets certain conditions). I don't have any specific applications in mind, though, so if it doesn't seem well-thought out, that's because it isn't.
* `on_vrs_object_collection`: do something with the aggregation of all VRS alleles collected during VCF annotation, such as dump them to a file. Called once after VCF ingestion is complete, but only if the class variable `collect_alleles` is `True`.
* `raise_for_output_args`: double-check that *some* kind of output has been declared in `annotate()`. This is here because there was a similar check in `annotate()` previously. The idea is to force a fast failure if you aren't going to be producing any kind of output. I don't feel particularly tied to keeping this, though.

The existing pickle file dump is modified slightly to use VRS IDs as keys (unsure why the other thing was being used previously, could change back if necessary). It's refactored to be an optional add-on, and an additional option to output an NDJSON dump is added. A basic implementation incorporating all of this is defined in the class `VcfAnnotator`. The CLI is updated to use this class.

See https://github.com/biocommons/anyvar/blob/b57f400c1fe4b821828847d906ac0a5246308d36/src/anyvar/extras/vcf.py for an external implementation.

Some potential issues:
* In general, reliance on `kwargs` to pass arguments to the child class methods -- it's a little clunky obviously, both with use and documentation.
* since retaining all constructed alleles might be costly for speed and memory, it can be disabled/enabled by an implementation with the class variable "collect_alleles". It's disabled by default, so if you tried to add functionality like dumping to a file and missed that you need to change the class variable, it wouldn't do anything. Ideally there would be some way to raise an abc error of some kind, idk.
* Previously, the VRS allele collection that's retained while ingesting VCFs (it was named `vrs_data` before, I'm trying a name like `allele_collection`?)  was retaining stringified dict dumps of alleles (i.e. `str(allele.model_dump(exclude_none=True))`). I'm not totally sure why this was the case, so I changed it to just hold onto the pydantic objects and defer decisions about serialization etc to `on_vrs_object_collection`. I am not sure if this causes memory issues with extremely large VCFs.