### PR TITLE
cicd: do not install setuptools

### DIFF
--- a/.github/workflows/python-cqa.yml
+++ b/.github/workflows/python-cqa.yml
@@ -10,9 +10,6 @@ jobs:
         with:
           submodules: recursive
       - uses: actions/setup-python@v5
-      - name: Update pip and setuptools
-        run: |
-          python -m pip install --upgrade pip setuptools
       - name: Install dependencies
         run: pip install -e '.[dev]'
       - name: Check style
@@ -44,9 +41,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Update pip and setuptools
-      run: |
-        python -m pip install --upgrade pip setuptools
     - name: Install dependencies
       run: |
         pip install -e .[dev,extras]


### PR DESCRIPTION
We were missing an issue upstream about a deprecated stdlib module because `setuptools` comes with an in-place fix -- but `setuptools` wasn't an explicit dependency declared for downstream users. I think we should just start with whatever `setup-python` gives us unless there's a pressing need.