### PR TITLE
fix: add disable_healthcheck kwarg to `create_dataproxy`

### DIFF
--- a/src/ga4gh/vrs/dataproxy.py
+++ b/src/ga4gh/vrs/dataproxy.py
@@ -350,8 +350,7 @@ def create_dataproxy(
 ) -> _DataProxy:
     """Create a dataproxy from uri or GA4GH_VRS_DATAPROXY_URI
 
-    :param: uri: Dataproxy URI
-        Currently accepted URI schemes:
+    :param uri: Dataproxy URI. Currently accepted URI schemes:
 
         * seqrepo+file:///path/to/seqrepo/root
         * seqrepo+:../relative/path/to/seqrepo/root

--- a/src/ga4gh/vrs/dataproxy.py
+++ b/src/ga4gh/vrs/dataproxy.py
@@ -251,6 +251,7 @@ class SeqRepoRESTDataProxy(_SeqRepoDataProxyBase):
         """Initialize REST-based dataproxy instance.
 
         :param base_url: root URL to server
+        :param disable_healthcheck: Whether healthcheck should be disabled
         """
         super().__init__()
         self.base_url = f"{base_url}/{self.rest_version}/"
@@ -344,16 +345,19 @@ def _isoformat(o: datetime.datetime) -> str:
 #         self.base_url = base_url
 
 
-def create_dataproxy(uri: str | None = None) -> _DataProxy:
+def create_dataproxy(
+    uri: str | None = None, disable_healthcheck: bool = False
+) -> _DataProxy:
     """Create a dataproxy from uri or GA4GH_VRS_DATAPROXY_URI
 
-    Currently accepted URI schemes:
+    :param: uri: Dataproxy URI
+        Currently accepted URI schemes:
 
-    * seqrepo+file:///path/to/seqrepo/root
-    * seqrepo+:../relative/path/to/seqrepo/root
-    * seqrepo+http://localhost:5000/seqrepo
-    * seqrepo+https://somewhere:5000/seqrepo
-
+        * seqrepo+file:///path/to/seqrepo/root
+        * seqrepo+:../relative/path/to/seqrepo/root
+        * seqrepo+http://localhost:5000/seqrepo
+        * seqrepo+https://somewhere:5000/seqrepo
+    :param disable_healthcheck: Whether healthcheck should be disabled in REST dataproxy
     :raise ValueError: if URI doesn't match recognized schemes, e.g. is missing provider
         prefix (`"seqrepo+"`)
     """
@@ -379,7 +383,9 @@ def create_dataproxy(uri: str | None = None) -> _DataProxy:
             sr = SeqRepo(root_dir=parsed_uri.path)
             dp = SeqRepoDataProxy(sr)
         elif proto in ("http", "https"):
-            dp = SeqRepoRESTDataProxy(uri[len(provider) + 1 :])
+            dp = SeqRepoRESTDataProxy(
+                uri[len(provider) + 1 :], disable_healthcheck=disable_healthcheck
+            )
         else:
             msg = f"SeqRepo URI scheme {parsed_uri.scheme} not implemented"
             raise ValueError(msg)


### PR DESCRIPTION
In #569, this parameter was added but did not add to the `create_dataproxy` function (we'll need this in our downstream apps)