### PR TITLE
Threading the VCF annotator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
     "pydantic~=2.1",
     "bioutils",
     "requests",
-    "canonicaljson"
+    "canonicaljson",
+    "setuptools>=78.1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pydantic~=2.1",
     "bioutils",
     "requests",
-    "canonicaljson",
+    "canonicaljson"
 ]
 
 [project.optional-dependencies]
@@ -49,6 +49,7 @@ extras = [
     "hgvs>=1.4",
     "dill~=0.3.7",
     "click",
+    "pysam>=0.23.0",
 ]
 dev = [
     # tests


### PR DESCRIPTION
A modest performance improvement at the cost of sorting. Could be improved to keep sorting by using chunking.

Includes commits from https://github.com/ga4gh/vrs-python/pull/533

## performance on small VCF

OLD method

```
(env2) ➜  vrs-python git:(feature/annotator) ✗ time vrs-annotate vcf --vcf-out test-old.vcf NA12878-chr14-AKT1.vcf.gz
Annotating NA12878-chr14-AKT1.vcf.gz with the VCF Annotator...
VCF Annotator finished in 10.25358 seconds
vrs-annotate vcf --vcf-out test-old.vcf NA12878-chr14-AKT1.vcf.gz  7.88s user 2.59s system 98% cpu 10.613 total
```

NEW method 

```
(env3) ➜  vrs-python git:(feature/thread-ann) ✗ time vrs-annotate vcf --vcf-out test-new.vcf NA12878-chr14-AKT1.vcf.gz
Annotating NA12878-chr14-AKT1.vcf.gz with the VCF Annotator...
VCF Annotator finished in 3.57795 seconds
vrs-annotate vcf --vcf-out test-new.vcf NA12878-chr14-AKT1.vcf.gz  10.65s user 8.09s system 488% cpu 3.835 total
```

Picking out a line to compare that things look the same

```
< chr14	106779713	.	G	A	50	PASS	AC=1;AF=0.5;AN=2;DP=34;FS=3.133;MQ=250;MQRankSum=4.697;QD=1.47;ReadPosRankSum=2.451;SOR=0.313;FractionInformativeReads=0.971;R2_5P_bias=13.461;VRS_Allele_IDs=ga4gh:VA.R0Y_drBrtNKY97AgFMoOY4XN5SQHOKg2,ga4gh:VA.vpg7ue7_gkI1EL39jv88tdC9V35WqclM	GT:AD:AF:DP:F1R2:F2R1:GQ:PL:GP:PRI:SB:MB	0/1:12,21:0.636:33:7,9:5,12:46:85,0,45:50,0.00011882,47.602:0,34.77,37.77:8,4,11,10:7,5,11,10
> chr14	106779713	.	G	A	50	PASS	AC=1;AF=0.5;AN=2;DP=34;FS=3.133;MQ=250;MQRankSum=4.697;QD=1.47;ReadPosRankSum=2.451;SOR=0.313;FractionInformativeReads=0.971;R2_5P_bias=13.461;VRS_Allele_IDs=ga4gh:VA.R0Y_drBrtNKY97AgFMoOY4XN5SQHOKg2,ga4gh:VA.vpg7ue7_gkI1EL39jv88tdC9V35WqclM	GT:AD:AF:DP:F1R2:F2R1:GQ:PL:GP:PRI:SB:MB	0/1:12,21:0.636:33:7,9:5,12:46:85,0,45:50,0.00011882,47.602:0,34.77,37.77:8,4,11,10:7,5,11,10
```

## performance on larger VCF

NEW method
```
(env3) ➜  vrs-python git:(feature/thread-ann) ✗ time vrs-annotate vcf --vcf-out test-new2.vcf data/ALL.chrX.BI_Beagle.20100804.sites.vcf.gz 
Annotating data/ALL.chrX.BI_Beagle.20100804.sites.vcf.gz with the VCF Annotator...
[W::bcf_hdr_check_sanity] PL should be declared as Number=G
VCF Annotator finished in 213.16505 seconds
vrs-annotate vcf --vcf-out test-new2.vcf   344.08s user 242.52s system 274% cpu 3:33.58 total
```

OLD method

```
(env2) ➜  vrs-python git:(feature/annotator) ✗ time vrs-annotate vcf --vcf-out test-old2.vcf data/ALL.chrX.BI_Beagle.20100804.sites.vcf.gz

Annotating data/ALL.chrX.BI_Beagle.20100804.sites.vcf.gz with the VCF Annotator...
[W::bcf_hdr_check_sanity] PL should be declared as Number=G
VCF Annotator finished in 365.42381 seconds
vrs-annotate vcf --vcf-out test-old2.vcf   285.39s user 77.96s system 99% cpu 6:05.75 total
```