### PR TITLE
fix: _from_vrs handle kwargs without error

### DIFF
--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -154,7 +154,7 @@ class _Translator(ABC):  # noqa: B024
         """Instantiate and return an HgvsTools instance"""
         return HgvsTools(self.data_proxy)
 
-    def _from_vrs(self, var: dict) -> models._VariationBase | None:
+    def _from_vrs(self, var: dict, **kwargs) -> models._VariationBase | None:  # noqa: ARG002
         """Convert from dict representation of VRS JSON to VRS object"""
         if not isinstance(var, Mapping):
             return None

--- a/tests/extras/test_allele_translator.py
+++ b/tests/extras/test_allele_translator.py
@@ -331,6 +331,11 @@ def test_from_invalid(tlr):
     ):
         tlr.translate_from("BRAF amplication")
 
+    with pytest.raises(
+        ValueError, match="Unable to parse data as beacon, gnomad, hgvs, spdi, vrs"
+    ):
+        tlr.translate_from("BRAF amplication", assembly_name="GRCh37")
+
 
 @pytest.mark.vcr
 def test_from_beacon(tlr):


### PR DESCRIPTION
the root cause of https://github.com/biocommons/anyvar/issues/467

If you have a valid variant expression, you can attach some extra kwargs like "assembly_name" to help ground certain kinds of translation. However, if you happen to have an invalid expression, the translator will attempt each different format of translation, including `_from_vrs`. If you have attached kwargs, `_from_vrs` will raise an unexpected TypeError because it, unlike the other `_from_` methods, doesn't include kwargs in its type signature. I can't think of a reason why this might be the case. I also added a test to show this.