### PR TITLE
feat!: show more informative error msg for vcf annotate output args issue

### DIFF
--- a/src/ga4gh/vrs/extras/annotator/cli.py
+++ b/src/ga4gh/vrs/extras/annotator/cli.py
@@ -14,7 +14,7 @@ import click
 import requests
 
 from ga4gh.vrs.dataproxy import create_dataproxy
-from ga4gh.vrs.extras.annotator.vcf import VcfAnnotator
+from ga4gh.vrs.extras.annotator.vcf import VcfAnnotator, VcfAnnotatorArgsError
 
 _logger = logging.getLogger(__name__)
 
@@ -187,16 +187,24 @@ def _annotate_vcf_cli(
     _logger.info(msg)
     if not silent:
         click.echo(msg)
-    annotator.annotate(
-        vcf_in.absolute(),
-        output_vcf_path=vcf_out,
-        vrs_attributes=vrs_attributes,
-        assembly=assembly,
-        compute_for_ref=(not skip_ref),
-        require_validation=require_validation,
-        output_pkl_path=pkl_out,
-        output_ndjson_path=ndjson_out,
-    )
+    try:
+        annotator.annotate(
+            vcf_in.absolute(),
+            output_vcf_path=vcf_out,
+            vrs_attributes=vrs_attributes,
+            assembly=assembly,
+            compute_for_ref=(not skip_ref),
+            require_validation=require_validation,
+            output_pkl_path=pkl_out,
+            output_ndjson_path=ndjson_out,
+        )
+    except VcfAnnotatorArgsError:
+        msg = "No VCF, PKL, or NDJSON output path provided -- must set at least one of --vcf_out, --pkl_out, or --ndjson_out"
+        if not silent:
+            click.echo(msg)
+        _logger.exception(msg)
+        exit(1)
+
     end = timer()
     msg = f"VCF Annotator finished in {(end - start):.5f} seconds"
     _logger.info(msg)

--- a/src/ga4gh/vrs/extras/annotator/vcf.py
+++ b/src/ga4gh/vrs/extras/annotator/vcf.py
@@ -23,6 +23,10 @@ class VcfAnnotatorError(Exception):
     """Custom exceptions for VCF Annotator tool"""
 
 
+class VcfAnnotatorArgsError(VcfAnnotatorError):
+    """Raise for improper args passed to VCF annotator"""
+
+
 class FieldName(str, Enum):
     """Define VCF field names for VRS annotations"""
 
@@ -477,7 +481,7 @@ class VcfAnnotator(AbstractVcfAnnotator):
         :param output_vcf_path: VCF output path arg passed to `annotate()`
         :kwparam output_pkl_path: optional path to PKL output
         :kwparam output_ndjson_path: optional path to NDJSON output
-        :raise VCFAnnotatorError: if no output args are shown
+        :raise VCFAnnotatorArgsError: if no output args are given
         """
         if (
             output_vcf_path is None
@@ -485,7 +489,7 @@ class VcfAnnotator(AbstractVcfAnnotator):
             and kwargs.get(self.ndjson_arg_name) is None
         ):
             msg = f"No VCF, PKL, or NDJSON output path provided -- must pass at least one of `output_vcf_path`, `{self.pkl_arg_name}`, `{self.ndjson_arg_name}` to annotate()."
-            raise VcfAnnotatorError(msg)
+            raise VcfAnnotatorArgsError(msg)
 
     def on_vrs_object(
         self,


### PR DESCRIPTION
Minor issue. Previously, if you forgot to add an output option, the error message you get concerns arg names passed to the `annotate()` method, not the CLI itself, so not very helpful.

I also think it might make sense to affix default behavior to the CLI (maybe just make a vcf in the current working dir) rather than raising this error, but that's a slightly bigger change.