### PR TITLE
fix: detect intronic RNA (r.) variants in is_intronic

### DIFF
--- a/src/ga4gh/vrs/utils/hgvs_tools.py
+++ b/src/ga4gh/vrs/utils/hgvs_tools.py
@@ -5,6 +5,7 @@ import re
 
 import hgvs
 import hgvs.dataproviders.uta
+import hgvs.location
 import hgvs.normalizer
 import hgvs.parser
 import hgvs.variantmapper
@@ -77,9 +78,17 @@ class HgvsTools:
             bool: True if the SequenceVariant is intronic, False otherwise.
 
         """
-        if isinstance(sv.posedit.pos, hgvs.location.BaseOffsetInterval):
-            return sv.posedit.pos.start.is_intronic or sv.posedit.pos.end.is_intronic
-        return False
+        # Coding (c.) intervals are BaseOffsetInterval, but RNA (r.) intervals
+        # are plain Interval even when their endpoints carry a base-offset
+        # position, so inspect the endpoints directly rather than the interval
+        # type. Non-offset coordinates (g./p.) use position types without
+        # is_intronic and are correctly reported as not intronic.
+        pos = sv.posedit.pos
+        start = getattr(pos, "start", None)
+        end = getattr(pos, "end", None)
+        return (
+            isinstance(start, hgvs.location.BaseOffsetPosition) and start.is_intronic
+        ) or (isinstance(end, hgvs.location.BaseOffsetPosition) and end.is_intronic)
 
     def get_edit_type(self, sv: HgvsSequenceVariant) -> str | None:
         """Safely extract ``type`` property from SequenceVariant"""

--- a/tests/extras/test_hgvs_tools.py
+++ b/tests/extras/test_hgvs_tools.py
@@ -27,6 +27,11 @@ def hgvs_tools():
         ("NR_000000.1:r.76-1g>a", True),  # intronic (acceptor side)
         ("NR_000000.1:r.77+1g>a", True),  # intronic (donor side)
         ("NR_000000.1:r.100a>u", False),  # exonic
+        # RNA (r.) exonic - real-world ClinVar pins from issue #628 (offset 0)
+        ("NR_001566.1:r.398_399del", False),
+        ("NR_001566.1:r.245del", False),
+        ("NM_001374385.1:r.2843_2931del", False),
+        ("NM_001323289.2:r.2632c>a", False),
         # genomic (g.) - no base-offset positions, never intronic
         ("NC_000001.11:g.100A>T", False),
     ],

--- a/tests/extras/test_hgvs_tools.py
+++ b/tests/extras/test_hgvs_tools.py
@@ -1,0 +1,37 @@
+"""Tests for ga4gh.vrs.utils.hgvs_tools."""
+
+import hgvs.parser
+import pytest
+
+from ga4gh.vrs.utils.hgvs_tools import HgvsTools
+
+
+@pytest.fixture(scope="module")
+def hgvs_tools():
+    # is_intronic only parses expressions, so build HgvsTools without the
+    # network-dependent __init__ (which opens a UTA connection).
+    tools = HgvsTools.__new__(HgvsTools)
+    tools.parser = hgvs.parser.Parser()
+    return tools
+
+
+@pytest.mark.parametrize(
+    ("hgvs_expr", "expected"),
+    [
+        # coding (c.)
+        ("NM_000000.1:c.76-1G>A", True),  # intronic (acceptor side)
+        ("NM_000000.1:c.87+1A>T", True),  # intronic (donor side)
+        ("NM_000000.1:c.100A>T", False),  # exonic
+        # RNA (r.) - previously missed: the interval is a plain Interval, not a
+        # BaseOffsetInterval, so the old isinstance check returned False
+        ("NR_000000.1:r.76-1g>a", True),  # intronic (acceptor side)
+        ("NR_000000.1:r.77+1g>a", True),  # intronic (donor side)
+        ("NR_000000.1:r.100a>u", False),  # exonic
+        # genomic (g.) - no base-offset positions, never intronic
+        ("NC_000001.11:g.100A>T", False),
+    ],
+)
+def test_is_intronic(hgvs_tools, hgvs_expr, expected):
+    sv = hgvs_tools.parse(hgvs_expr)
+    assert sv is not None
+    assert hgvs_tools.is_intronic(sv) is expected


### PR DESCRIPTION
`is_intronic` only recognized introns on coding (c.) coordinates because it gated on the interval being a `BaseOffsetInterval`. RNA (r.) coordinates parse to a plain `Interval` whose endpoints are still `BaseOffsetPosition`, so intronic r. variants slipped past the "Intronic HGVS variants are not supported" guard

inspect the interval endpoints instead of the interval type. g./p. coordinates have no base-offset positions and stay non-intronic

closes #628
