### PR TITLE
feat: update models to vrs 2.1.0-snapshot.2026-02.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/vrs"]
 	path = submodules/vrs
 	url = https://github.com/ga4gh/vrs.git
-	branch = v2
+	branch = v2-add-intronic-positions-tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/vrs"]
 	path = submodules/vrs
 	url = https://github.com/ga4gh/vrs.git
-	branch = 2.0
+	branch = v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/vrs"]
 	path = submodules/vrs
 	url = https://github.com/ga4gh/vrs.git
-	branch = v2-add-intronic-positions-tests
+	branch = 2.1.0-snapshot.2026-02

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -199,7 +199,7 @@ class ConceptSet(Element, BaseModelForbidExtra):
 
     type: Literal["ConceptSet"] = Field(
         default="ConceptSet",
-        description='MUST be "ConceptSet"',
+        description='MUST be "ConceptSet".',
     )
     concepts: list[MappableConcept] | list[ConceptSet] = Field(
         ...,

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -203,7 +203,7 @@ class ConceptSet(Element, BaseModelForbidExtra):
     )
     concepts: list[MappableConcept] | list[ConceptSet] = Field(
         ...,
-        description="A list of concepts that are dependent (occurring together), or independent (existing separately), depending on the",
+        description="A list of concepts that are dependent (occurring together), or independent (existing separately), depending on the membership operator.",
         min_length=2,
     )
     membershipOperator: MembershipOperator = Field(  # noqa: N815

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from enum import StrEnum
+from enum import Enum
 from typing import Annotated, Any, Literal
 
 from pydantic import (
@@ -25,7 +25,7 @@ class BaseModelForbidExtra(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class Relation(StrEnum):
+class Relation(str, Enum):
     """A mapping relation between concepts as defined by the Simple Knowledge
     Organization System (SKOS).
     """
@@ -37,7 +37,7 @@ class Relation(StrEnum):
     RELATED_MATCH = "relatedMatch"
 
 
-class MembershipOperator(StrEnum):
+class MembershipOperator(str, Enum):
     """The logical relationship between concepts in the set, in the context of some
     knowledge reported about them. The value 'AND' indicates that the concepts are
     dependent and occur together in this context - i.e. the reported assertion is not

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC
-from enum import Enum
-from typing import Annotated, Any
+from enum import StrEnum
+from typing import Annotated, Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -25,7 +25,7 @@ class BaseModelForbidExtra(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class Relation(str, Enum):
+class Relation(StrEnum):
     """A mapping relation between concepts as defined by the Simple Knowledge
     Organization System (SKOS).
     """
@@ -35,6 +35,20 @@ class Relation(str, Enum):
     BROAD_MATCH = "broadMatch"
     NARROW_MATCH = "narrowMatch"
     RELATED_MATCH = "relatedMatch"
+
+
+class MembershipOperator(StrEnum):
+    """The logical relationship between concepts in the set, in the context of some
+    knowledge reported about them. The value 'AND' indicates that the concepts are
+    dependent and occur together in this context - i.e. the reported assertion is not
+    necessarily true for each concept on its own - only in combination with the
+    other(s). The value 'OR' indicates that each concept applies independently in this
+    context - i.e. the reported assertion is necessarily true for each concept on its
+    own, independent of the presence of the other(s).
+    """
+
+    AND = "AND"
+    OR = "OR"
 
 
 #########################################
@@ -172,6 +186,29 @@ class ConceptMapping(Element, BaseModelForbidExtra):
     relation: Relation = Field(
         ...,
         description="A mapping relation between concepts as defined by the Simple Knowledge Organization System (SKOS).",
+    )
+
+
+class ConceptSet(Element, BaseModelForbidExtra):
+    """A set of concepts that may be considered as dependent (occurring together), or
+    independent (existing separately) in the context of some knowledge reported about
+    them, as indicated by a set membership operator. e.g. a set of independent molecular
+    consequences that both result from the presence of a particular genetic variant
+    (membership operator = OR).
+    """
+
+    type: Literal["ConceptSet"] = Field(
+        default="ConceptSet",
+        description='MUST be "ConceptSet"',
+    )
+    concepts: list[MappableConcept] | list[ConceptSet] = Field(
+        ...,
+        description="A list of concepts that are dependent (occurring together), or independent (existing separately), depending on the",
+        min_length=2,
+    )
+    membershipOperator: MembershipOperator = Field(  # noqa: N815
+        ...,
+        description="The logical relationship between concepts in the set, in the context of some knowledge reported about them. The value 'AND' indicates that the concepts are dependent and occur together in this context - i.e. the reported assertion is not necessarily true for each concept on its own - only in combination with the other(s). The value 'OR' indicates that each concept applies independently in this context - i.e. the reported assertion is necessarily true for each concept on its own, independent of the presence of the other(s).",
     )
 
 

--- a/src/ga4gh/core/models.py
+++ b/src/ga4gh/core/models.py
@@ -197,6 +197,8 @@ class ConceptSet(Element, BaseModelForbidExtra):
     (membership operator = OR).
     """
 
+    model_config = ConfigDict(use_enum_values=True)
+
     type: Literal["ConceptSet"] = Field(
         default="ConceptSet",
         description='MUST be "ConceptSet".',

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -805,7 +805,7 @@ class RelativeAllele(_VariationBase, BaseModelForbidExtra):
         default=VrsType.RELATIVE_ALLELE.value,
         description=f'MUST be "{VrsType.RELATIVE_ALLELE.value}"',
     )
-    relativeState: (
+    mappedState: (
         LiteralSequenceExpression | ReferenceLengthExpression | LengthExpression
     ) = Field(
         ...,
@@ -819,12 +819,12 @@ class RelativeAllele(_VariationBase, BaseModelForbidExtra):
     )
     relativeLocation: RelativeSequenceLocation | iriReference = Field(
         ...,
-        description="The relative location at which the baseState and relativeState are expressed.",
+        description="The relative location at which the baseState and mappedState are expressed.",
     )
 
     class ga4gh(Ga4ghIdentifiableObject.ga4gh):
         prefix = "RA"
-        inherent = ["relativeState", "baseState", "relativeLocation", "type"]
+        inherent = ["mappedState", "baseState", "relativeLocation", "type"]
 
 
 class CisPhasedBlock(_VariationBase, BaseModelForbidExtra):

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -683,16 +683,16 @@ class SequenceOffsetLocation(_ValueObject, BaseModelForbidExtra):
         default=VrsType.SEQ_OFFSET_LOCATION.value,
         description=f'MUST be "{VrsType.SEQ_OFFSET_LOCATION.value}"',
     )
-    sequenceReference: SequenceReference | iriReference | None = Field(
-        default=None,
+    sequenceReference: SequenceReference | iriReference = Field(
+        ...,
         description="A sequence reference that has been mapped from which a relative location is defined.",
     )
-    anchor: int | None = Field(
-        default=None,
+    anchor: int = Field(
+        ...,
         description="The position on the sequence reference from which the relative location offset is calculated.",
     )
-    anchorOrientation: AnchorOrientation | None = Field(
-        default=None,
+    anchorOrientation: AnchorOrientation = Field(
+        ...,
         description="Indicates which side of a discontinuous anchor on the sequenceReference is used as the reference point for interpreting offsetStart/offsetEnd. The anchor is an inter-residue coordinate on the sequenceReference. When that anchor corresponds to a boundary whose realization on a base sequence yields two distinct locations (e.g., an exon junction), this property disambiguates which anchor side on the sequenceReference is intended. `left` denotes the side immediately preceding the anchor in sequenceReference coordinate order; `right` denotes the side immediately following the anchor in sequenceReference coordinate order.",
     )
     offsetStart: int | Range | None = Field(
@@ -725,11 +725,11 @@ class RelativeSequenceLocation(Ga4ghIdentifiableObject, BaseModelForbidExtra):
         default=VrsType.RELATIVE_SEQ_LOC.value,
         description=f'MUST be "{VrsType.RELATIVE_SEQ_LOC.value}"',
     )
-    baseSequenceLocation: SequenceLocation | iriReference | None = Field(
-        default=None, description="An absolute location on a sequence."
+    baseSequenceLocation: SequenceLocation | iriReference = Field(
+        ..., description="An absolute location on a sequence."
     )
-    mappedSequenceLocation: SequenceOffsetLocation | iriReference | None = Field(
-        default=None,
+    mappedSequenceLocation: SequenceOffsetLocation | iriReference = Field(
+        ...,
         description="A location relative to an offset on a mapped sequence.",
     )
 
@@ -806,19 +806,19 @@ class RelativeAllele(_VariationBase, BaseModelForbidExtra):
         description=f'MUST be "{VrsType.RELATIVE_ALLELE.value}"',
     )
     relativeState: (
-        LiteralSequenceExpression | ReferenceLengthExpression | LengthExpression | None
+        LiteralSequenceExpression | ReferenceLengthExpression | LengthExpression
     ) = Field(
-        default=None,
+        ...,
         description='The state of the RelativeAllele as expressed on the mapped sequence. This will differ from the base state when mapping to a reverse complement sequence, commonly observed when representing the state on transcripts mapped to the "negative strand" of a chromosome.',
     )
     baseState: (
-        LiteralSequenceExpression | ReferenceLengthExpression | LengthExpression | None
+        LiteralSequenceExpression | ReferenceLengthExpression | LengthExpression
     ) = Field(
-        default=None,
+        ...,
         description="The state of the RelativeAllele as expressed on the base sequence.",
     )
-    relativeLocation: RelativeSequenceLocation | iriReference | None = Field(
-        default=None,
+    relativeLocation: RelativeSequenceLocation | iriReference = Field(
+        ...,
         description="The relative location at which the baseState and relativeState are expressed.",
     )
 

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -679,6 +679,8 @@ class SequenceOffsetLocation(_ValueObject, BaseModelForbidExtra):
     reference.
     """
 
+    model_config = ConfigDict(use_enum_values=True)
+
     type: Literal["SequenceOffsetLocation"] = Field(
         default=VrsType.SEQ_OFFSET_LOCATION.value,
         description=f'MUST be "{VrsType.SEQ_OFFSET_LOCATION.value}"',

--- a/src/ga4gh/vrs/models.py
+++ b/src/ga4gh/vrs/models.py
@@ -521,7 +521,7 @@ class ReferenceLengthExpression(_ValueObject, BaseModelForbidExtra):
     )
     sequence: sequenceString | None = Field(
         default=None,
-        description="the literal Sequence encoded by the Reference Length Expression.",
+        description="the literal sequence encoded by the Reference Length Expression.",
     )
     repeatSubunitLength: int = Field(
         ..., description="The number of residues in the repeat subunit."
@@ -689,7 +689,7 @@ class SequenceOffsetLocation(_ValueObject, BaseModelForbidExtra):
     )
     anchor: int = Field(
         ...,
-        description="The position on the sequence reference from which the relative location offset is calculated.",
+        description="The inter-residue position on the sequence reference from which the relative location offset is calculated.",
     )
     anchorOrientation: AnchorOrientation = Field(
         ...,

--- a/tests/test_vrs.py
+++ b/tests/test_vrs.py
@@ -284,6 +284,8 @@ def test_enref2():
 def test_class_refatt_map():
     class_refatt_map_expected = {
         "Allele": ["location"],
+        "RelativeAllele": ["relativeLocation"],
+        "RelativeSequenceLocation": ["baseSequenceLocation"],
         "CisPhasedBlock": ["members"],
         "CopyNumberCount": ["location"],
         "CopyNumberChange": ["location"],


### PR DESCRIPTION
GKS-Core Release: https://github.com/ga4gh/gks-core/releases/tag/1.1.0
VRS Release: https://github.com/ga4gh/vrs/releases/tag/2.1.0-snapshot.2026-02.2 (changes can easily be seen https://github.com/ga4gh/vrs/compare/2.0.1...2.1.0-snapshot.2026-02.2)

I'd also like to create a new release once this is merged: `2.4.0-a0`