### PR TITLE
ci: remove get_branch job for pypi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,25 +4,9 @@ on:
     tags:
       - "*.*.**"
 jobs:
-  get_branch:
-    runs-on: ubuntu-latest
-    outputs:
-      branch_name: ${{ steps.get_branch_name.outputs.name }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Get branch name
-        id: get_branch_name
-        run: |
-          raw=$(git branch -r --contains ${{ github.ref }})
-          branch=$(echo "$raw" | grep "origin/main" | grep -v "HEAD" | sed "s|origin/||" | xargs)
-          echo "name=$branch" >> "$GITHUB_OUTPUT"
   build:
     name: Build distribution
     runs-on: ubuntu-latest
-    needs: get_branch
-    if: needs.get_branch.outputs.branch_name == 'main'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
* This is from over 4 years ago and I don't think we actually need this. There are times when we want to create releases off other branches (and its easy to forget to update). I think we should just remove

Let me know if I'm missing something?