### PR TITLE
build: declare python 3.13 support

### DIFF
--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     env:
       SEQREPO_ROOT_DIR: ./tests/data/seqrepo/latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
 ]


### PR DESCRIPTION
Someone (@melissacline ?) had suggested we hold off on the move to supporting Python 3.11-13 for userbase maximization reasons. In the meantime, this PR expands support up to 3.13 so that we have it declared in metadata and are testing it in CI.