### PR TITLE
fix-logging-warnings

### DIFF
--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -468,11 +468,11 @@ class AlleleTranslator(_Translator):
                     alt_length=vo.state.length,
                 )
                 # Warn if the derived sequence is different from the one in the object
-                if vo.state.sequence and vo.state.sequence != alt_seq:
+                if vo.state.sequence and vo.state.sequence.root != alt_seq:
                     _logger.warning(
                         "Derived sequence '%s' is different from provided state.sequence '%s'",
                         alt_seq,
-                        vo.state.sequence,
+                        vo.state.sequence.root,
                     )
             else:
                 alt_seq = vo.state.sequence.root


### PR DESCRIPTION
This PR stops logging unnecessary warnings like:
```
Derived sequence '' is different from provided state.sequence 'root='''

Derived sequence 'CCCC' is different from provided state.sequence 'root='CCCC''
```

An example for reproducing the warning log. Functionality is correct, but the condition for logging has a small bug.

```python
>>> from ga4gh.vrs.extras.translator import AlleleTranslator
>>> from ga4gh.vrs.dataproxy import create_dataproxy
>>> dp = create_dataproxy('seqrepo+file:///usr/local/share/seqrepo/2024-12-20')
>>> translator = AlleleTranslator(data_proxy=dp)
>>> allele = translator.translate_from('21-5030497-C-CACCT', 'gnomad')
>>> translator.translate_to(allele, 'spdi')
Derived sequence 'ACCTACCT' is different from provided state.sequence 'root='ACCTACCT''
['NC_000021.9:5030497:4:ACCTACCT']
```
