### PR TITLE
feat!: update pydantic models to vrs 2.0.0-snapshot.2025-02

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/vrs"]
 	path = submodules/vrs
 	url = https://github.com/ga4gh/vrs.git
-	branch = 2.0.0-ballot.2024-11
+	branch = 2.0.0-snapshot.2025-02

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -95,11 +95,11 @@ class Entity(BaseModel, ABC):
         ...,
         description="The name of the class that is instantiated by a data object representing the Entity.",
     )
-    label: Optional[str] = Field(None, description="A primary name for the entity.")
+    name: Optional[str] = Field(None, description="A primary name for the entity.")
     description: Optional[str] = Field(
         None, description="A free-text description of the Entity."
     )
-    alternativeLabels: Optional[list[str]] = Field(  # noqa: N815
+    aliases: Optional[list[str]] = Field(
         None, description="Alternative name(s) for the Entity."
     )
     extensions: Optional[list[Extension]] = Field(
@@ -134,7 +134,7 @@ class Coding(Element):
     code system.
     """
 
-    label: Optional[str] = Field(
+    name: Optional[str] = Field(
         None,
         description="The human-readable name for the coded concept, as defined by the code system.",
     )
@@ -187,13 +187,13 @@ class Extension(Element):
 
 
 class MappableConcept(Element):
-    """A concept label that may be mapped to one or more `Codings`."""
+    """A concept name that may be mapped to one or more `Codings`."""
 
     conceptType: Optional[str] = Field(  # noqa: N815
         None,
         description="A term indicating the type of concept being represented by the MappableConcept.",
     )
-    label: Optional[str] = Field(None, description="A primary name for the concept.")
+    name: Optional[str] = Field(None, description="A primary name for the concept.")
     primaryCode: Optional[code] = Field(  # noqa: N815
         None,
         description="A primary code for the concept that is used to identify the concept in a terminology or code system. If there is a public code system for the primaryCode then it should also be specified in the mappings array with a relation of 'exactMatch'. This attribute is provided to both allow a more technical code to be used when a public Coding with a system is not available as well as when it is available but should be identified as the primary code.",
@@ -203,11 +203,16 @@ class MappableConcept(Element):
         description="A list of mappings to concepts in terminologies or code systems. Each mapping should include a coding and a relation.",
     )
 
+    class ga4gh:  # noqa: N801
+        """Contain properties used for computing digests"""
+
+        inherent: tuple[str] = ("primaryCode",)
+
     @model_validator(mode="after")
-    def require_label_or_primary_code(cls, v):  # noqa: ANN001 N805 ANN201
-        """Ensure that ``label`` or ``primaryCode`` is provided"""
-        if v.primaryCode is None and v.label is None:
-            err_msg = "`One of label` or `primaryCode` must be provided."
+    def require_name_or_primary_code(cls, v):  # noqa: ANN001 N805 ANN201
+        """Ensure that ``name`` or ``primaryCode`` is provided"""
+        if v.primaryCode is None and v.name is None:
+            err_msg = "`One of name` or `primaryCode` must be provided."
             raise ValueError(err_msg)
         return v
 

--- a/tests/validation/test_models.py
+++ b/tests/validation/test_models.py
@@ -153,12 +153,12 @@ def test_mappable_concept():
     """Test the MappableConcept model validator"""
     # Does not provide required fields
     with pytest.raises(
-        ValueError, match="`One of label` or `primaryCode` must be provided."
+        ValueError, match="`One of name` or `primaryCode` must be provided."
     ):
         core_models.MappableConcept(conceptType="test")
 
     # Valid models
-    assert core_models.MappableConcept(label="Primary Label")
+    assert core_models.MappableConcept(name="Primary Label")
     assert core_models.MappableConcept(primaryCode="EFO:0030067")
 
 
@@ -169,7 +169,7 @@ def test_copy_number_change():
     # Primary code not provided
     with pytest.raises(ValueError, match="`primaryCode` is required."):
         models.CopyNumberChange(
-            location=location, copyChange=core_models.MappableConcept(label="test")
+            location=location, copyChange=core_models.MappableConcept(name="test")
         )
 
     # Primary code not valid EFO

--- a/tests/validation/test_schemas.py
+++ b/tests/validation/test_schemas.py
@@ -128,23 +128,27 @@ def test_schema_class_fields(gks_schema, pydantic_models):
                 )
 
 
-def test_ga4gh_keys():
+@pytest.mark.parametrize(
+    ("gks_schema", "pydantic_models"),
+    [
+        (GKSSchema.VRS, vrs_models),
+        (GKSSchema.CORE, core_models),
+    ],
+)
+def test_ga4gh_keys(gks_schema, pydantic_models):
     """Ensure ga4gh inherent defined in schema model exist in corresponding Pydantic model"""
-    vrs_mapping = GKS_SCHEMA_MAPPING[GKSSchema.VRS]
-    for vrs_class in vrs_mapping.concrete_classes:
-        if vrs_mapping.schema[vrs_class].get("ga4gh", {}).get("inherent", None) is None:
+    mapping = GKS_SCHEMA_MAPPING[gks_schema]
+    for schema_model in mapping.concrete_classes:
+        if mapping.schema[schema_model].get("ga4gh", {}).get("inherent", None) is None:
             continue
 
-        pydantic_model = getattr(vrs_models, vrs_class)
+        pydantic_model = getattr(pydantic_models, schema_model)
 
         try:
-            pydantic_model_digest_keys = pydantic_model.ga4gh.keys
+            pydantic_model_digest_inherent = pydantic_model.ga4gh.inherent
         except AttributeError as e:
-            raise AttributeError(vrs_class) from e
+            raise AttributeError(schema_model) from e
 
-        assert set(pydantic_model_digest_keys) == set(
-            vrs_mapping.schema[vrs_class]["ga4gh"]["inherent"]
-        ), vrs_class
-        assert pydantic_model_digest_keys == sorted(pydantic_model.ga4gh.keys), (
-            vrs_class
-        )
+        assert set(pydantic_model_digest_inherent) == set(
+            mapping.schema[schema_model]["ga4gh"]["inherent"]
+        ), schema_model


### PR DESCRIPTION
close #503

* Also changes `ga4gh.keys` -> `ga4gh.inherent`

This work is needed for GKS AnVIL / ClinVar Submission

Submodule source.yaml diffs:
* https://github.com/ga4gh/gks-core/compare/064ba233eae6c9e1f914380fcf4917d300532c57...1.0.0-snapshot.2025-02.1#diff-c69e6cf4bc50458dc06f67c253a3337f9bd7522d77d8836e8d66d8b3258935a5
* https://github.com/ga4gh/vrs/compare/c9b3dd447960dec24a9e2992d7a14cc4eb5060e2...2.0.0-snapshot.2025-02.1#diff-7869e6a91abfc2ed9ce4581931d776a63caae890e9c7c83f6babeff35c2376c2