### PR TITLE
fix: handle key error in translate_to

### DIFF
--- a/src/ga4gh/vrs/extras/translator.py
+++ b/src/ga4gh/vrs/extras/translator.py
@@ -142,8 +142,14 @@ class _Translator(ABC):  # noqa: B024
         kwargs:
             ref_seq_limit Optional(int):
                 If vo.state is a ReferenceLengthExpression, and `ref_seq_limit` is specified, and `fmt` is `spdi`, the reference sequence is included in the SPDI expression if it is below the limit Otherwise only the length of the reference sequence is included. If the limit is None, the reference sequence is always included. In all cases, the alt sequence is included. Default is 0 (never include reference sequence).
+        :raise NotImplementedError: If `fmt` is not supported
         """
-        t = self.to_translators[fmt]
+        try:
+            t = self.to_translators[fmt]
+        except KeyError as e:
+            msg = f"{fmt} is not supported"
+            raise NotImplementedError(msg) from e
+
         return t(vo, **kwargs)
 
     ############################################################################

--- a/tests/extras/test_allele_translator.py
+++ b/tests/extras/test_allele_translator.py
@@ -978,20 +978,7 @@ def test_normalize_microsatellite_counts(tlr, case):
     )
 
 
-# TODO: Readd these tests
-# @pytest.mark.vcr
-# def test_errors(tlr):
-#     with pytest.raises(ValueError):
-#         tlr._from_beacon("bogus")
-#
-#     with pytest.raises(ValueError):
-#         tlr._from_gnomad("NM_182763.2:c.688+403C>T")
-#
-#     with pytest.raises(ValueError):
-#         tlr._from_hgvs("NM_182763.2:c.688+403C>T")
-#
-#     with pytest.raises(ValueError):
-#         tlr._from_hgvs("NM_182763.2:c.688_690inv")
-#
-#     with pytest.raises(ValueError):
-#         tlr._from_spdi("NM_182763.2:c.688+403C>T")
+@pytest.mark.vcr
+def test_translate_to_invalid_fmt(tlr):
+    with pytest.raises(NotImplementedError, match="gnomad is not supported"):
+        tlr.translate_to(models.Allele.model_validate(snv_output), fmt="gnomad")


### PR DESCRIPTION
close #638

* Unsupported `fmt` in `translate_to` should raise `NotImplementedError`