### PR TITLE
Update hgvs dependency to >=1.5.5,<2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ extras = [
     "psycopg2-binary",
     "biocommons.seqrepo>=0.5.1",
     "bioutils>=0.5.2",
-    "hgvs>=1.4,<1.5.5",
+    "hgvs>=1.5.5,<2.0",
     "dill~=0.3.7",
     "click",
     "pysam==0.23.0",  # pinned pending https://github.com/ga4gh/vrs-python/issues/560


### PR DESCRIPTION
### Summary

This PR updates the hgvs extra dependency constraint to `>=1.5.5,<2.0`.

hgvs 1.5.5 removes usage of `pkg_resources`, which is deprecated and scheduled for removal. The previous constraint allowed hgvs 1.5.4, which still triggers the deprecation warning.

Related to #604